### PR TITLE
docs: sync README and CONTRIBUTING with current project state

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ Good contributions include:
 │   └── [name]/
 │       └── SKILL.md                     The skill prompt — what the AI follows when invoked
 ├── hooks/
-│   └── hooks.json                       Automated behaviors (currently empty)
+│   └── hooks.json                       Hook configuration (session automation)
 └── agents/
     └── knowledge-linker.md              Knowledge graph agent (used by /connect)
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,14 +15,19 @@ Good contributions include:
 ## Project Structure
 
 ```text
-.claude/plugins/onebrain/
+.claude-plugin/                          Root marketplace config
+└── marketplace.json                     Registers plugins for Claude
+
+.claude/plugins/onebrain/                Main plugin directory
 ├── .claude-plugin/
-│   └── plugin.json      Plugin manifest (name, version, description)
-├── skills/          One directory per slash command
+│   └── plugin.json                      Plugin manifest (name, version, description)
+├── skills/                              One directory per slash command (14 skills)
 │   └── [name]/
-│       └── SKILL.md     The skill prompt — what the AI follows when invoked
-├── hooks/           Automated behaviors (session start, session end)
-└── agents/          Specialized subagents
+│       └── SKILL.md                     The skill prompt — what the AI follows when invoked
+├── hooks/
+│   └── hooks.json                       Automated behaviors (currently empty)
+└── agents/
+    └── knowledge-linker.md              Knowledge graph agent (used by /connect)
 ```
 
 Skills are plain Markdown files. The AI reads them at runtime — no compilation or build step.
@@ -42,7 +47,7 @@ Skills are plain Markdown files. The AI reads them at runtime — no compilation
    No `triggers:` field is needed. Skill routing is handled by the command tables in `CLAUDE.md`, `GEMINI.md`, and `AGENTS.md` — register your command there (see step 4).
 
 3. Write the skill as a numbered sequence of steps the AI should follow
-4. Register the command in `CLAUDE.md`, `GEMINI.md`, `AGENTS.md`, and `README.md`
+4. Register the command in `CLAUDE.md`, `GEMINI.md`, `AGENTS.md`, and `README.md` (also increment the command count in the "What It Does" section of README.md)
 
 ## Editing an Existing Skill
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ An AI-powered second brain for Obsidian. Turn Claude Code, Gemini CLI, or any AI
 ## What It Does
 
 - **Memory across sessions** — your AI remembers your name, role, goals, and past conversations
-- **12 slash commands** — braindump, capture, research, consolidate, connect, and more
+- **14 slash commands** — braindump, capture, research, consolidate, connect, and more
 - **Vault-native** — all notes are Markdown, everything stays in your Obsidian vault
 - **Multi-agent** — works with Claude Code, Gemini CLI, or any AI that reads Markdown
 - **Pre-configured** — open in Obsidian and everything is ready to go
@@ -69,18 +69,21 @@ cd onebrain
 - Open Obsidian → **Open folder as vault** → select the vault directory
 - When prompted about community plugins, click **Trust author and enable plugins**
 
-#### 2. Install community plugins
+#### 2. Community plugins
 
-Go to **Settings → Community plugins → Browse** and install:
+Three plugins are pre-configured and ready to go — just click **Trust author and enable plugins** when Obsidian prompts you:
 
 - **Tasks** — task management with due dates
 - **Dataview** — query notes like a database
+- **Terminal** — run your AI agent from within Obsidian
+
+These are recommended but optional — install them via **Settings → Community plugins → Browse**:
+
 - **Templater** — advanced templates
 - **Calendar** — visual calendar view
 - **Tag Wrangler** — manage tags across vault
 - **QuickAdd** — fast capture workflows
 - **Obsidian Git** — version control for your vault
-- **Terminal** — run your AI agent from within Obsidian
 
 #### 3. Start your AI agent
 
@@ -118,7 +121,8 @@ onebrain/
 ├── CLAUDE.md          Instructions for Claude Code
 ├── GEMINI.md          Instructions for Gemini CLI
 ├── AGENTS.md          Universal agent instructions
-└── vault.yml          Your vault configuration (created during onboarding)
+├── vault.yml          Your vault configuration (created during onboarding)
+└── .claude-plugin/    Claude plugin marketplace config
 ```
 
 The core workflow: capture everything to inbox → process with `/consolidate` → grow your knowledge base → archive what's done.
@@ -138,6 +142,7 @@ The core workflow: capture everything to inbox → process with `/consolidate` �
 | `/weekly` | Review the week, surface patterns, set intentions |
 | `/tasks` | Task dashboard — overdue, due soon, open, and completed this week |
 | `/wrapup` | Wrap up session and save summary to session log |
+| `/reorganize` | Migrate flat notes into organized subfolders |
 | `/update` | Update skills, config, and plugins from GitHub |
 | `/help` | List all available commands with descriptions |
 

--- a/README.md
+++ b/README.md
@@ -67,17 +67,16 @@ cd onebrain
 #### 1. Open in Obsidian
 
 - Open Obsidian → **Open folder as vault** → select the vault directory
-- When prompted about community plugins, click **Trust author and enable plugins**
 
 #### 2. Community plugins
 
-Three plugins are pre-configured and ready to go — just click **Trust author and enable plugins** when Obsidian prompts you:
+These three plugins are pre-configured in vault settings — install them via **Settings → Community plugins → Browse**, then click **Trust author and enable plugins** when prompted:
 
 - **Tasks** — task management with due dates
 - **Dataview** — query notes like a database
 - **Terminal** — run your AI agent from within Obsidian
 
-These are recommended but optional — install them via **Settings → Community plugins → Browse**:
+These are recommended but optional — install via the same Browse panel:
 
 - **Templater** — advanced templates
 - **Calendar** — visual calendar view


### PR DESCRIPTION
## Summary

- Fix command count: 12 → 14 (two commands were missing from the count)
- Add missing `/reorganize` to the commands table in README
- Clarify community plugins: split into pre-configured (Tasks, Dataview, Terminal) vs optional recommended ones — the old list implied all 8 needed manual install
- Add `.claude-plugin/` to the vault structure tree
- Expand CONTRIBUTING project structure with actual filenames (`hooks.json`, `knowledge-linker.md`), skill count (14), and root marketplace config

## Test plan

- [ ] Verify command count matches actual skill directory count (`ls .claude/plugins/onebrain/skills/ | wc -l`)
- [ ] Verify community-plugins.json lists exactly the 3 pre-configured plugins
- [ ] Confirm all 14 commands appear in the table

🤖 Generated with [Claude Code](https://claude.com/claude-code)