### PR TITLE
docs: update product tagline to fusion-focused branding

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "onebrain",
       "source": "./.claude/plugins/onebrain",
-      "description": "AI-powered second brain for Obsidian"
+      "description": "OneBrain — Where human and AI thinking become one"
     },
     {
       "name": "obsidian",

--- a/.claude/plugins/onebrain/.claude-plugin/plugin.json
+++ b/.claude/plugins/onebrain/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "onebrain",
   "version": "1.0.0",
-  "description": "AI-powered second brain for Obsidian — memory, skills, and personal chief of staff",
+  "description": "OneBrain — Where human and AI thinking become one. A powerful thinking partner powered by AI synergy.",
   "author": {
     "name": "OneBrain Contributors"
   }

--- a/.claude/plugins/onebrain/skills/onboarding/SKILL.md
+++ b/.claude/plugins/onebrain/skills/onboarding/SKILL.md
@@ -28,7 +28,7 @@ For steps that present a fixed set of choices (personality archetype, communicat
 
 Say:
 
-> Welcome to OneBrain — your AI-powered second brain inside Obsidian.
+> Welcome to OneBrain — where human and AI thinking become one.
 >
 > I'm going to ask you a few quick questions to personalize your vault. This takes about 2 minutes, and you can always update your settings later by editing MEMORY.md directly.
 >

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OneBrain
 
-An AI-powered second brain for Obsidian. Turn Claude Code, Gemini CLI, or any AI agent into a personal chief of staff that lives inside your vault — one that knows you, remembers past sessions, and helps you capture, organize, and synthesize knowledge.
+OneBrain — Where human and AI thinking become one. Turn Claude Code, Gemini CLI, or any AI agent into a powerful thinking partner inside your Obsidian vault — creating AI-powered synergy that captures, organizes, and synthesizes your knowledge as one unified mind.
 
 ## What It Does
 

--- a/install.ps1
+++ b/install.ps1
@@ -24,7 +24,7 @@ function Print-Banner {
   Write-Host "██████╔╝██║  ██║██║  ██║██║██║ ╚████║" -ForegroundColor Blue
   Write-Host "╚═════╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚═╝╚═╝  ╚═══╝" -ForegroundColor Blue
   Write-Host
-  Write-Host " > all thoughts. one brain. zero friction." -ForegroundColor Yellow
+  Write-Host " > Think. Sync. OneBrain." -ForegroundColor Yellow
   Write-Host
 }
 

--- a/install.sh
+++ b/install.sh
@@ -47,7 +47,7 @@ print_banner() {
   echo "${BLUE}${BOLD}██████╔╝██║  ██║██║  ██║██║██║ ╚████║${RESET}"
   echo "${BLUE}${BOLD}╚═════╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚═╝╚═╝  ╚═══╝${RESET}"
   echo
-  echo "${YELLOW} > all thoughts. one brain. zero friction.${RESET}"
+  echo "${YELLOW} > Think. Sync. OneBrain.${RESET}"
   echo
 }
 


### PR DESCRIPTION
## Summary

- Replace "AI-powered second brain for Obsidian" across all touchpoints — the name OneBrain already encodes the concept, "second brain" contradicts it
- Introduce a 4-tier tagline system: micro (install banner), short (marketplace), medium (plugin.json), long (README hero)
- Core tagline: **"OneBrain — Where human and AI thinking become one"** with micro slogan **"Think. Sync. OneBrain."**

## Changes

| File | Tier | New text |
|------|------|----------|
| `install.sh` / `install.ps1` | Micro | Think. Sync. OneBrain. |
| `.claude-plugin/marketplace.json` | Short | OneBrain — Where human and AI thinking become one |
| `.claude/plugins/onebrain/.claude-plugin/plugin.json` | Medium | ...A powerful thinking partner powered by AI synergy. |
| `README.md` | Long/Hero | Full fusion-concept hero paragraph |

## Test plan

- [ ] Verify README renders correctly on GitHub
- [ ] Verify marketplace.json and plugin.json are valid JSON
- [ ] Run `bash install.sh` and confirm new banner tagline appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)