### PR TITLE
Harmonize CLAUDE.md, GEMINI.md, and AGENTS.md for consistency

### DIFF
--- a/.claude/plugins/onebrain/skills/onboarding/SKILL.md
+++ b/.claude/plugins/onebrain/skills/onboarding/SKILL.md
@@ -232,8 +232,7 @@ In `CLAUDE.md`, `GEMINI.md`, and `AGENTS.md`, replace all occurrences of:
 - "Completed projects and archived items" → "Inactive items from any category"
 
 Also insert a line for `02-areas/` in the vault structure sections (PARA adds a folder with no OneBrain counterpart):
-- In `CLAUDE.md` and `GEMINI.md`: add `02-areas/        Ongoing responsibilities (health, finance, career)` immediately after the `01-projects/` line in the vault structure code block
-- In `AGENTS.md`: add `| \`02-areas/\` | Ongoing responsibilities (health, finance, career) |` immediately after the `| \`01-projects/\` |` table row
+- In `CLAUDE.md`, `GEMINI.md`, and `AGENTS.md`: add `02-areas/        Ongoing responsibilities (health, finance, career)` immediately after the `01-projects/` line in the vault structure code block
 
 In all `.md` files under `.claude/plugins/onebrain/` (excluding `skills/onboarding/SKILL.md` and `skills/update/SKILL.md`), replace all occurrences of:
 - `02-knowledge/` → `03-resources/`
@@ -248,7 +247,6 @@ In `CLAUDE.md`, `GEMINI.md`, and `AGENTS.md`, replace all occurrences of:
 - `02-knowledge/` → `02-permanent/`
 - "Raw braindumps and quick captures (process regularly)" → "Temporary capture — raw ideas and quick notes"
 - "Active projects with tasks and notes" → "Notes from sources you've read"
-- "Active projects with tasks and inline notes" → "Notes from sources you've read"
 - "Consolidated notes, insights, and reference material" → "Atomic, linked notes — your knowledge graph"
 
 In all `.md` files under `.claude/plugins/onebrain/` (excluding `skills/onboarding/SKILL.md` and `skills/update/SKILL.md`), replace all occurrences of:

--- a/.claude/plugins/onebrain/skills/update/SKILL.md
+++ b/.claude/plugins/onebrain/skills/update/SKILL.md
@@ -134,13 +134,11 @@ From `vault.yml`, read the `folders` mapping:
 - Replace "Consolidated notes, insights, and reference material" → "Topics of interest and reference material"
 - Replace "Completed projects and old items" → "Inactive items from any category"
 - Replace "Completed projects and archived items" → "Inactive items from any category"
-- Insert `02-areas/        Ongoing responsibilities (health, finance, career)` after the `01-projects/` line in `CLAUDE.md` and `GEMINI.md` vault structure code blocks (if not already present)
-- Insert `| \`02-areas/\` | Ongoing responsibilities (health, finance, career) |` after the `| \`01-projects/\` |` row in `AGENTS.md` (if not already present)
+- Insert `02-areas/        Ongoing responsibilities (health, finance, career)` after the `01-projects/` line in `CLAUDE.md`, `GEMINI.md`, and `AGENTS.md` vault structure code blocks (if not already present)
 
 **If method is `zettelkasten`, also in `CLAUDE.md`, `GEMINI.md`, and `AGENTS.md`:**
 - Replace "Raw braindumps and quick captures (process regularly)" → "Temporary capture — raw ideas and quick notes"
 - Replace "Active projects with tasks and notes" → "Notes from sources you've read"
-- Replace "Active projects with tasks and inline notes" → "Notes from sources you've read"
 - Replace "Consolidated notes, insights, and reference material" → "Atomic, linked notes — your knowledge graph"
 
 **In all `.md` files under `.claude/plugins/onebrain/` (excluding `skills/onboarding/SKILL.md` and `skills/update/SKILL.md`), replace all occurrences of:**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,10 +2,7 @@
 
 This file contains instructions for any AI agent that can read markdown files.
 You are a personal chief of staff operating inside an Obsidian vault called OneBrain.
-
-## First Step Every Session
-
-Read `MEMORY.md` — it contains your user's identity, preferences, and session context.
+Read MEMORY.md at the start of every session to load identity and context.
 
 ## Your Role
 
@@ -14,47 +11,56 @@ Be proactive: surface connections, flag stale tasks, suggest next actions based 
 
 ## Vault Structure
 
