### PR TITLE
Auto-install community plugins during vault setup

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -189,7 +189,7 @@ function Install-Plugins {
       $cssPath = Join-Path $pluginDir "styles.css"
       try {
         $cssResponse = Invoke-WebRequest -Uri "$baseUrl/styles.css" -OutFile $cssPath -PassThru -ErrorAction Stop
-        # Remove if non-200 or empty (PS5 writes the 404 HTML body to disk without throwing)
+        # Defensive: remove if non-200 or empty (guards against zero-byte writes on network drop)
         $cssLen = try { (Get-Item $cssPath -ErrorAction Stop).Length } catch { 0 }
         if ($cssResponse.StatusCode -ne 200 -or $cssLen -eq 0) {
           try { Remove-Item $cssPath -Force -ErrorAction Stop } catch {
@@ -199,7 +199,9 @@ function Install-Plugins {
       } catch {
         # Network/TLS/unexpected errors — warn but don't fail the plugin
         Write-Host "  ⚠️  Could not download styles.css for $pluginId`: $($_.Exception.Message)" -ForegroundColor Yellow
-        try { Remove-Item $cssPath -Force -ErrorAction Stop } catch {}
+        try { Remove-Item $cssPath -Force -ErrorAction Stop } catch {
+          Write-Host "  ⚠️  Could not remove partial styles.css for ${pluginId}: $($_.Exception.Message)" -ForegroundColor Yellow
+        }
       }
     }
 
@@ -281,7 +283,7 @@ function Main {
   $repoUrl = "https://github.com/kengio/onebrain/archive/refs/heads/main.zip"
   $tmpDir  = Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid().ToString())
   try {
-    New-Item -ItemType Directory -Path $tmpDir -Force | Out-Null
+    New-Item -ItemType Directory -Path $tmpDir -Force -ErrorAction Stop | Out-Null
   } catch {
     Print-Error "Could not create a temporary directory. Check that your system temp folder is writeable."
     exit 1
@@ -455,7 +457,7 @@ function Main {
   $open = Read-Host "  ? Open vault folder in Explorer? [Y/n]"
   if ($open -eq '' -or $open -match '^[Yy]') {
     try {
-      Start-Process explorer.exe $vaultPath
+      Start-Process explorer.exe -ArgumentList $vaultPath
     } catch {
       Print-Info "Could not open Explorer automatically. Your vault is at: $vaultPath"
     }

--- a/install.ps1
+++ b/install.ps1
@@ -65,7 +65,15 @@ function Install-Plugins {
 
   if (-not (Test-Path $pluginsJson)) { return ,@($failedPlugins) }
 
-  $pluginIds = Get-Content $pluginsJson -Raw | ConvertFrom-Json
+  # Wrap ConvertFrom-Json in try/catch: malformed JSON (e.g. sync-conflict markers) throws
+  # a terminating error and must not propagate to the outer Main catch as a fatal abort.
+  try {
+    $pluginIds = Get-Content $pluginsJson -Raw | ConvertFrom-Json -ErrorAction Stop
+  } catch {
+    Write-Host "  ⚠️  community-plugins.json could not be parsed: $($_.Exception.Message)" -ForegroundColor Yellow
+    Write-Host "  Skipping plugin installation." -ForegroundColor Yellow
+    return ,@($failedPlugins)
+  }
   # Validate that the file is a flat array of strings (guards against sync-conflict corruption)
   if (-not $pluginIds -or $pluginIds.Count -eq 0) { return ,@($failedPlugins) }
   if ($pluginIds | Where-Object { $_ -isnot [string] }) {
@@ -88,12 +96,32 @@ function Install-Plugins {
   }
   Write-Done "Registry fetched"
 
+  # Wrap New-Item in try/catch: a filesystem error here must not propagate to the outer
+  # Main catch as a fatal abort — plugin installation is a non-fatal step.
   $pluginsDir = Join-Path $VaultPath ".obsidian\plugins"
-  if (-not (Test-Path $pluginsDir)) {
-    New-Item -ItemType Directory -Path $pluginsDir -Force | Out-Null
+  try {
+    if (-not (Test-Path $pluginsDir)) {
+      New-Item -ItemType Directory -Path $pluginsDir -Force -ErrorAction Stop | Out-Null
+    }
+  } catch {
+    Write-Host "  ⚠️  Could not create plugins directory '$pluginsDir': $($_.Exception.Message)" -ForegroundColor Yellow
+    Write-Host "  All plugins will need to be installed manually." -ForegroundColor Yellow
+    return ,@($pluginIds)
   }
 
+  # GitHub REST API: 60 req/hr unauthenticated (shared per IP) — 5,000/hr with GITHUB_TOKEN.
+  # Build headers once; GITHUB_TOKEN does not change during the loop.
+  $ghHeaders = @{ Accept = "application/vnd.github.v3+json" }
+  if ($env:GITHUB_TOKEN) { $ghHeaders["Authorization"] = "Bearer $env:GITHUB_TOKEN" }
+
   foreach ($pluginId in $pluginIds) {
+    # Validate plugin ID: reject IDs with path-traversal or shell-unsafe characters
+    if ($pluginId -notmatch '^[a-zA-Z0-9_-]+$') {
+      Write-Host "  ⚠️  skipped invalid plugin ID: '$pluginId'" -ForegroundColor Yellow
+      $failedPlugins += $pluginId
+      continue
+    }
+
     # Find matching entry in the registry
     $entry = $registry | Where-Object { $_.id -eq $pluginId } | Select-Object -First 1
     if (-not $entry -or -not $entry.repo) {
@@ -105,11 +133,6 @@ function Install-Plugins {
 
     Write-Step "🔌" "Installing $pluginId..."
 
-    # GitHub REST API: 60 req/hr unauthenticated (shared per IP). Each plugin consumes
-    # one request. Set GITHUB_TOKEN env var to raise the limit to 5,000/hr.
-    $ghHeaders = @{ Accept = "application/vnd.github.v3+json" }
-    if ($env:GITHUB_TOKEN) { $ghHeaders["Authorization"] = "Bearer $env:GITHUB_TOKEN" }
-
     try {
       $release = Invoke-RestMethod `
         -Uri "https://api.github.com/repos/$repo/releases/latest" `
@@ -117,9 +140,11 @@ function Install-Plugins {
         -ErrorAction Stop
       $tag = $release.tag_name
     } catch {
-      # Check for GitHub rate limit specifically
-      if ($_.Exception.Message -match '403' -or ($_.Exception.Response -and $_.Exception.Response.StatusCode -eq 403)) {
-        Write-Host "  ❌ rate-limited $pluginId (GitHub API rate limit reached; set GITHUB_TOKEN to raise to 5,000/hr)" -ForegroundColor Red
+      # HTTP 403 can mean rate limit or access denied (private repo, bad token scope) —
+      # check status code via the response object to avoid matching "403" in unrelated messages
+      $statusCode = if ($_.Exception.Response) { [int]$_.Exception.Response.StatusCode } else { 0 }
+      if ($statusCode -eq 403) {
+        Write-Host "  ❌ forbidden $pluginId (HTTP 403 — rate limited or access denied; check GITHUB_TOKEN)" -ForegroundColor Red
       } else {
         Write-Host "  ❌ failed $pluginId (could not get release tag: $($_.Exception.Message))" -ForegroundColor Red
       }
@@ -133,8 +158,15 @@ function Install-Plugins {
       continue
     }
 
+    # Wrap New-Item per-plugin in try/catch to preserve non-fatal contract
     $pluginDir = Join-Path $pluginsDir $pluginId
-    New-Item -ItemType Directory -Path $pluginDir -Force | Out-Null
+    try {
+      New-Item -ItemType Directory -Path $pluginDir -Force -ErrorAction Stop | Out-Null
+    } catch {
+      Write-Host "  ❌ failed $pluginId (could not create plugin directory: $($_.Exception.Message))" -ForegroundColor Red
+      $failedPlugins += $pluginId
+      continue
+    }
 
     $baseUrl = "https://github.com/$repo/releases/download/$tag"
     $ok = $true
@@ -151,24 +183,23 @@ function Install-Plugins {
     }
 
     # styles.css is optional — not all plugins ship it.
-    # PS5 Invoke-WebRequest does not throw on HTTP 4xx — check StatusCode explicitly.
-    # Network/TLS errors do throw and are warned about (not silently ignored).
+    # PS5 Invoke-WebRequest does not throw on HTTP 4xx — check StatusCode explicitly to
+    # avoid keeping a 404 HTML error page on disk as a "valid" CSS file.
     if ($ok) {
       $cssPath = Join-Path $pluginDir "styles.css"
       try {
         $cssResponse = Invoke-WebRequest -Uri "$baseUrl/styles.css" -OutFile $cssPath -PassThru -ErrorAction Stop
-        # Remove if HTTP error or empty (handles PS5 which writes 404 HTML body to disk)
-        if ($cssResponse.StatusCode -ne 200 -or (Get-Item $cssPath -ErrorAction SilentlyContinue).Length -eq 0) {
-          Remove-Item $cssPath -Force -ErrorAction SilentlyContinue
+        # Remove if non-200 or empty (PS5 writes the 404 HTML body to disk without throwing)
+        $cssLen = try { (Get-Item $cssPath -ErrorAction Stop).Length } catch { 0 }
+        if ($cssResponse.StatusCode -ne 200 -or $cssLen -eq 0) {
+          try { Remove-Item $cssPath -Force -ErrorAction Stop } catch {
+            Write-Host "  ⚠️  Could not remove bad styles.css for ${pluginId}: $($_.Exception.Message)" -ForegroundColor Yellow
+          }
         }
-      } catch [System.Net.WebException] {
-        # Network-level failure (DNS, TLS, timeout) — not a missing optional file; warn the user
-        Write-Host "  ⚠️  Could not download styles.css for $pluginId`: $($_.Exception.Message)" -ForegroundColor Yellow
-        Remove-Item $cssPath -Force -ErrorAction SilentlyContinue
       } catch {
-        # Any other unexpected error — warn but don't fail the plugin
-        Write-Host "  ⚠️  Unexpected error downloading styles.css for $pluginId`: $($_.Exception.Message)" -ForegroundColor Yellow
-        Remove-Item $cssPath -Force -ErrorAction SilentlyContinue
+        # Network/TLS/unexpected errors — warn but don't fail the plugin
+        Write-Host "  ⚠️  Could not download styles.css for $pluginId`: $($_.Exception.Message)" -ForegroundColor Yellow
+        try { Remove-Item $cssPath -Force -ErrorAction Stop } catch {}
       }
     }
 
@@ -403,21 +434,19 @@ function Main {
   Write-Host "Next steps:" -ForegroundColor White
   Write-Host "  1. Open Obsidian"
   Write-Host "     File -> Open Folder as Vault -> select: $vaultPath"
+  $step = 2
   if ($script:FailedPlugins.Count -gt 0) {
-    Write-Host "  2. Install missing plugins manually (Settings -> Community plugins -> Browse):" -ForegroundColor White
+    Write-Host "  $step. Install missing plugins manually (Settings -> Community plugins -> Browse):" -ForegroundColor White
     foreach ($p in $script:FailedPlugins) {
       Write-Host "     $p" -ForegroundColor Cyan
     }
-    Write-Host "  3. Open your terminal in the vault directory and run your AI agent:"
-    Write-Host "     claude  or  gemini" -ForegroundColor Cyan
-    Write-Host "  4. Run the onboarding command:"
-    Write-Host "     /onboarding" -ForegroundColor Cyan
-  } else {
-    Write-Host "  2. Open your terminal in the vault directory and run your AI agent:"
-    Write-Host "     claude  or  gemini" -ForegroundColor Cyan
-    Write-Host "  3. Run the onboarding command:"
-    Write-Host "     /onboarding" -ForegroundColor Cyan
+    $step++
   }
+  Write-Host "  $step. Open your terminal in the vault directory and run your AI agent:"
+  Write-Host "     claude  or  gemini" -ForegroundColor Cyan
+  $step++
+  Write-Host "  $step. Run the onboarding command:"
+  Write-Host "     /onboarding" -ForegroundColor Cyan
   Write-Host "     (Onboarding will ask you to choose a vault organization method"
   Write-Host "      and create your folders: OneBrain, PARA, or Zettelkasten)"
   Write-Host

--- a/install.ps1
+++ b/install.ps1
@@ -50,7 +50,124 @@ function Prompt-WithDefault {
   if ([string]::IsNullOrWhiteSpace($answer)) { $Default } else { $answer }
 }
 
+# ─── Plugin installer ─────────────────────────────────────────────────────────
+# Install-Plugins <vaultPath>
+# Downloads the latest release of each plugin listed in .obsidian/community-plugins.json.
+# Uses only PowerShell 5+ built-ins: Invoke-RestMethod, ConvertFrom-Json, Invoke-WebRequest.
+# Non-fatal: returns a list of plugin IDs that failed (empty array on full success).
+function Install-Plugins {
+  param([string]$VaultPath)
+
+  $pluginsJson = Join-Path $VaultPath ".obsidian\community-plugins.json"
+  $registryUrl = "https://raw.githubusercontent.com/obsidianmd/obsidian-releases/master/community-plugins.json"
+  $failedPlugins = @()
+
+  if (-not (Test-Path $pluginsJson)) { return $failedPlugins }
+
+  $pluginIds = Get-Content $pluginsJson -Raw | ConvertFrom-Json
+  if (-not $pluginIds -or $pluginIds.Count -eq 0) { return $failedPlugins }
+
+  Write-Host
+  Write-Host "  Installing community plugins..." -ForegroundColor Cyan
+  Write-Host
+
+  # Fetch Obsidian plugin registry once
+  Write-Step "📦" "Fetching plugin registry..."
+  try {
+    $registry = Invoke-RestMethod -Uri $registryUrl -ErrorAction Stop
+  } catch {
+    Write-Host "  ⚠️  Could not reach plugin registry. Plugins will need to be installed manually." -ForegroundColor Yellow
+    return $pluginIds  # all plugins are "failed"
+  }
+  Write-Done "Registry fetched"
+
+  $pluginsDir = Join-Path $VaultPath ".obsidian\plugins"
+  if (-not (Test-Path $pluginsDir)) {
+    New-Item -ItemType Directory -Path $pluginsDir -Force | Out-Null
+  }
+
+  foreach ($pluginId in $pluginIds) {
+    # Find matching entry in the registry
+    $entry = $registry | Where-Object { $_.id -eq $pluginId } | Select-Object -First 1
+    if (-not $entry -or -not $entry.repo) {
+      Write-Host "  ⚠️  skipped $pluginId (not found in registry)" -ForegroundColor Yellow
+      $failedPlugins += $pluginId
+      continue
+    }
+    $repo = $entry.repo
+
+    Write-Step "🔌" "Installing $pluginId..."
+
+    # Get latest release tag
+    try {
+      $release = Invoke-RestMethod `
+        -Uri "https://api.github.com/repos/$repo/releases/latest" `
+        -Headers @{ Accept = "application/vnd.github.v3+json" } `
+        -ErrorAction Stop
+      $tag = $release.tag_name
+    } catch {
+      Write-Host "  ❌ failed $pluginId (could not get release tag)" -ForegroundColor Red
+      $failedPlugins += $pluginId
+      continue
+    }
+
+    if (-not $tag) {
+      Write-Host "  ❌ failed $pluginId (empty release tag)" -ForegroundColor Red
+      $failedPlugins += $pluginId
+      continue
+    }
+
+    $pluginDir = Join-Path $pluginsDir $pluginId
+    New-Item -ItemType Directory -Path $pluginDir -Force | Out-Null
+
+    $baseUrl = "https://github.com/$repo/releases/download/$tag"
+    $ok = $true
+
+    # main.js and manifest.json are required
+    foreach ($asset in @("main.js", "manifest.json")) {
+      try {
+        Invoke-WebRequest -Uri "$baseUrl/$asset" -OutFile (Join-Path $pluginDir $asset) -ErrorAction Stop | Out-Null
+      } catch {
+        $ok = $false
+        break
+      }
+    }
+
+    # styles.css is optional
+    if ($ok) {
+      try {
+        $cssPath = Join-Path $pluginDir "styles.css"
+        Invoke-WebRequest -Uri "$baseUrl/styles.css" -OutFile $cssPath -ErrorAction Stop | Out-Null
+        # Remove if it downloaded as empty
+        if ((Get-Item $cssPath).Length -eq 0) { Remove-Item $cssPath -Force }
+      } catch {
+        # Optional asset — ignore failure
+      }
+    }
+
+    if ($ok) {
+      Write-Done "$pluginId"
+    } else {
+      Write-Host "  ❌ failed $pluginId (download error)" -ForegroundColor Red
+      Remove-Item -Path $pluginDir -Recurse -Force -ErrorAction SilentlyContinue
+      $failedPlugins += $pluginId
+    }
+  }
+
+  if ($failedPlugins.Count -gt 0) {
+    Write-Host
+    Write-Host "  Some plugins could not be installed automatically:" -ForegroundColor Yellow
+    foreach ($p in $failedPlugins) {
+      Write-Host "    • $p" -ForegroundColor Yellow
+    }
+    Write-Host "  Install them manually: Settings -> Community plugins -> Browse" -ForegroundColor Yellow
+  }
+
+  return $failedPlugins
+}
+
 # ─── Main ─────────────────────────────────────────────────────────────────────
+$script:FailedPlugins = @()
 function Main {
   Print-Banner
   Print-Info "This script downloads OneBrain and sets up a fresh Obsidian vault."
@@ -192,6 +309,9 @@ function Main {
       }
     }
 
+    # ── Step 4b: Install community plugins ──────────────────────────────────
+    $script:FailedPlugins = Install-Plugins $vaultPath
+
     # ── Step 5: Initialize git ──────────────────────────────────────────────
     Write-Step "🧠" "Initializing git repository..."
     # Push-Location lives in its own try/catch outside the finally-guarded block so that
@@ -252,13 +372,21 @@ function Main {
   Write-Host "Next steps:" -ForegroundColor White
   Write-Host "  1. Open Obsidian"
   Write-Host "     File -> Open Folder as Vault -> select: $vaultPath"
-  Write-Host "  2. Install community plugins (Settings -> Community plugins -> Browse):"
-  Write-Host "     Tasks  Dataview  Templater  Calendar" -ForegroundColor Cyan
-  Write-Host "     Tag Wrangler  QuickAdd  Obsidian Git  Terminal" -ForegroundColor Cyan
-  Write-Host "  3. Open the Terminal plugin in Obsidian and run your AI agent:"
-  Write-Host "     claude  or  gemini" -ForegroundColor Cyan
-  Write-Host "  4. Run the onboarding command:"
-  Write-Host "     /onboarding" -ForegroundColor Cyan
+  if ($script:FailedPlugins.Count -gt 0) {
+    Write-Host "  2. Install missing plugins manually (Settings -> Community plugins -> Browse):" -ForegroundColor White
+    foreach ($p in $script:FailedPlugins) {
+      Write-Host "     $p" -ForegroundColor Cyan
+    }
+    Write-Host "  3. Open your terminal in the vault directory and run your AI agent:"
+    Write-Host "     claude  or  gemini" -ForegroundColor Cyan
+    Write-Host "  4. Run the onboarding command:"
+    Write-Host "     /onboarding" -ForegroundColor Cyan
+  } else {
+    Write-Host "  2. Open your terminal in the vault directory and run your AI agent:"
+    Write-Host "     claude  or  gemini" -ForegroundColor Cyan
+    Write-Host "  3. Run the onboarding command:"
+    Write-Host "     /onboarding" -ForegroundColor Cyan
+  }
   Write-Host "     (Onboarding will ask you to choose a vault organization method"
   Write-Host "      and create your folders: OneBrain, PARA, or Zettelkasten)"
   Write-Host

--- a/install.ps1
+++ b/install.ps1
@@ -171,11 +171,18 @@ function Install-Plugins {
     $baseUrl = "https://github.com/$repo/releases/download/$tag"
     $ok = $true
 
-    # main.js and manifest.json are required; short-circuit on first failure
+    # main.js and manifest.json are required; short-circuit on first failure.
+    # After download, verify non-empty: a network drop can produce a 200 with zero bytes.
     foreach ($asset in @("main.js", "manifest.json")) {
       if (-not $ok) { break }
+      $assetPath = Join-Path $pluginDir $asset
       try {
-        Invoke-WebRequest -Uri "$baseUrl/$asset" -OutFile (Join-Path $pluginDir $asset) -ErrorAction Stop | Out-Null
+        Invoke-WebRequest -Uri "$baseUrl/$asset" -OutFile $assetPath -ErrorAction Stop | Out-Null
+        $assetLen = try { (Get-Item $assetPath -ErrorAction Stop).Length } catch { 0 }
+        if ($assetLen -eq 0) {
+          Write-Host "  ⚠️  $pluginId/$asset downloaded as empty (network drop?)" -ForegroundColor Yellow
+          $ok = $false
+        }
       } catch {
         Write-Host "  ⚠️  $pluginId/$asset failed: $($_.Exception.Message)" -ForegroundColor Yellow
         $ok = $false
@@ -183,8 +190,8 @@ function Install-Plugins {
     }
 
     # styles.css is optional — not all plugins ship it.
-    # PS5 Invoke-WebRequest does not throw on HTTP 4xx — check StatusCode explicitly to
-    # avoid keeping a 404 HTML error page on disk as a "valid" CSS file.
+    # Invoke-WebRequest throws on HTTP 4xx/5xx (caught below), but a 200 with zero bytes
+    # is possible on a mid-transfer network drop. Check length and remove if empty.
     if ($ok) {
       $cssPath = Join-Path $pluginDir "styles.css"
       try {

--- a/install.ps1
+++ b/install.ps1
@@ -53,7 +53,8 @@ function Prompt-WithDefault {
 # ─── Plugin installer ─────────────────────────────────────────────────────────
 # Install-Plugins <vaultPath>
 # Downloads the latest release of each plugin listed in .obsidian/community-plugins.json.
-# Uses only PowerShell 5+ built-ins: Invoke-RestMethod, ConvertFrom-Json, Invoke-WebRequest.
+# No external dependencies — uses only PowerShell 5+ built-in cmdlets. Does not
+# require curl, jq, or additional modules.
 # Non-fatal: returns a list of plugin IDs that failed (empty array on full success).
 function Install-Plugins {
   param([string]$VaultPath)
@@ -62,10 +63,15 @@ function Install-Plugins {
   $registryUrl = "https://raw.githubusercontent.com/obsidianmd/obsidian-releases/master/community-plugins.json"
   $failedPlugins = @()
 
-  if (-not (Test-Path $pluginsJson)) { return $failedPlugins }
+  if (-not (Test-Path $pluginsJson)) { return ,@($failedPlugins) }
 
   $pluginIds = Get-Content $pluginsJson -Raw | ConvertFrom-Json
-  if (-not $pluginIds -or $pluginIds.Count -eq 0) { return $failedPlugins }
+  # Validate that the file is a flat array of strings (guards against sync-conflict corruption)
+  if (-not $pluginIds -or $pluginIds.Count -eq 0) { return ,@($failedPlugins) }
+  if ($pluginIds | Where-Object { $_ -isnot [string] }) {
+    Write-Host "  ⚠️  community-plugins.json is malformed (expected array of strings). Skipping plugin installation." -ForegroundColor Yellow
+    return ,@($failedPlugins)
+  }
 
   Write-Host
   Write-Host "  Installing community plugins..." -ForegroundColor Cyan
@@ -76,8 +82,9 @@ function Install-Plugins {
   try {
     $registry = Invoke-RestMethod -Uri $registryUrl -ErrorAction Stop
   } catch {
-    Write-Host "  ⚠️  Could not reach plugin registry. Plugins will need to be installed manually." -ForegroundColor Yellow
-    return $pluginIds  # all plugins are "failed"
+    Write-Host "  ⚠️  Plugin registry unavailable: $($_.Exception.Message)" -ForegroundColor Yellow
+    Write-Host "  All plugins will need to be installed manually." -ForegroundColor Yellow
+    return ,@($pluginIds)  # all plugins are "failed"
   }
   Write-Done "Registry fetched"
 
@@ -98,15 +105,24 @@ function Install-Plugins {
 
     Write-Step "🔌" "Installing $pluginId..."
 
-    # Get latest release tag
+    # GitHub REST API: 60 req/hr unauthenticated (shared per IP). Each plugin consumes
+    # one request. Set GITHUB_TOKEN env var to raise the limit to 5,000/hr.
+    $ghHeaders = @{ Accept = "application/vnd.github.v3+json" }
+    if ($env:GITHUB_TOKEN) { $ghHeaders["Authorization"] = "Bearer $env:GITHUB_TOKEN" }
+
     try {
       $release = Invoke-RestMethod `
         -Uri "https://api.github.com/repos/$repo/releases/latest" `
-        -Headers @{ Accept = "application/vnd.github.v3+json" } `
+        -Headers $ghHeaders `
         -ErrorAction Stop
       $tag = $release.tag_name
     } catch {
-      Write-Host "  ❌ failed $pluginId (could not get release tag)" -ForegroundColor Red
+      # Check for GitHub rate limit specifically
+      if ($_.Exception.Message -match '403' -or ($_.Exception.Response -and $_.Exception.Response.StatusCode -eq 403)) {
+        Write-Host "  ❌ rate-limited $pluginId (GitHub API rate limit reached; set GITHUB_TOKEN to raise to 5,000/hr)" -ForegroundColor Red
+      } else {
+        Write-Host "  ❌ failed $pluginId (could not get release tag: $($_.Exception.Message))" -ForegroundColor Red
+      }
       $failedPlugins += $pluginId
       continue
     }
@@ -123,25 +139,36 @@ function Install-Plugins {
     $baseUrl = "https://github.com/$repo/releases/download/$tag"
     $ok = $true
 
-    # main.js and manifest.json are required
+    # main.js and manifest.json are required; short-circuit on first failure
     foreach ($asset in @("main.js", "manifest.json")) {
+      if (-not $ok) { break }
       try {
         Invoke-WebRequest -Uri "$baseUrl/$asset" -OutFile (Join-Path $pluginDir $asset) -ErrorAction Stop | Out-Null
       } catch {
+        Write-Host "  ⚠️  $pluginId/$asset failed: $($_.Exception.Message)" -ForegroundColor Yellow
         $ok = $false
-        break
       }
     }
 
-    # styles.css is optional
+    # styles.css is optional — not all plugins ship it.
+    # PS5 Invoke-WebRequest does not throw on HTTP 4xx — check StatusCode explicitly.
+    # Network/TLS errors do throw and are warned about (not silently ignored).
     if ($ok) {
+      $cssPath = Join-Path $pluginDir "styles.css"
       try {
-        $cssPath = Join-Path $pluginDir "styles.css"
-        Invoke-WebRequest -Uri "$baseUrl/styles.css" -OutFile $cssPath -ErrorAction Stop | Out-Null
-        # Remove if it downloaded as empty
-        if ((Get-Item $cssPath).Length -eq 0) { Remove-Item $cssPath -Force }
+        $cssResponse = Invoke-WebRequest -Uri "$baseUrl/styles.css" -OutFile $cssPath -PassThru -ErrorAction Stop
+        # Remove if HTTP error or empty (handles PS5 which writes 404 HTML body to disk)
+        if ($cssResponse.StatusCode -ne 200 -or (Get-Item $cssPath -ErrorAction SilentlyContinue).Length -eq 0) {
+          Remove-Item $cssPath -Force -ErrorAction SilentlyContinue
+        }
+      } catch [System.Net.WebException] {
+        # Network-level failure (DNS, TLS, timeout) — not a missing optional file; warn the user
+        Write-Host "  ⚠️  Could not download styles.css for $pluginId`: $($_.Exception.Message)" -ForegroundColor Yellow
+        Remove-Item $cssPath -Force -ErrorAction SilentlyContinue
       } catch {
-        # Optional asset — ignore failure
+        # Any other unexpected error — warn but don't fail the plugin
+        Write-Host "  ⚠️  Unexpected error downloading styles.css for $pluginId`: $($_.Exception.Message)" -ForegroundColor Yellow
+        Remove-Item $cssPath -Force -ErrorAction SilentlyContinue
       }
     }
 
@@ -149,7 +176,11 @@ function Install-Plugins {
       Write-Done "$pluginId"
     } else {
       Write-Host "  ❌ failed $pluginId (download error)" -ForegroundColor Red
-      Remove-Item -Path $pluginDir -Recurse -Force -ErrorAction SilentlyContinue
+      try {
+        Remove-Item -Path $pluginDir -Recurse -Force -ErrorAction Stop
+      } catch {
+        Write-Host "  ⚠️  Could not remove partial directory '$pluginDir'. Remove it manually before opening Obsidian." -ForegroundColor Yellow
+      }
       $failedPlugins += $pluginId
     }
   }
@@ -163,7 +194,7 @@ function Install-Plugins {
     Write-Host "  Install them manually: Settings -> Community plugins -> Browse" -ForegroundColor Yellow
   }
 
-  return $failedPlugins
+  return ,@($failedPlugins)
 }
 
 # ─── Main ─────────────────────────────────────────────────────────────────────
@@ -310,7 +341,7 @@ function Main {
     }
 
     # ── Step 4b: Install community plugins ──────────────────────────────────
-    $script:FailedPlugins = Install-Plugins $vaultPath
+    $script:FailedPlugins = @(Install-Plugins $vaultPath)
 
     # ── Step 5: Initialize git ──────────────────────────────────────────────
     Write-Step "🧠" "Initializing git repository..."

--- a/install.sh
+++ b/install.sh
@@ -359,12 +359,14 @@ install_plugins() {
     fi
 
     # styles.css is optional — not all plugins ship it.
-    # curl exit code 22 = HTTP error (status 400+, typically 404) — expected and silent.
-    # Any other non-zero exit (disk full, TLS, DNS) is unexpected and warrants a warning.
+    # curl exit 22 = HTTP 4xx/5xx (with -f flag) — expected when asset is absent.
+    # curl exit 56 = "failure receiving network data" — GitHub's CDN sometimes resets
+    # the connection instead of returning a 404 for a missing release asset; treat as absent.
+    # Any other non-zero exit (disk full, TLS error, DNS failure) is unexpected and warns.
     if [ "$ok" = true ]; then
       local css_exit=0
       curl -fsSL "${base_url}/styles.css" -o "$plugin_dir/styles.css" 2>/dev/null || css_exit=$?
-      if [ "$css_exit" -ne 0 ] && [ "$css_exit" -ne 22 ]; then
+      if [ "$css_exit" -ne 0 ] && [ "$css_exit" -ne 22 ] && [ "$css_exit" -ne 56 ]; then
         print_info "  ${YELLOW}warning${RESET} Unexpected error downloading styles.css for ${plugin_id} (curl exit ${css_exit})"
       fi
       # Remove styles.css if absent or zero bytes (curl -f suppresses 404 bodies, leaving an empty file)

--- a/install.sh
+++ b/install.sh
@@ -220,9 +220,10 @@ install_plugins() {
   # Reuse _INSTALL_TMPDIR (cleaned by the EXIT trap) to avoid a separate tempfile leak.
   local registry_file="$_INSTALL_TMPDIR/plugin-registry.json"
   spinner_start "Fetching plugin registry..."
-  if ! curl -fsSL "$registry_url" -o "$registry_file" 2>/dev/null; then
+  local registry_err
+  if ! registry_err=$(curl -fsSL "$registry_url" -o "$registry_file" 2>&1 >/dev/null); then
     spinner_stop "$ICON_FAIL" ""
-    print_info "Could not reach the plugin registry. All plugins will need to be installed manually."
+    print_info "Could not reach the plugin registry${registry_err:+ (${registry_err})}. All plugins will need to be installed manually."
     # Populate FAILED_PLUGINS so the success message shows manual install instructions.
     while IFS= read -r _pid; do
       [ -z "$_pid" ] && continue
@@ -234,10 +235,35 @@ install_plugins() {
   spinner_stop "$ICON_OK" "Registry fetched"
 
   local plugins_dir="$vault/.obsidian/plugins"
-  mkdir -p "$plugins_dir"
+  if ! mkdir -p "$plugins_dir" 2>/dev/null; then
+    print_info "Could not create plugins directory. Check permissions on '$vault/.obsidian/'."
+    while IFS= read -r _pid; do
+      [ -z "$_pid" ] && continue
+      failed_plugins+=("$_pid")
+    done <<< "$plugin_ids"
+    FAILED_PLUGINS=("${failed_plugins[@]}")
+    return 0
+  fi
+
+  # GitHub REST API: 60 req/hr unauthenticated (shared per IP) — 5,000/hr with GITHUB_TOKEN.
+  # Build auth args once; GITHUB_TOKEN does not change during the loop.
+  local curl_auth_args=()
+  if [ -n "${GITHUB_TOKEN:-}" ]; then
+    curl_auth_args=(-H "Authorization: Bearer ${GITHUB_TOKEN}")
+  fi
+
+  local curl_errf="$_INSTALL_TMPDIR/curl_err"
 
   while IFS= read -r plugin_id; do
     [ -z "$plugin_id" ] && continue
+
+    # Validate plugin ID: reject IDs with path-traversal or shell-unsafe characters.
+    # All legitimate Obsidian plugin IDs use only alphanumerics, hyphens, and underscores.
+    if ! printf '%s' "$plugin_id" | grep -qE '^[a-zA-Z0-9_-]+$'; then
+      print_info "  ${YELLOW}skipped${RESET} invalid plugin ID: '${plugin_id}'"
+      failed_plugins+=("$plugin_id")
+      continue
+    fi
 
     # Extract the GitHub repo for this plugin ID from the registry.
     # grep -F (fixed-string) prevents plugin IDs with special characters from
@@ -257,19 +283,15 @@ install_plugins() {
 
     spinner_start "  Installing ${plugin_id}..."
 
-    # GitHub REST API: 60 req/hr unauthenticated (shared per IP). Each plugin consumes
-    # one request. Set GITHUB_TOKEN env var to raise the limit to 5,000/hr.
-    local curl_auth_args=()
-    if [ -n "${GITHUB_TOKEN:-}" ]; then
-      curl_auth_args=(-H "Authorization: Bearer ${GITHUB_TOKEN}")
-    fi
-    local release_json
-    release_json=$(curl -fsSL \
+    # Use -sSL (not -fsSL) so the response body is preserved on HTTP errors, enabling
+    # rate-limit detection. The HTTP status code is appended with -w and parsed below.
+    local api_raw http_code release_json tag
+    api_raw=$(curl -sSL -w '\n%{http_code}' \
       -H "Accept: application/vnd.github.v3+json" \
       "${curl_auth_args[@]}" \
-      "https://api.github.com/repos/${repo}/releases/latest" 2>/dev/null) || release_json=""
-
-    local tag
+      "https://api.github.com/repos/${repo}/releases/latest" 2>/dev/null) || api_raw=""
+    http_code=$(printf '%s\n' "$api_raw" | tail -1)
+    release_json=$(printf '%s\n' "$api_raw" | sed '$d')
     tag=$(printf '%s' "$release_json" \
           | grep '"tag_name"' \
           | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/' \
@@ -277,32 +299,42 @@ install_plugins() {
 
     if [ -z "$tag" ]; then
       spinner_stop "$ICON_FAIL" ""
-      # Distinguish GitHub rate limit (actionable) from other failures
-      if printf '%s' "$release_json" | grep -q '"API rate limit exceeded"'; then
-        print_info "  ${RED}rate-limited${RESET} ${plugin_id} (GitHub API rate limit reached; set GITHUB_TOKEN to raise to 5,000/hr)"
+      # HTTP 403 can mean rate limit or access denied — check body to distinguish
+      if [ "$http_code" = "403" ]; then
+        if printf '%s' "$release_json" | grep -qE '"(API rate limit exceeded|exceeded a secondary rate limit)"'; then
+          print_info "  ${RED}rate-limited${RESET} ${plugin_id} (GitHub rate limit reached; set GITHUB_TOKEN to raise to 5,000/hr)"
+        else
+          print_info "  ${YELLOW}skipped${RESET} ${plugin_id} (GitHub API returned 403 — check GITHUB_TOKEN if set)"
+        fi
       else
-        print_info "  ${YELLOW}skipped${RESET} ${plugin_id} (could not get release tag)"
+        print_info "  ${YELLOW}skipped${RESET} ${plugin_id} (could not get release tag — HTTP ${http_code:-error})"
       fi
       failed_plugins+=("$plugin_id")
       continue
     fi
 
     local plugin_dir="$plugins_dir/$plugin_id"
-    mkdir -p "$plugin_dir"
+    if ! mkdir -p "$plugin_dir" 2>/dev/null; then
+      spinner_stop "$ICON_FAIL" ""
+      print_info "  ${YELLOW}failed${RESET}  ${plugin_id} (could not create plugin directory)"
+      failed_plugins+=("$plugin_id")
+      continue
+    fi
 
     local base_url="https://github.com/${repo}/releases/download/${tag}"
     local ok=true
 
-    # main.js and manifest.json are required; short-circuit on first failure
-    if ! curl -fsSL "${base_url}/main.js" -o "$plugin_dir/main.js" 2>/dev/null; then
-      ok=false
-    fi
-    if [ "$ok" = true ] && ! curl -fsSL "${base_url}/manifest.json" -o "$plugin_dir/manifest.json" 2>/dev/null; then
-      ok=false
-    fi
+    # main.js and manifest.json are required; short-circuit on first failure.
+    # curl stderr (error details) is captured to $curl_errf for the failure message.
+    for asset in main.js manifest.json; do
+      if ! curl -fsSL "${base_url}/${asset}" -o "$plugin_dir/${asset}" 2>"$curl_errf"; then
+        ok=false
+        break
+      fi
+    done
 
     # styles.css is optional — not all plugins ship it.
-    # curl exit code 22 = HTTP error (404 Not Found) — expected and silent.
+    # curl exit code 22 = HTTP error (status 400+, typically 404) — expected and silent.
     # Any other non-zero exit (disk full, TLS, DNS) is unexpected and warrants a warning.
     if [ "$ok" = true ]; then
       local css_exit=0
@@ -318,10 +350,14 @@ install_plugins() {
       spinner_stop "$ICON_OK" "${plugin_id}"
     else
       spinner_stop "$ICON_FAIL" ""
-      if ! rm -rf "$plugin_dir" 2>/dev/null; then
-        print_info "  ${YELLOW}warning${RESET} Could not remove partial directory '$plugin_dir'. Remove it manually before opening Obsidian."
+      local curl_err_detail
+      curl_err_detail=$(cat "$curl_errf" 2>/dev/null | head -1 | tr -d '\r')
+      local rm_err
+      if ! rm_err=$(rm -rf "$plugin_dir" 2>&1); then
+        print_info "  ${YELLOW}warning${RESET} Could not remove partial directory '$plugin_dir': $rm_err"
+        print_info "  Remove it manually before opening Obsidian."
       fi
-      print_info "  ${YELLOW}failed${RESET}  ${plugin_id} (download error)"
+      print_info "  ${YELLOW}failed${RESET}  ${plugin_id} (${curl_err_detail:-download error})"
       failed_plugins+=("$plugin_id")
     fi
   done <<< "$plugin_ids"
@@ -527,25 +563,22 @@ main() {
   echo "${BOLD}Next steps:${RESET}"
   echo "  1. Open Obsidian"
   echo "     File → Open Folder as Vault → select: ${CYAN}${vault_path}${RESET}"
+  local step=2
   if [ ${#FAILED_PLUGINS[@]} -gt 0 ]; then
-    echo "  2. Install missing plugins manually (Settings → Community plugins → Browse):"
+    echo "  ${step}. Install missing plugins manually (Settings → Community plugins → Browse):"
     for p in "${FAILED_PLUGINS[@]}"; do
       echo "     ${CYAN}${p}${RESET}"
     done
-    echo "  3. Open your terminal in the vault directory:"
-    echo "     ${CYAN}cd \"${vault_path}\"${RESET}"
-    echo "  4. Start your AI assistant:"
-    echo "     ${CYAN}claude${RESET}  or  ${CYAN}gemini${RESET}"
-    echo "  5. Run the onboarding command:"
-    echo "     ${CYAN}/onboarding${RESET}"
-  else
-    echo "  2. Open your terminal in the vault directory:"
-    echo "     ${CYAN}cd \"${vault_path}\"${RESET}"
-    echo "  3. Start your AI assistant:"
-    echo "     ${CYAN}claude${RESET}  or  ${CYAN}gemini${RESET}"
-    echo "  4. Run the onboarding command:"
-    echo "     ${CYAN}/onboarding${RESET}"
+    step=$((step + 1))
   fi
+  echo "  ${step}. Open your terminal in the vault directory:"
+  echo "     ${CYAN}cd \"${vault_path}\"${RESET}"
+  step=$((step + 1))
+  echo "  ${step}. Start your AI assistant:"
+  echo "     ${CYAN}claude${RESET}  or  ${CYAN}gemini${RESET}"
+  step=$((step + 1))
+  echo "  ${step}. Run the onboarding command:"
+  echo "     ${CYAN}/onboarding${RESET}"
   echo "     (Onboarding will ask you to choose a vault organization method"
   echo "      and create your folders: OneBrain, PARA, or Zettelkasten)"
   echo

--- a/install.sh
+++ b/install.sh
@@ -192,7 +192,134 @@ prompt_with_default() {
   echo "${answer:-$default}"
 }
 
+# ─── Plugin installer ─────────────────────────────────────────────────────────
+# install_plugins <vault_path>
+# Downloads the latest release of each plugin listed in .obsidian/community-plugins.json.
+# Uses only curl (already a required dependency) and POSIX tools (grep, sed, mkdir).
+# Non-fatal: warns on failure and returns a list of plugins to install manually.
+install_plugins() {
+  local vault="$1"
+  local plugins_json="$vault/.obsidian/community-plugins.json"
+  local registry_url="https://raw.githubusercontent.com/obsidianmd/obsidian-releases/master/community-plugins.json"
+  local registry_file
+  local failed_plugins=()
+
+  # Read plugin IDs from the flat JSON array (no jq needed — one string per line after grep)
+  if [ ! -f "$plugins_json" ]; then
+    return 0
+  fi
+  local plugin_ids
+  plugin_ids=$(grep -o '"[^"]*"' "$plugins_json" | tr -d '"')
+  if [ -z "$plugin_ids" ]; then
+    return 0
+  fi
+
+  print_header "Installing community plugins..."
+
+  # Fetch the Obsidian community plugin registry once
+  registry_file=$(mktemp)
+  spinner_start "Fetching plugin registry..."
+  if ! curl -fsSL "$registry_url" -o "$registry_file" 2>/dev/null; then
+    spinner_stop "$ICON_FAIL" ""
+    print_info "Could not reach the plugin registry. Plugins will need to be installed manually."
+    rm -f "$registry_file"
+    _print_manual_plugin_steps
+    return 0
+  fi
+  spinner_stop "$ICON_OK" "Registry fetched"
+
+  local plugins_dir="$vault/.obsidian/plugins"
+  mkdir -p "$plugins_dir"
+
+  while IFS= read -r plugin_id; do
+    [ -z "$plugin_id" ] && continue
+
+    # Extract the GitHub repo for this plugin ID from the registry.
+    # Registry format: {"id": "plugin-id", "repo": "owner/repo", ...}
+    # grep -A5 finds the object block starting with the id line; second grep extracts repo.
+    local repo
+    repo=$(grep -A5 "\"id\": *\"${plugin_id}\"" "$registry_file" \
+           | grep '"repo"' \
+           | sed 's/.*"repo": *"\([^"]*\)".*/\1/' \
+           | head -1)
+
+    if [ -z "$repo" ]; then
+      print_info "  ${YELLOW}skipped${RESET} ${plugin_id} (not found in registry)"
+      failed_plugins+=("$plugin_id")
+      continue
+    fi
+
+    spinner_start "  Installing ${plugin_id}..."
+
+    # Get the latest release tag from GitHub API (no auth needed for 60 req/hr)
+    local release_json tag
+    release_json=$(curl -fsSL \
+      -H "Accept: application/vnd.github.v3+json" \
+      "https://api.github.com/repos/${repo}/releases/latest" 2>/dev/null) || release_json=""
+
+    tag=$(printf '%s' "$release_json" \
+          | grep '"tag_name"' \
+          | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/' \
+          | head -1)
+
+    if [ -z "$tag" ]; then
+      spinner_stop "$ICON_FAIL" ""
+      print_info "  ${YELLOW}skipped${RESET} ${plugin_id} (could not get release tag)"
+      failed_plugins+=("$plugin_id")
+      continue
+    fi
+
+    local plugin_dir="$plugins_dir/$plugin_id"
+    mkdir -p "$plugin_dir"
+
+    local base_url="https://github.com/${repo}/releases/download/${tag}"
+    local ok=true
+
+    # main.js and manifest.json are required
+    if ! curl -fsSL "${base_url}/main.js" -o "$plugin_dir/main.js" 2>/dev/null; then
+      ok=false
+    fi
+    if ! curl -fsSL "${base_url}/manifest.json" -o "$plugin_dir/manifest.json" 2>/dev/null; then
+      ok=false
+    fi
+    # styles.css is optional — not all plugins ship it
+    curl -fsSL "${base_url}/styles.css" -o "$plugin_dir/styles.css" 2>/dev/null || true
+    # Remove empty styles.css if nothing was downloaded
+    [ -s "$plugin_dir/styles.css" ] || rm -f "$plugin_dir/styles.css"
+
+    if [ "$ok" = true ]; then
+      spinner_stop "$ICON_OK" "${plugin_id}"
+    else
+      spinner_stop "$ICON_FAIL" ""
+      rm -rf "$plugin_dir"
+      print_info "  ${YELLOW}failed${RESET}  ${plugin_id} (download error)"
+      failed_plugins+=("$plugin_id")
+    fi
+  done <<< "$plugin_ids"
+
+  rm -f "$registry_file"
+
+  if [ ${#failed_plugins[@]} -gt 0 ]; then
+    echo
+    print_info "Some plugins could not be installed automatically:"
+    for p in "${failed_plugins[@]}"; do
+      print_info "  • $p"
+    done
+    print_info "Install them manually: Settings → Community plugins → Browse"
+  fi
+
+  # Export for use in the success message
+  FAILED_PLUGINS=("${failed_plugins[@]}")
+}
+
+_print_manual_plugin_steps() {
+  echo "  2. Install community plugins (Settings → Community plugins → Browse):"
+  echo "     ${CYAN}Tasks  Dataview  Templater  Calendar${RESET}"
+  echo "     ${CYAN}Tag Wrangler  QuickAdd  Obsidian Git  Terminal${RESET}"
+}
+
 # ─── Main ─────────────────────────────────────────────────────────────────────
+FAILED_PLUGINS=()
 main() {
   # ── TTY check: when piped (curl | bash), stdin (fd 0) is the pipe — not the
   # ── terminal. Open /dev/tty as fd 3 so prompts reach the user without
@@ -341,6 +468,9 @@ main() {
     exit 1
   fi
 
+  # ── Step 4b: Install community plugins ──────────────────────────────────
+  install_plugins "$vault_path"
+
   # ── Step 5: Initialize git ──────────────────────────────────────────────────
   # git -C runs each command inside vault_path without changing the script's working
   # directory, avoiding side-effects on any $PWD references that follow.
@@ -376,15 +506,25 @@ main() {
   echo "${BOLD}Next steps:${RESET}"
   echo "  1. Open Obsidian"
   echo "     File → Open Folder as Vault → select: ${CYAN}${vault_path}${RESET}"
-  echo "  2. Install community plugins (Settings → Community plugins → Browse):"
-  echo "     ${CYAN}Tasks  Dataview  Templater  Calendar${RESET}"
-  echo "     ${CYAN}Tag Wrangler  QuickAdd  Obsidian Git  Terminal${RESET}"
-  echo "  3. Open your terminal in the vault directory:"
-  echo "     ${CYAN}cd \"${vault_path}\"${RESET}"
-  echo "  4. Start your AI assistant:"
-  echo "     ${CYAN}claude${RESET}  or  ${CYAN}gemini${RESET}"
-  echo "  5. Run the onboarding command:"
-  echo "     ${CYAN}/onboarding${RESET}"
+  if [ ${#FAILED_PLUGINS[@]} -gt 0 ]; then
+    echo "  2. Install missing plugins manually (Settings → Community plugins → Browse):"
+    for p in "${FAILED_PLUGINS[@]}"; do
+      echo "     ${CYAN}${p}${RESET}"
+    done
+    echo "  3. Open your terminal in the vault directory:"
+    echo "     ${CYAN}cd \"${vault_path}\"${RESET}"
+    echo "  4. Start your AI assistant:"
+    echo "     ${CYAN}claude${RESET}  or  ${CYAN}gemini${RESET}"
+    echo "  5. Run the onboarding command:"
+    echo "     ${CYAN}/onboarding${RESET}"
+  else
+    echo "  2. Open your terminal in the vault directory:"
+    echo "     ${CYAN}cd \"${vault_path}\"${RESET}"
+    echo "  3. Start your AI assistant:"
+    echo "     ${CYAN}claude${RESET}  or  ${CYAN}gemini${RESET}"
+    echo "  4. Run the onboarding command:"
+    echo "     ${CYAN}/onboarding${RESET}"
+  fi
   echo "     (Onboarding will ask you to choose a vault organization method"
   echo "      and create your folders: OneBrain, PARA, or Zettelkasten)"
   echo

--- a/install.sh
+++ b/install.sh
@@ -221,7 +221,7 @@ install_plugins() {
   local registry_file="$_INSTALL_TMPDIR/plugin-registry.json"
   spinner_start "Fetching plugin registry..."
   local registry_err
-  if ! registry_err=$(curl -fsSL "$registry_url" -o "$registry_file" 2>&1 >/dev/null); then
+  if ! registry_err=$(curl -fsSL "$registry_url" -o "$registry_file" 2>&1); then
     spinner_stop "$ICON_FAIL" ""
     print_info "Could not reach the plugin registry${registry_err:+ (${registry_err})}. All plugins will need to be installed manually."
     # Populate FAILED_PLUGINS so the success message shows manual install instructions.
@@ -235,8 +235,9 @@ install_plugins() {
   spinner_stop "$ICON_OK" "Registry fetched"
 
   local plugins_dir="$vault/.obsidian/plugins"
-  if ! mkdir -p "$plugins_dir" 2>/dev/null; then
-    print_info "Could not create plugins directory. Check permissions on '$vault/.obsidian/'."
+  local mkdir_err
+  if ! mkdir_err=$(mkdir -p "$plugins_dir" 2>&1); then
+    print_info "Could not create plugins directory${mkdir_err:+ (${mkdir_err})}."
     while IFS= read -r _pid; do
       [ -z "$_pid" ] && continue
       failed_plugins+=("$_pid")
@@ -247,9 +248,12 @@ install_plugins() {
 
   # GitHub REST API: 60 req/hr unauthenticated (shared per IP) — 5,000/hr with GITHUB_TOKEN.
   # Build auth args once; GITHUB_TOKEN does not change during the loop.
-  local curl_auth_args=()
+  # Accept header is included in the array (not hardcoded on the curl line) so both
+  # authenticated and unauthenticated calls send identical headers, and the array is
+  # never expanded empty (which would be a no-op, but is cleaner to avoid).
+  local curl_auth_args=(-H "Accept: application/vnd.github.v3+json")
   if [ -n "${GITHUB_TOKEN:-}" ]; then
-    curl_auth_args=(-H "Authorization: Bearer ${GITHUB_TOKEN}")
+    curl_auth_args+=(-H "Authorization: Bearer ${GITHUB_TOKEN}")
   fi
 
   local curl_errf="$_INSTALL_TMPDIR/curl_err"
@@ -281,15 +285,20 @@ install_plugins() {
       continue
     fi
 
+    # Clear the shared error file before each plugin so stale errors from a prior
+    # iteration never bleed into this plugin's failure message.
+    : > "$curl_errf"
+
     spinner_start "  Installing ${plugin_id}..."
 
     # Use -sSL (not -fsSL) so the response body is preserved on HTTP errors, enabling
     # rate-limit detection. The HTTP status code is appended with -w and parsed below.
+    # Stderr (transport errors: DNS, TLS, timeout) is captured to $curl_errf so users
+    # see actionable detail instead of a generic "could not get release tag" message.
     local api_raw http_code release_json tag
     api_raw=$(curl -sSL -w '\n%{http_code}' \
-      -H "Accept: application/vnd.github.v3+json" \
       "${curl_auth_args[@]}" \
-      "https://api.github.com/repos/${repo}/releases/latest" 2>/dev/null) || api_raw=""
+      "https://api.github.com/repos/${repo}/releases/latest" 2>"$curl_errf") || true
     http_code=$(printf '%s\n' "$api_raw" | tail -1)
     release_json=$(printf '%s\n' "$api_raw" | sed '$d')
     tag=$(printf '%s' "$release_json" \
@@ -299,7 +308,12 @@ install_plugins() {
 
     if [ -z "$tag" ]; then
       spinner_stop "$ICON_FAIL" ""
-      # HTTP 403 can mean rate limit or access denied — check body to distinguish
+      # HTTP 403 can mean rate limit or access denied — check body to distinguish.
+      # Rate-limit strings come from GitHub REST API error response "message" field.
+      # Note: GitHub primary rate limits now return HTTP 429 (not 403) as of 2023;
+      # a 429 would fall through to the generic branch below with its HTTP code shown.
+      local api_transport_err
+      api_transport_err=$(cat "$curl_errf" 2>/dev/null | head -1 | tr -d '\r')
       if [ "$http_code" = "403" ]; then
         if printf '%s' "$release_json" | grep -qE '"(API rate limit exceeded|exceeded a secondary rate limit)"'; then
           print_info "  ${RED}rate-limited${RESET} ${plugin_id} (GitHub rate limit reached; set GITHUB_TOKEN to raise to 5,000/hr)"
@@ -307,16 +321,16 @@ install_plugins() {
           print_info "  ${YELLOW}skipped${RESET} ${plugin_id} (GitHub API returned 403 — check GITHUB_TOKEN if set)"
         fi
       else
-        print_info "  ${YELLOW}skipped${RESET} ${plugin_id} (could not get release tag — HTTP ${http_code:-error})"
+        print_info "  ${YELLOW}skipped${RESET} ${plugin_id} (could not get release tag — HTTP ${http_code:-error}${api_transport_err:+; ${api_transport_err}})"
       fi
       failed_plugins+=("$plugin_id")
       continue
     fi
 
     local plugin_dir="$plugins_dir/$plugin_id"
-    if ! mkdir -p "$plugin_dir" 2>/dev/null; then
+    if ! mkdir_err=$(mkdir -p "$plugin_dir" 2>&1); then
       spinner_stop "$ICON_FAIL" ""
-      print_info "  ${YELLOW}failed${RESET}  ${plugin_id} (could not create plugin directory)"
+      print_info "  ${YELLOW}failed${RESET}  ${plugin_id} (could not create plugin directory${mkdir_err:+: ${mkdir_err}})"
       failed_plugins+=("$plugin_id")
       continue
     fi
@@ -332,6 +346,17 @@ install_plugins() {
         break
       fi
     done
+    # Verify required assets are non-empty: curl can exit 0 but write zero bytes on a
+    # network drop mid-transfer, or write an HTML error page if the redirect returned 200.
+    if [ "$ok" = true ]; then
+      for asset in main.js manifest.json; do
+        if [ ! -s "$plugin_dir/$asset" ]; then
+          printf '%s: empty or missing after download\n' "$asset" > "$curl_errf"
+          ok=false
+          break
+        fi
+      done
+    fi
 
     # styles.css is optional — not all plugins ship it.
     # curl exit code 22 = HTTP error (status 400+, typically 404) — expected and silent.

--- a/install.sh
+++ b/install.sh
@@ -196,12 +196,12 @@ prompt_with_default() {
 # install_plugins <vault_path>
 # Downloads the latest release of each plugin listed in .obsidian/community-plugins.json.
 # Uses only curl (already a required dependency) and POSIX tools (grep, sed, mkdir).
-# Non-fatal: warns on failure and returns a list of plugins to install manually.
+# Non-fatal: warns on failure and populates the global FAILED_PLUGINS array with
+# any plugin IDs that could not be installed.
 install_plugins() {
   local vault="$1"
   local plugins_json="$vault/.obsidian/community-plugins.json"
   local registry_url="https://raw.githubusercontent.com/obsidianmd/obsidian-releases/master/community-plugins.json"
-  local registry_file
   local failed_plugins=()
 
   # Read plugin IDs from the flat JSON array (no jq needed — one string per line after grep)
@@ -216,14 +216,19 @@ install_plugins() {
 
   print_header "Installing community plugins..."
 
-  # Fetch the Obsidian community plugin registry once
-  registry_file=$(mktemp)
+  # Fetch the Obsidian community plugin registry once.
+  # Reuse _INSTALL_TMPDIR (cleaned by the EXIT trap) to avoid a separate tempfile leak.
+  local registry_file="$_INSTALL_TMPDIR/plugin-registry.json"
   spinner_start "Fetching plugin registry..."
   if ! curl -fsSL "$registry_url" -o "$registry_file" 2>/dev/null; then
     spinner_stop "$ICON_FAIL" ""
-    print_info "Could not reach the plugin registry. Plugins will need to be installed manually."
-    rm -f "$registry_file"
-    _print_manual_plugin_steps
+    print_info "Could not reach the plugin registry. All plugins will need to be installed manually."
+    # Populate FAILED_PLUGINS so the success message shows manual install instructions.
+    while IFS= read -r _pid; do
+      [ -z "$_pid" ] && continue
+      failed_plugins+=("$_pid")
+    done <<< "$plugin_ids"
+    FAILED_PLUGINS=("${failed_plugins[@]}")
     return 0
   fi
   spinner_stop "$ICON_OK" "Registry fetched"
@@ -235,10 +240,11 @@ install_plugins() {
     [ -z "$plugin_id" ] && continue
 
     # Extract the GitHub repo for this plugin ID from the registry.
-    # Registry format: {"id": "plugin-id", "repo": "owner/repo", ...}
-    # grep -A5 finds the object block starting with the id line; second grep extracts repo.
+    # grep -F (fixed-string) prevents plugin IDs with special characters from
+    # matching unintended entries. grep -A10 assumes "repo" appears within 10 lines
+    # of the "id" field — valid for the current Obsidian registry format.
     local repo
-    repo=$(grep -A5 "\"id\": *\"${plugin_id}\"" "$registry_file" \
+    repo=$(grep -F "\"id\": \"${plugin_id}\"" "$registry_file" -A10 \
            | grep '"repo"' \
            | sed 's/.*"repo": *"\([^"]*\)".*/\1/' \
            | head -1)
@@ -251,12 +257,19 @@ install_plugins() {
 
     spinner_start "  Installing ${plugin_id}..."
 
-    # Get the latest release tag from GitHub API (no auth needed for 60 req/hr)
-    local release_json tag
+    # GitHub REST API: 60 req/hr unauthenticated (shared per IP). Each plugin consumes
+    # one request. Set GITHUB_TOKEN env var to raise the limit to 5,000/hr.
+    local curl_auth_args=()
+    if [ -n "${GITHUB_TOKEN:-}" ]; then
+      curl_auth_args=(-H "Authorization: Bearer ${GITHUB_TOKEN}")
+    fi
+    local release_json
     release_json=$(curl -fsSL \
       -H "Accept: application/vnd.github.v3+json" \
+      "${curl_auth_args[@]}" \
       "https://api.github.com/repos/${repo}/releases/latest" 2>/dev/null) || release_json=""
 
+    local tag
     tag=$(printf '%s' "$release_json" \
           | grep '"tag_name"' \
           | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/' \
@@ -264,7 +277,12 @@ install_plugins() {
 
     if [ -z "$tag" ]; then
       spinner_stop "$ICON_FAIL" ""
-      print_info "  ${YELLOW}skipped${RESET} ${plugin_id} (could not get release tag)"
+      # Distinguish GitHub rate limit (actionable) from other failures
+      if printf '%s' "$release_json" | grep -q '"API rate limit exceeded"'; then
+        print_info "  ${RED}rate-limited${RESET} ${plugin_id} (GitHub API rate limit reached; set GITHUB_TOKEN to raise to 5,000/hr)"
+      else
+        print_info "  ${YELLOW}skipped${RESET} ${plugin_id} (could not get release tag)"
+      fi
       failed_plugins+=("$plugin_id")
       continue
     fi
@@ -275,29 +293,38 @@ install_plugins() {
     local base_url="https://github.com/${repo}/releases/download/${tag}"
     local ok=true
 
-    # main.js and manifest.json are required
+    # main.js and manifest.json are required; short-circuit on first failure
     if ! curl -fsSL "${base_url}/main.js" -o "$plugin_dir/main.js" 2>/dev/null; then
       ok=false
     fi
-    if ! curl -fsSL "${base_url}/manifest.json" -o "$plugin_dir/manifest.json" 2>/dev/null; then
+    if [ "$ok" = true ] && ! curl -fsSL "${base_url}/manifest.json" -o "$plugin_dir/manifest.json" 2>/dev/null; then
       ok=false
     fi
-    # styles.css is optional — not all plugins ship it
-    curl -fsSL "${base_url}/styles.css" -o "$plugin_dir/styles.css" 2>/dev/null || true
-    # Remove empty styles.css if nothing was downloaded
-    [ -s "$plugin_dir/styles.css" ] || rm -f "$plugin_dir/styles.css"
+
+    # styles.css is optional — not all plugins ship it.
+    # curl exit code 22 = HTTP error (404 Not Found) — expected and silent.
+    # Any other non-zero exit (disk full, TLS, DNS) is unexpected and warrants a warning.
+    if [ "$ok" = true ]; then
+      local css_exit=0
+      curl -fsSL "${base_url}/styles.css" -o "$plugin_dir/styles.css" 2>/dev/null || css_exit=$?
+      if [ "$css_exit" -ne 0 ] && [ "$css_exit" -ne 22 ]; then
+        print_info "  ${YELLOW}warning${RESET} Unexpected error downloading styles.css for ${plugin_id} (curl exit ${css_exit})"
+      fi
+      # Remove styles.css if absent or zero bytes (curl -f suppresses 404 bodies, leaving an empty file)
+      [ -s "$plugin_dir/styles.css" ] || rm -f "$plugin_dir/styles.css"
+    fi
 
     if [ "$ok" = true ]; then
       spinner_stop "$ICON_OK" "${plugin_id}"
     else
       spinner_stop "$ICON_FAIL" ""
-      rm -rf "$plugin_dir"
+      if ! rm -rf "$plugin_dir" 2>/dev/null; then
+        print_info "  ${YELLOW}warning${RESET} Could not remove partial directory '$plugin_dir'. Remove it manually before opening Obsidian."
+      fi
       print_info "  ${YELLOW}failed${RESET}  ${plugin_id} (download error)"
       failed_plugins+=("$plugin_id")
     fi
   done <<< "$plugin_ids"
-
-  rm -f "$registry_file"
 
   if [ ${#failed_plugins[@]} -gt 0 ]; then
     echo
@@ -308,14 +335,8 @@ install_plugins() {
     print_info "Install them manually: Settings → Community plugins → Browse"
   fi
 
-  # Export for use in the success message
+  # Populate global for use in the success message
   FAILED_PLUGINS=("${failed_plugins[@]}")
-}
-
-_print_manual_plugin_steps() {
-  echo "  2. Install community plugins (Settings → Community plugins → Browse):"
-  echo "     ${CYAN}Tasks  Dataview  Templater  Calendar${RESET}"
-  echo "     ${CYAN}Tag Wrangler  QuickAdd  Obsidian Git  Terminal${RESET}"
 }
 
 # ─── Main ─────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Adds `install_plugins()` to `install.sh` and `Install-Plugins` to `install.ps1` that automatically download all 8 community plugins listed in `.obsidian/community-plugins.json` at install time
- Fetches each plugin's latest GitHub release via the Obsidian community plugin registry — no additional tools required (`curl`/`grep`/`sed` on macOS/Linux; PowerShell 5+ built-ins on Windows)
- Updates "Next steps" output: removes the manual plugin install step when all plugins succeed; lists only failed plugins if any

## How it works

1. Downloads the Obsidian community plugin registry once
2. For each plugin ID, looks up its GitHub repo in the registry
3. Calls the GitHub Releases API to get the latest tag
4. Downloads `main.js`, `manifest.json`, and optional `styles.css` into `.obsidian/plugins/<plugin-id>/`

## Error handling

- Registry unreachable → warns and falls back to manual install instructions
- Individual plugin fails → warns and continues; lists failed plugins at the end
- Never aborts the overall install

## Test plan

- [ ] Run `install.sh` and verify `.obsidian/plugins/` contains 8 subdirectories with `main.js` + `manifest.json`
- [ ] Open vault in Obsidian and confirm plugins appear in Settings → Community plugins
- [ ] Verify "Next steps" no longer mentions manual plugin installation (all-success path)
- [ ] Simulate network failure for one plugin; verify warning is shown and install completes
- [ ] Verify `install.ps1` produces the same results on Windows/PowerShell 5+

🤖 Generated with [Claude Code](https://claude.com/claude-code)