### PR TITLE
Add autonomous permission config for Claude, Gemini, and all AI agents

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "permissions": {
+    "allow": [
+      "Read",
+      "Write",
+      "Edit",
+      "Glob",
+      "Grep",
+      "Bash(git:*)",
+      "WebFetch",
+      "WebSearch"
+    ]
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,3 +108,12 @@ If conditions are met:
 - Don't move files to the archive folder without telling the user
 - Prefer editing existing notes over creating new ones
 - Keep `MEMORY.md` under ~200 lines
+
+## Permissions
+
+- Do not ask for confirmation when reading files
+- Do not ask for confirmation when writing or editing files
+- Do not ask for confirmation when searching files or directories
+- Do not ask for confirmation when fetching URLs or performing web searches
+- Do not ask for confirmation when running git commands
+- Always proceed with file and web operations autonomously within this vault

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,7 +112,7 @@ If conditions are met:
 ## Permissions
 
 - Do not ask for confirmation when reading files
-- Do not ask for confirmation when writing or editing files
+- Do not ask for confirmation when writing or editing files (but DO confirm before deleting any note)
 - Do not ask for confirmation when searching files or directories
 - Do not ask for confirmation when fetching URLs or performing web searches
 - Do not ask for confirmation when running git commands

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -112,7 +112,7 @@ At the end of every session:
 ## Permissions
 
 - Do not ask for confirmation when reading files
-- Do not ask for confirmation when writing or editing files
+- Do not ask for confirmation when writing or editing files (but DO confirm before deleting any note)
 - Do not ask for confirmation when searching files or directories
 - Do not ask for confirmation when fetching URLs or performing web searches
 - Do not ask for confirmation when running git commands

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -109,6 +109,15 @@ At the end of every session:
 - Always prefer adding to existing notes over creating new ones
 - Keep MEMORY.md under ~200 lines
 
+## Permissions
+
+- Do not ask for confirmation when reading files
+- Do not ask for confirmation when writing or editing files
+- Do not ask for confirmation when searching files or directories
+- Do not ask for confirmation when fetching URLs or performing web searches
+- Do not ask for confirmation when running git commands
+- Always proceed with file and web operations autonomously within this vault
+
 ## Auto Session Summary
 
 Before your final response in a session, silently save a session summary if ALL of these are true:


### PR DESCRIPTION
## Summary

- Add `.claude/settings.json` with explicit allow rules for file tools (`Read`, `Write`, `Edit`, `Glob`, `Grep`), git, `WebFetch`, and `WebSearch` — so Claude Code never prompts for these in the vault
- Add `## Permissions` section to `GEMINI.md` instructing Gemini CLI to proceed without confirmation for file, web, and git operations (Gemini has no project-level settings file)
- Add `## Permissions` section to `AGENTS.md` for all other AI CLIs (Codex, Aider, etc.) that read this file

## Test plan

- [ ] Open vault in Claude Code — verify no permission prompts for file reads/writes
- [ ] Open vault in Gemini CLI — verify it proceeds autonomously on file operations
- [ ] Confirm `.claude/settings.json` is valid JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)