-> **Note:** Vault folders are created during `/onboarding`. The table below shows the default (OneBrain method).
+> **Note:** Vault folders are created during `/onboarding`. The structure below shows the default (OneBrain method).
 > If you chose PARA or Zettelkasten during onboarding, your folders will differ. See `vault.yml` for your configuration.
 
-| Folder | Purpose |
-|--------|---------|
-| `00-inbox/` | Raw braindumps and quick captures (process regularly) |
-| `01-projects/` | Active projects with tasks and inline notes |
-| `02-knowledge/` | Consolidated notes, insights, and reference material |
-| `03-archive/` | Completed projects and archived items |
-| `04-memory-log/` | Session summaries (one per session, YYYY-MM-DD-session-NN.md) |
-| `MEMORY.md` | Identity and evolving knowledge — always loaded |
+```
+00-inbox/        Raw braindumps and quick captures (process regularly)
+01-projects/     Active projects with tasks and notes
+02-knowledge/    Consolidated notes, insights, and reference material
+03-archive/      Completed projects and archived items
+04-memory-log/   Session summaries (YYYY-MM-DD-session-NN.md)
+MEMORY.md        Identity and evolving knowledge (loaded every session)
+```
 
-## Task Format
+## Task Syntax (Obsidian Tasks Plugin)
 
-When creating tasks, always use Obsidian Tasks plugin syntax:
+Always create tasks in this format when capturing action items:
 ```
 - [ ] Task description 📅 YYYY-MM-DD
 ```
 
-Priority markers: `🔺` high / `⏫` medium / `🔽` low
+Use these priority markers when relevant:
+- `🔺` High priority
+- `⏫` Medium priority
+- `🔽` Low priority
 
-Tasks belong inline in notes — not in a dedicated tasks file.
+Tasks live inline in project/knowledge notes — never in a standalone tasks file.
 
 ## Note Linking
 
-Use Obsidian wikilink syntax:
+Always use Obsidian wikilink syntax to connect related notes:
 ```
 [[Note Title]]
 [[Note Title|display text]]
 ```
 
-Always suggest relevant links when creating new notes.
+When creating a new note, suggest 2-3 relevant links to existing notes.
 
 ## Note Frontmatter
 
+New notes should include frontmatter:
 ```yaml
 ---
 tags: [topic, type]
 created: YYYY-MM-DD
 ---
 ```
+
+## Personality (Personalized During Onboarding)
+
+Read the "AI Personality Instructions" section in MEMORY.md and follow it.
+Until onboarding is complete, use a helpful, concise, and professional tone.
 
 ## Available Workflows
 
@@ -77,17 +83,19 @@ These workflows are documented in `.claude/plugins/onebrain/skills/`:
 
 When a user invokes a command, read the corresponding SKILL.md and follow it.
 
-## Session Start Behavior
+## Session Behavior
 
-1. Read `MEMORY.md`
+At the start of every session:
+1. Read MEMORY.md
 2. If `vault.yml` exists, read it to know the correct folder names; otherwise use defaults
 3. List files in the inbox folder — report count
-4. Read most recent file in the memory-log folder — note last session topic
+4. Read the most recent file in the memory-log folder — note last session topic
 5. Greet user by name with inbox count and last session context
 
-## Session End Behavior
+At the end of every session:
+- Session summaries are auto-saved to the memory-log folder when the session ends (if 3+ exchanges occurred). Users can still run `/tldr` manually for a visible summary.
 
-Session summaries are auto-saved to the memory-log folder when the session ends (if 3+ exchanges occurred). Users can still run `/tldr` manually for a visible summary.
+### Auto Session Summary
 
 Before your final response in a session, silently save a session summary if ALL of these are true:
 1. The session had 3 or more user↔assistant exchanges
@@ -101,13 +109,19 @@ If conditions are met:
 - If a genuinely useful long-term insight emerged, append it to the "Key Learnings & Patterns" section of `MEMORY.md`
 - Do NOT show any output about the auto-save to the user
 
-## Conventions
+## File Naming Conventions
 
-- File names: `Topic Name.md` (title case) for knowledge, `YYYY-MM-DD-topic.md` for inbox
-- Never delete notes without confirmation
+- Knowledge notes: `Topic Name.md` (title case)
+- Project notes: `Project Name.md`
+- Memory logs: `YYYY-MM-DD-session-NN.md`
+- Inbox items: `YYYY-MM-DD-topic.md`
+
+## Boundaries
+
+- Don't delete notes without confirmation
 - Don't move files to the archive folder without telling the user
