### PR TITLE
Add /tasks slash command

### DIFF
--- a/.claude/plugins/onebrain/plugin.json
+++ b/.claude/plugins/onebrain/plugin.json
@@ -14,6 +14,7 @@
     "skills/reading-notes",
     "skills/weekly",
     "skills/tldr",
+    "skills/tasks",
     "skills/update"
   ],
   "hooks": [

--- a/.claude/plugins/onebrain/skills/tasks/SKILL.md
+++ b/.claude/plugins/onebrain/skills/tasks/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: tasks
+description: Show a dashboard of all tasks across the vault — overdue, due soon, open, and recently completed
+triggers:
+  - /tasks
+  - tasks
+  - show tasks
+  - my todos
+  - todo list
+---
+
+# Task Dashboard
+
+Shows all tasks across the vault, organized by urgency, with quick actions to update them.
+
+---
+
+## Step 1: Scan the Vault
+
+Use the Grep tool to find all task lines across active vault folders.
+
+Search for `- \[.\]` (regex) in these directories only:
+- `00-inbox/`
+- `01-projects/`
+- `02-knowledge/`
+- `04-memory-log/`
+
+**Skip entirely:** `03-archive/`, `.obsidian/`, `.claude/`, `CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, `README.md`
+
+These excluded files contain template examples or system instructions, not real tasks.
+
+---
+
+## Step 2: Parse Each Task Line
+
+For each matched line, extract:
+
+| Field | How to extract |
+|-------|---------------|
+| **Status** | `- [ ]` = open, `- [x]` = completed |
+| **Description** | Text after the checkbox, minus emoji markers |
+| **Due date** | `📅 YYYY-MM-DD` if present |
+| **Priority** | `🔺` high, `⏫` medium, `🔽` low (absent = none) |
+| **Source** | File path → strip extension and leading path → `[[Note Name]]` |
+
+---
+
+## Step 3: Categorize by Urgency
+
+Today's date is available from the system. Using it:
+
+- **Overdue** — open tasks with due date < today
+- **Due Soon** — open tasks with due date within the next 7 days (today through today+7)
+- **All Open** — open tasks with no due date, or due date > 7 days out
+- **Completed This Week** — completed (`- [x]`) tasks found in files modified in the last 7 days
+
+Within each section, sort by:
+1. Priority: 🔺 → ⏫ → 🔽 → none
+2. Then by due date (earliest first)
+
+---
+
+## Step 4: Display the Dashboard
+
+Print the dashboard in this format:
+
+```
+## 🔴 Overdue (N)
+- [ ] Task description 📅 YYYY-MM-DD  🔺  ← [[Source Note]]
+
+## 🟡 Due Soon (N)
+- [ ] Task description 📅 YYYY-MM-DD  ← [[Source Note]]
+
+## 📋 All Open (N)
+- [ ] Task description  ← [[Source Note]]
+
+## ✅ Completed This Week (N)
+- [x] Task description 📅 YYYY-MM-DD  ← [[Source Note]]
+```
+
+If a section has no tasks, show:
+> None — you're clear!
+
+Show the count `(N)` in every section header, even when zero.
+
+---
+
+## Step 5: Quick Actions
+
+After the dashboard, say:
+
+> **Quick actions:**
+> 1. ✅ Mark tasks complete — tell me which ones
+> 2. ➕ Add a quick task — I'll ask for details
+> 3. 👋 Done — no changes needed
+
+Wait for the user's choice, then follow the matching branch below.
+
+### Branch 1 — Mark Complete
+
+- Ask the user to identify tasks by number (based on dashboard order) or description.
+- Read the source file for each identified task.
+- Change `- [ ]` to `- [x]` for the matching line(s).
+- Confirm: "Marked N task(s) complete in [[Source Note]]."
+
+### Branch 2 — Add a Task
+
+Ask in sequence:
+1. **Description** — what's the task?
+2. **Due date** — any deadline? (optional, skip if none)
+3. **Priority** — high 🔺, medium ⏫, low 🔽, or none?
+4. **Where to add it** — suggest existing project notes by name; default to `00-inbox/YYYY-MM-DD-tasks.md` if no preference.
+
+Write the task in Obsidian Tasks format:
+```
+- [ ] Task description 📅 YYYY-MM-DD  🔺
+```
+
+Confirm: "Added to [[Note Name]]."
+
+### Branch 3 — Done
+
+Say:
+> All good — your task list is up to date. See you next time!
+
+---
+
+## Step 6: Empty State
+
+If no tasks are found anywhere after scanning:
+
+> No tasks found in your vault yet. Tasks get created when you use `/braindump`, `/weekly`, or add them manually to notes.
+>
+> Want to add one now?
+
+If yes, proceed with Branch 2 above.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,7 @@ These workflows are documented in `.claude/plugins/onebrain/skills/`:
 | `/summarize-url` | `summarize-url/SKILL.md` | URL → summary note |
 | `/reading-notes` | `reading-notes/SKILL.md` | Book/article → structured notes |
 | `/weekly` | `weekly/SKILL.md` | Weekly reflection |
+| `/tasks` | `tasks/SKILL.md` | Task dashboard — overdue, due soon, open, completed |
 | `/tldr` | `tldr/SKILL.md` | Session summary → memory log |
 | `/update` | `update/SKILL.md` | Update system files from GitHub |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,7 @@ Until onboarding is complete, use a helpful, concise, and professional tone.
 | `/summarize-url` | Fetch a URL and create a summary note |
 | `/reading-notes` | Process a book or article into structured notes |
 | `/weekly` | Weekly reflection — review sessions, surface patterns |
+| `/tasks` | View all tasks across the vault — overdue, due soon, open, completed |
 | `/tldr` | End-of-session summary → saved to memory log |
 | `/update` | Update OneBrain system files from GitHub |
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -73,6 +73,7 @@ Run these by typing the command name as a prompt:
 | `/summarize-url` | Fetch a URL and create a summary note |
 | `/reading-notes` | Process a book or article into structured notes |
 | `/weekly` | Weekly reflection — review sessions, surface patterns |
+| `/tasks` | View all tasks across the vault — overdue, due soon, open, completed |
 | `/tldr` | End-of-session summary → saved to memory log |
 | `/update` | Update OneBrain system files from GitHub |
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ An AI-powered second brain for Obsidian. Turn Claude Code, Gemini CLI, or any AI
 ## What It Does
 
 - **Memory across sessions** — your AI remembers your name, role, goals, and past conversations
-- **11 slash commands** — braindump, capture, research, consolidate, connect, and more
+- **12 slash commands** — braindump, capture, research, consolidate, connect, and more
 - **Vault-native** — all notes are Markdown, everything stays in your Obsidian vault
 - **Multi-agent** — works with Claude Code, Gemini CLI, or any AI that reads Markdown
 - **Pre-configured** — open in Obsidian and everything is ready to go
@@ -94,6 +94,7 @@ onebrain/
 | `/summarize-url [url]` | Fetch a URL and save a summary note |
 | `/reading-notes` | Turn a book or article into structured notes |
 | `/weekly` | Review the week, surface patterns, set intentions |
+| `/tasks` | Task dashboard — overdue, due soon, open, and completed this week |
 | `/tldr` | Save a session summary to your memory log |
 | `/update` | Update skills, config, and plugins from GitHub |
 


### PR DESCRIPTION
## Summary

- Adds a new `/tasks` skill to the OneBrain plugin that scans the vault and displays a prioritized task dashboard
- Categorizes tasks as overdue, due soon, all open, and completed this week
- Offers quick actions: mark tasks complete, add a new task, or exit

## Test plan

- [ ] Run `/tasks` with no tasks in vault — verify empty state message appears
- [ ] Add tasks to a note in `00-inbox/` — run `/tasks` — verify they appear in the correct section
- [ ] Use "mark complete" action — verify `- [ ]` becomes `- [x]` in source file
- [ ] Use "add task" action — verify task is written in Obsidian Tasks format to correct file
- [ ] Confirm tasks in `03-archive/` and `.claude/` are excluded from results

🤖 Generated with [Claude Code](https://claude.com/claude-code)