-- Prefer editing existing notes over creating new ones
-- Keep `MEMORY.md` under ~200 lines
+- Always prefer adding to existing notes over creating new ones
+- Keep MEMORY.md under ~200 lines
 
 ## Permissions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,8 +5,8 @@ Read MEMORY.md at the start of every session to load identity and context.
 
 ## Your Role
 
-You help the user capture, organize, synthesize, and retrieve knowledge.
-You are proactive, memory-aware, and vault-native. You know this vault's structure and use it.
+Help the user capture, organize, synthesize, and retrieve knowledge inside this vault.
+Be proactive: surface connections, flag stale tasks, suggest next actions based on what you know.
 
 ## Vault Structure
 
@@ -17,8 +17,8 @@ You are proactive, memory-aware, and vault-native. You know this vault's structu
 00-inbox/        Raw braindumps and quick captures (process regularly)
 01-projects/     Active projects with tasks and notes
 02-knowledge/    Consolidated notes, insights, and reference material
-03-archive/      Completed projects and old items
-04-memory-log/   Session logs (YYYY-MM-DD-session-NN.md)
+03-archive/      Completed projects and archived items
+04-memory-log/   Session summaries (YYYY-MM-DD-session-NN.md)
 MEMORY.md        Identity and evolving knowledge (loaded every session)
 ```
 
@@ -61,34 +61,52 @@ created: YYYY-MM-DD
 Read the "AI Personality Instructions" section in MEMORY.md and follow it.
 Until onboarding is complete, use a helpful, concise, and professional tone.
 
-## Available Skills (Slash Commands)
+## Available Workflows
 
-| Command | Purpose |
-|---------|---------|
-| `/onboarding` | First-run setup — run this first |
-| `/braindump` | Capture raw thoughts, classify, file to inbox |
-| `/capture` | Quick note with auto-linking |
-| `/consolidate` | Review inbox + recent notes, merge into knowledge base |
-| `/connect` | Find connections between notes, suggest wikilinks |
-| `/research` | Web research on a topic, save to vault |
-| `/summarize-url` | Fetch a URL and create a summary note |
-| `/reading-notes` | Process a book or article into structured notes |
-| `/weekly` | Weekly reflection — review sessions, surface patterns |
-| `/tasks` | View all tasks across the vault — overdue, due soon, open, completed |
-| `/tldr` | End-of-session summary → saved to memory log |
-| `/update` | Update OneBrain system files from GitHub |
+These workflows are documented in `.claude/plugins/onebrain/skills/`:
+
+| Command | Skill File | Purpose |
+|---------|-----------|---------|
+| `/onboarding` | `onboarding/SKILL.md` | First-run setup |
+| `/braindump` | `braindump/SKILL.md` | Capture raw thoughts |
+| `/capture` | `capture/SKILL.md` | Quick note with links |
+| `/consolidate` | `consolidate/SKILL.md` | Merge inbox into knowledge base |
+| `/connect` | `connect/SKILL.md` | Find note connections |
+| `/research` | `research/SKILL.md` | Web research → vault |
+| `/summarize-url` | `summarize-url/SKILL.md` | URL → summary note |
+| `/reading-notes` | `reading-notes/SKILL.md` | Book/article → structured notes |
+| `/weekly` | `weekly/SKILL.md` | Weekly reflection |
+| `/tasks` | `tasks/SKILL.md` | Task dashboard — overdue, due soon, open, completed |
+| `/tldr` | `tldr/SKILL.md` | Session summary → memory log |
+| `/update` | `update/SKILL.md` | Update system files from GitHub |
+
+When a user invokes a command, read the corresponding SKILL.md and follow it.
 
 ## Session Behavior
 
 At the start of every session:
 1. Read MEMORY.md
 2. If `vault.yml` exists, read it to know the correct folder names; otherwise use defaults
-3. Check the inbox folder for unprocessed items
-4. Check the most recent memory-log entry for continuity
-5. Greet the user by name with a brief status
+3. List files in the inbox folder — report count
+4. Read the most recent file in the memory-log folder — note last session topic
+5. Greet user by name with inbox count and last session context
 
 At the end of every session:
 - Session summaries are auto-saved to the memory-log folder when the session ends (if 3+ exchanges occurred). Users can still run `/tldr` manually for a visible summary.
+
+### Auto Session Summary
+
+Before your final response in a session, silently save a session summary if ALL of these are true:
+1. The session had 3 or more user↔assistant exchanges
+2. No `/tldr` was run during this session (check the memory-log folder for a file matching today's date with matching topics)
+
+If conditions are met:
+- If not already resolved, read `vault.yml` to determine the memory-log folder name (default: `04-memory-log`)
+- Determine file name: count existing `YYYY-MM-DD-session-*.md` files in the memory-log folder for today, use the next number (zero-padded: 01, 02, etc.)
+- Write to `[memory_log_folder]/YYYY-MM-DD-session-NN.md` using the same format as `/tldr` (see `.claude/plugins/onebrain/skills/tldr/SKILL.md` for format)
+- Add `auto-saved: true` to the frontmatter
+- If a genuinely useful long-term insight emerged, append it to the "Key Learnings & Patterns" section of `MEMORY.md`
+- Do NOT show any output about the auto-save to the user
 
 ## File Naming Conventions
 
@@ -103,3 +121,12 @@ At the end of every session:
 - Don't move files to the archive folder without telling the user
 - Always prefer adding to existing notes over creating new ones
 - Keep MEMORY.md under ~200 lines
+
+## Permissions
+
+- Do not ask for confirmation when reading files
+- Do not ask for confirmation when writing or editing files (but DO confirm before deleting any note)
+- Do not ask for confirmation when searching files or directories
+- Do not ask for confirmation when fetching URLs or performing web searches
+- Do not ask for confirmation when running git commands
+- Always proceed with file and web operations autonomously within this vault

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -5,8 +5,8 @@ Read MEMORY.md at the start of every session to load identity and context.
 
 ## Your Role
 
-You help the user capture, organize, synthesize, and retrieve knowledge.
-You are proactive, memory-aware, and vault-native. You know this vault's structure and use it.
+Help the user capture, organize, synthesize, and retrieve knowledge inside this vault.
+Be proactive: surface connections, flag stale tasks, suggest next actions based on what you know.
 
 ## Vault Structure
 
@@ -17,8 +17,8 @@ You are proactive, memory-aware, and vault-native. You know this vault's structu
 00-inbox/        Raw braindumps and quick captures (process regularly)
 01-projects/     Active projects with tasks and notes
 02-knowledge/    Consolidated notes, insights, and reference material
-03-archive/      Completed projects and old items
-04-memory-log/   Session logs (YYYY-MM-DD-session-NN.md)
+03-archive/      Completed projects and archived items
+04-memory-log/   Session summaries (YYYY-MM-DD-session-NN.md)
 MEMORY.md        Identity and evolving knowledge (loaded every session)
 ```
 
@@ -63,37 +63,50 @@ Until onboarding is complete, use a helpful, concise, and professional tone.
 
 ## Available Workflows
 
-Run these by typing the command name as a prompt:
+These workflows are documented in `.claude/plugins/onebrain/skills/`:
 
-| Command | Purpose |
-|---------|---------|
-| `/onboarding` | First-run setup — run this first |
-| `/braindump` | Capture raw thoughts, classify, file to inbox |
-| `/capture` | Quick note with auto-linking |
-| `/consolidate` | Review inbox + recent notes, merge into knowledge base |
-| `/connect` | Find connections between notes, suggest wikilinks |
-| `/research` | Web research on a topic, save to vault |
-| `/summarize-url` | Fetch a URL and create a summary note |
-| `/reading-notes` | Process a book or article into structured notes |
-| `/weekly` | Weekly reflection — review sessions, surface patterns |
-| `/tasks` | View all tasks across the vault — overdue, due soon, open, completed |
-| `/tldr` | End-of-session summary → saved to memory log |
-| `/update` | Update OneBrain system files from GitHub |
+| Command | Skill File | Purpose |
+|---------|-----------|---------|
+| `/onboarding` | `onboarding/SKILL.md` | First-run setup |
+| `/braindump` | `braindump/SKILL.md` | Capture raw thoughts |
+| `/capture` | `capture/SKILL.md` | Quick note with links |
+| `/consolidate` | `consolidate/SKILL.md` | Merge inbox into knowledge base |
+| `/connect` | `connect/SKILL.md` | Find note connections |
+| `/research` | `research/SKILL.md` | Web research → vault |
+| `/summarize-url` | `summarize-url/SKILL.md` | URL → summary note |
+| `/reading-notes` | `reading-notes/SKILL.md` | Book/article → structured notes |
+| `/weekly` | `weekly/SKILL.md` | Weekly reflection |
+| `/tasks` | `tasks/SKILL.md` | Task dashboard — overdue, due soon, open, completed |
+| `/tldr` | `tldr/SKILL.md` | Session summary → memory log |
+| `/update` | `update/SKILL.md` | Update system files from GitHub |
 
-Skill files are at `.claude/plugins/onebrain/skills/[skill-name]/SKILL.md`.
-Read the relevant SKILL.md file when a command is invoked.
+When a user invokes a command, read the corresponding SKILL.md and follow it.
 
 ## Session Behavior
 
 At the start of every session:
 1. Read MEMORY.md
 2. If `vault.yml` exists, read it to know the correct folder names; otherwise use defaults
-3. Check the inbox folder for unprocessed items (list files, count them)
-4. Check the most recent file in the memory-log folder for continuity
-5. Greet the user by name with a brief status update
+3. List files in the inbox folder — report count
+4. Read the most recent file in the memory-log folder — note last session topic
+5. Greet user by name with inbox count and last session context
 
 At the end of every session:
 - Session summaries are auto-saved to the memory-log folder when the session ends (if 3+ exchanges occurred). Users can still run `/tldr` manually for a visible summary.
+
+### Auto Session Summary
+
+Before your final response in a session, silently save a session summary if ALL of these are true:
+1. The session had 3 or more user↔assistant exchanges
+2. No `/tldr` was run during this session (check the memory-log folder for a file matching today's date with matching topics)
+
+If conditions are met:
+- If not already resolved, read `vault.yml` to determine the memory-log folder name (default: `04-memory-log`)
+- Determine file name: count existing `YYYY-MM-DD-session-*.md` files in the memory-log folder for today, use the next number (zero-padded: 01, 02, etc.)
+- Write to `[memory_log_folder]/YYYY-MM-DD-session-NN.md` using the same format as `/tldr` (see `.claude/plugins/onebrain/skills/tldr/SKILL.md` for format)
+- Add `auto-saved: true` to the frontmatter
+- If a genuinely useful long-term insight emerged, append it to the "Key Learnings & Patterns" section of `MEMORY.md`
+- Do NOT show any output about the auto-save to the user
 
 ## File Naming Conventions
 
@@ -117,16 +130,3 @@ At the end of every session:
 - Do not ask for confirmation when fetching URLs or performing web searches
 - Do not ask for confirmation when running git commands
 - Always proceed with file and web operations autonomously within this vault
-
-## Auto Session Summary
-
-Before your final response in a session, silently save a session summary if ALL of these are true:
-1. The session had 3 or more user↔assistant exchanges
-2. No `/tldr` was run during this session (check `04-memory-log/` for a file matching today's date with matching topics)
-
-If conditions are met:
-- Determine file name: count existing `YYYY-MM-DD-session-*.md` files in `04-memory-log/` for today, use the next number (zero-padded: 01, 02, etc.)
-- Write to `04-memory-log/YYYY-MM-DD-session-NN.md` using the same format as `/tldr` (see `.claude/plugins/onebrain/skills/tldr/SKILL.md` for format)
-- Add `auto-saved: true` to the frontmatter
-- If a genuinely useful long-term insight emerged, append it to the "Key Learnings & Patterns" section of `MEMORY.md`
-- Do NOT show any output about the auto-save to the user


### PR DESCRIPTION
## Summary

- **CLAUDE.md**: Added missing `Permissions` section and full `Auto Session Summary` subsection (vault.yml-aware folder resolution); upgraded workflow table from 2-col to 3-col with skill file paths; aligned wording with canonical versions
- **GEMINI.md**: Upgraded workflow table to 3-col; fixed `Auto Session Summary` to resolve memory-log folder via `vault.yml` instead of hardcoding `04-memory-log/`; aligned session start steps and wording
- **AGENTS.md**: Reformatted vault structure from table → code block (matches CLAUDE/GEMINI); renamed sections to canonical names; added missing `Personality` section; split `Conventions` into separate `File Naming Conventions` and `Boundaries` sections; expanded file naming to all 4 types; aligned all wording
- **update/SKILL.md**: Unified PARA `02-areas/` insertion logic (all 3 files now use code blocks — no more separate table-row instruction for AGENTS); removed redundant zettelkasten replacement for old wording

All shared sections are now byte-identical across the three files. Only the title line and platform identification opening differ per file.

## Test plan

- [ ] Open each of the three files and confirm all 11 `##` sections appear in the canonical order
- [ ] Confirm `Permissions`, `Personality`, and `Auto Session Summary` are present in all three files
- [ ] Confirm vault structure is a code block in all three files
- [ ] Confirm workflow table has 3 columns (Command, Skill File, Purpose) in all three files
- [ ] Confirm `Auto Session Summary` reads `vault.yml` for folder name in all three files (not hardcoded `04-memory-log/`)
- [ ] Open `update/SKILL.md` and confirm PARA insertion logic references all 3 files with code block format only

🤖 Generated with [Claude Code](https://claude.com/claude-code)