### PR TITLE
feat: add PostToolUse hook to auto-open vault files in Obsidian

### DIFF
--- a/.claude/plugins/onebrain/.claude-plugin/plugin.json
+++ b/.claude/plugins/onebrain/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "onebrain",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "OneBrain — Where human and AI thinking become one. A powerful thinking partner powered by AI synergy.",
   "author": {
     "name": "OneBrain Contributors"

--- a/.claude/plugins/onebrain/hooks/hooks.json
+++ b/.claude/plugins/onebrain/hooks/hooks.json
@@ -1,3 +1,16 @@
 {
-  "hooks": {}
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/open-in-obsidian.sh\" || powershell.exe -ExecutionPolicy Bypass -File \"${CLAUDE_PLUGIN_ROOT}/hooks/open-in-obsidian.ps1\"",
+            "async": true
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/.claude/plugins/onebrain/hooks/open-in-obsidian.ps1
+++ b/.claude/plugins/onebrain/hooks/open-in-obsidian.ps1
@@ -9,10 +9,10 @@ $ErrorActionPreference = "SilentlyContinue"
 $debugLog = $null
 if ($env:DEBUG -eq "1") {
     $debugLog = Join-Path $env:TEMP "onebrain-hook-debug.log"
-    Add-Content $debugLog "[$([datetime]::Now.ToString('o'))] open-in-obsidian.ps1 started"
+    Add-Content -Encoding UTF8 $debugLog "[$([datetime]::Now.ToString('o'))] open-in-obsidian.ps1 started"
 }
 function Write-Log($msg) {
-    if ($debugLog) { Add-Content $debugLog "[$([datetime]::Now.ToString('o'))] $msg" }
+    if ($debugLog) { Add-Content -Encoding UTF8 $debugLog "[$([datetime]::Now.ToString('o'))] $msg" }
 }
 
 # ── Read stdin ────────────────────────────────────────────────────────────────
@@ -34,8 +34,13 @@ if (-not $filePath) {
 Write-Log "file_path: $filePath"
 
 # ── Resolve absolute path ──────────────────────────────────────────────────────
-# Use GetFullPath — handles non-existent new files safely (Resolve-Path throws)
-$absPath = [System.IO.Path]::GetFullPath($filePath)
+# Claude Code always provides absolute paths — use directly if already absolute.
+# GetFullPath handles the rare relative-path case; note CLR cwd may differ from PS $PWD.
+if ([System.IO.Path]::IsPathRooted($filePath)) {
+    $absPath = $filePath
+} else {
+    $absPath = [System.IO.Path]::GetFullPath($filePath)
+}
 Write-Log "abs_path: $absPath"
 
 # ── Vault boundary check ───────────────────────────────────────────────────────
@@ -99,6 +104,6 @@ $uri = "obsidian://open?path=$encoded"
 Write-Log "opening URI: $uri"
 
 # ── Open in Obsidian ──────────────────────────────────────────────────────────
-Start-Process $uri
+Start-Process "$uri"
 Write-Log "done"
 exit 0

--- a/.claude/plugins/onebrain/hooks/open-in-obsidian.ps1
+++ b/.claude/plugins/onebrain/hooks/open-in-obsidian.ps1
@@ -1,0 +1,104 @@
+# open-in-obsidian.ps1 — PostToolUse hook (Windows PowerShell)
+# Opens a vault file in Obsidian after Write/Edit tool use.
+# Scoped to content folders only. Enforces vault boundary.
+# No external dependencies — PowerShell built-ins only.
+
+$ErrorActionPreference = "SilentlyContinue"
+
+# ── Debug logging ─────────────────────────────────────────────────────────────
+$debugLog = $null
+if ($env:DEBUG -eq "1") {
+    $debugLog = Join-Path $env:TEMP "onebrain-hook-debug.log"
+    Add-Content $debugLog "[$([datetime]::Now.ToString('o'))] open-in-obsidian.ps1 started"
+}
+function Write-Log($msg) {
+    if ($debugLog) { Add-Content $debugLog "[$([datetime]::Now.ToString('o'))] $msg" }
+}
+
+# ── Read stdin ────────────────────────────────────────────────────────────────
+# Collect into $json directly — do NOT reassign $input (it's a PowerShell automatic variable)
+try {
+    $json = $input | ConvertFrom-Json
+} catch {
+    Write-Log "JSON parse failed, exiting"
+    exit 0
+}
+if (-not $json) { exit 0 }
+
+# ── Extract file_path ─────────────────────────────────────────────────────────
+$filePath = $json.tool_input.file_path
+if (-not $filePath) {
+    Write-Log "file_path empty or missing, exiting"
+    exit 0
+}
+Write-Log "file_path: $filePath"
+
+# ── Resolve absolute path ──────────────────────────────────────────────────────
+# Use GetFullPath — handles non-existent new files safely (Resolve-Path throws)
+$absPath = [System.IO.Path]::GetFullPath($filePath)
+Write-Log "abs_path: $absPath"
+
+# ── Vault boundary check ───────────────────────────────────────────────────────
+$vaultRoot = $env:CLAUDE_PROJECT_DIR
+if (-not $vaultRoot) {
+    Write-Log "CLAUDE_PROJECT_DIR not set, exiting"
+    exit 0
+}
+$vaultRoot = $vaultRoot.TrimEnd('\').TrimEnd('/')
+
+if (-not $absPath.StartsWith($vaultRoot + '\') -and -not $absPath.StartsWith($vaultRoot + '/')) {
+    Write-Log "file outside vault, exiting"
+    exit 0
+}
+
+# ── Read content folders from vault.yml ───────────────────────────────────────
+function Get-ContentFolders($vaultRootPath) {
+    $defaults = @("00-inbox","01-projects","02-areas","03-knowledge","04-resources")
+    $yml = Join-Path $vaultRootPath "vault.yml"
+    if (-not (Test-Path $yml)) { return $defaults }
+    # $keys and $defaults must stay in sync — same order, same length
+    $keys = @("inbox","projects","areas","knowledge","resources")
+    $folders = @{}
+    $inFolders = $false
+    foreach ($line in Get-Content $yml) {
+        if ($inFolders -and $line -match "^\S" -and $line.Trim() -ne "folders:") { break }
+        if ($line.Trim() -eq "folders:") { $inFolders = $true; continue }
+        if ($inFolders -and $line -match "^\s+(\w+):\s*(.+)") {
+            $folders[$Matches[1]] = $Matches[2].Trim()
+        }
+    }
+    return ($keys | ForEach-Object {
+        if ($folders[$_]) { $folders[$_] }
+        else { $defaults[[Array]::IndexOf($keys, $_)] }
+    })
+}
+
+$contentFolders = Get-ContentFolders $vaultRoot
+Write-Log "content folders: $($contentFolders -join '|')"
+
+# ── Content folder filter ──────────────────────────────────────────────────────
+$matched = $false
+foreach ($folder in $contentFolders) {
+    $folderPath = Join-Path $vaultRoot $folder
+    if ($absPath.StartsWith($folderPath + '\') -or $absPath.StartsWith($folderPath + '/') -or $absPath -eq $folderPath) {
+        $matched = $true
+        break
+    }
+}
+
+if (-not $matched) {
+    Write-Log "file not in content folder, exiting"
+    exit 0
+}
+
+# ── URL-encode path ────────────────────────────────────────────────────────────
+# EscapeDataString encodes all characters including / and : which we need preserved
+# Use a manual approach: encode only unsafe chars, preserve path separators
+$encoded = [Uri]::EscapeDataString($absPath) -replace '%2F','/' -replace '%3A',':'  -replace '%5C','/'
+$uri = "obsidian://open?path=$encoded"
+Write-Log "opening URI: $uri"
+
+# ── Open in Obsidian ──────────────────────────────────────────────────────────
+Start-Process $uri
+Write-Log "done"
+exit 0

--- a/.claude/plugins/onebrain/hooks/open-in-obsidian.ps1
+++ b/.claude/plugins/onebrain/hooks/open-in-obsidian.ps1
@@ -3,8 +3,6 @@
 # Scoped to content folders only. Enforces vault boundary.
 # No external dependencies — PowerShell built-ins only.
 
-$ErrorActionPreference = "SilentlyContinue"
-
 # ── Debug logging ─────────────────────────────────────────────────────────────
 $debugLog = $null
 if ($env:DEBUG -eq "1") {
@@ -18,7 +16,7 @@ function Write-Log($msg) {
 # ── Read stdin ────────────────────────────────────────────────────────────────
 # Collect into $json directly — do NOT reassign $input (it's a PowerShell automatic variable)
 try {
-    $json = $input | ConvertFrom-Json
+    $json = $input | ConvertFrom-Json -ErrorAction SilentlyContinue
 } catch {
     Write-Log "JSON parse failed, exiting"
     exit 0
@@ -67,6 +65,7 @@ function Get-ContentFolders($vaultRootPath) {
     $inFolders = $false
     foreach ($line in Get-Content $yml) {
         if ($inFolders -and $line -match "^\S" -and $line.Trim() -ne "folders:") { break }
+        if ($inFolders -and $line.Trim() -eq "") { break }
         if ($line.Trim() -eq "folders:") { $inFolders = $true; continue }
         if ($inFolders -and $line -match "^\s+(\w+):\s*(.+)") {
             $folders[$Matches[1]] = $Matches[2].Trim()
@@ -97,13 +96,18 @@ if (-not $matched) {
 }
 
 # ── URL-encode path ────────────────────────────────────────────────────────────
-# EscapeDataString encodes all characters including / and : which we need preserved
-# Use a manual approach: encode only unsafe chars, preserve path separators
+# EscapeDataString over-encodes path separators; restore them manually:
+# %2F → / (forward slash), %3A → : (drive letter colon), %5C → / (backslash → forward slash)
+# Windows paths use backslash but obsidian:// URIs require forward slashes
 $encoded = [Uri]::EscapeDataString($absPath) -replace '%2F','/' -replace '%3A',':'  -replace '%5C','/'
 $uri = "obsidian://open?path=$encoded"
 Write-Log "opening URI: $uri"
 
 # ── Open in Obsidian ──────────────────────────────────────────────────────────
-Start-Process "$uri"
-Write-Log "done"
+try {
+    Start-Process "$uri"
+    Write-Log "done"
+} catch {
+    Write-Log "Start-Process failed: $_"
+}
 exit 0

--- a/.claude/plugins/onebrain/hooks/open-in-obsidian.sh
+++ b/.claude/plugins/onebrain/hooks/open-in-obsidian.sh
@@ -19,6 +19,10 @@ fi
 log() { [ -n "$LOG" ] && echo "[$(date -u +"%Y-%m-%dT%H:%M:%SZ")] $*" >> "$LOG" || true; }
 
 # ── Read stdin ────────────────────────────────────────────────────────────────
+if [ -t 0 ]; then
+  log "stdin is a TTY (not a pipe), exiting"
+  exit 0
+fi
 input=$(cat)
 
 # ── Extract file_path ─────────────────────────────────────────────────────────
@@ -60,7 +64,7 @@ if [[ "$abs_path" != "$vault_root"/* ]]; then
 fi
 
 # ── Read content folders from vault.yml ───────────────────────────────────────
-# Pure bash — no Python required
+# POSIX tools only (grep, sed, cut, tr) — no Python or jq required
 read_content_folders() {
   # $vault_root is set from $CLAUDE_PROJECT_DIR (trailing slash already stripped)
   local yml="$vault_root/vault.yml"
@@ -70,6 +74,10 @@ read_content_folders() {
   while IFS= read -r line || [ -n "$line" ]; do
     # Exit folders block on any non-indented, non-comment line after block started
     if [ "$in_folders" -eq 1 ] && printf '%s' "$line" | grep -qE '^[^[:space:]#]'; then
+      break
+    fi
+    # Also break on blank lines after block has been entered
+    if [ "$in_folders" -eq 1 ] && [ -z "$(printf '%s' "$line" | tr -d '[:space:]')" ]; then
       break
     fi
     if printf '%s' "$line" | grep -qE '^\s*folders:\s*$'; then
@@ -87,8 +95,13 @@ read_content_folders() {
   printf '%s' "${result%|}"
 }
 
-folders_raw=$(read_content_folders 2>/dev/null || true)
-if [ -z "$folders_raw" ]; then
+if [ -f "$vault_root/vault.yml" ]; then
+  folders_raw=$(read_content_folders 2>/dev/null || true)
+  if [ -z "$folders_raw" ]; then
+    log "vault.yml found but no content folder keys parsed — using defaults"
+    folders_raw="00-inbox|01-projects|02-areas|03-knowledge|04-resources"
+  fi
+else
   folders_raw="00-inbox|01-projects|02-areas|03-knowledge|04-resources"
 fi
 log "content folders: $folders_raw"
@@ -110,7 +123,7 @@ if [ "$matched" -eq 0 ]; then
 fi
 
 # ── URL-encode path ────────────────────────────────────────────────────────────
-# Node.js is always available (Claude Code requires it) — use as primary encoder
+# Try Node.js first (usually on PATH when Claude Code is running), then fall back to python3/python
 encoded=$(FP="$abs_path" node -e \
   "const p=process.env.FP;process.stdout.write(encodeURIComponent(p).replace(/%2F/gi,'/').replace(/%3A/gi,':'));" \
   2>/dev/null \
@@ -119,7 +132,7 @@ encoded=$(FP="$abs_path" node -e \
   || true)
 
 if [ -z "$encoded" ]; then
-  log "URL encoding failed (node/python3/python all absent), exiting"
+  log "URL encoding failed (node, python3, and python all failed or are absent), exiting"
   exit 0
 fi
 
@@ -133,14 +146,16 @@ case "$OSTYPE" in
     ;;
   linux-gnu*)
     if grep -qiE 'microsoft|wsl' /proc/sys/kernel/osrelease 2>/dev/null; then
-      cmd.exe /c start "" "$uri" 2>/dev/null || \
-        /mnt/c/Windows/System32/cmd.exe /c start "" "$uri" 2>/dev/null || true
+      cmd_uri="${uri//%/%%}"
+      cmd.exe /c start "" "$cmd_uri" 2>/dev/null || \
+        /mnt/c/Windows/System32/cmd.exe /c start "" "$cmd_uri" 2>/dev/null || true
     else
       xdg-open "$uri" &>/dev/null &
     fi
     ;;
   msys*|cygwin*)
-    cmd.exe /c start "" "$uri"
+    cmd_uri="${uri//%/%%}"
+    cmd.exe /c start "" "$cmd_uri" 2>/dev/null || true
     ;;
   *)
     log "unknown OSTYPE: $OSTYPE, exiting"

--- a/.claude/plugins/onebrain/hooks/open-in-obsidian.sh
+++ b/.claude/plugins/onebrain/hooks/open-in-obsidian.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# open-in-obsidian.sh — PostToolUse hook
+# Opens a vault file in Obsidian after Write/Edit tool use.
+# Scoped to content folders only. Enforces vault boundary.
+# Always exits 0 — never blocks Claude Code.
+
+# No set -euo pipefail — this is a hook script where resilience matters over
+# strictness. Every code path must exit 0 gracefully; pipefail would cause
+# silent crashes on malformed input instead of the intended graceful no-ops.
+
+# ── Debug logging ────────────────────────────────────────────────────────────
+LOG=""
+if [ "${DEBUG:-}" = "1" ]; then
+  LOG="/tmp/onebrain-hook-debug.log"
+  # Truncate log if over 1MB to prevent unbounded growth
+  [ -f "$LOG" ] && [ "$(wc -c < "$LOG")" -gt 1048576 ] && : > "$LOG"
+  echo "[$(date -Iseconds)] open-in-obsidian.sh started" >> "$LOG"
+fi
+log() { [ -n "$LOG" ] && echo "[$(date -Iseconds)] $*" >> "$LOG" || true; }
+
+# ── Read stdin ────────────────────────────────────────────────────────────────
+input=$(cat)
+
+# ── Extract file_path ─────────────────────────────────────────────────────────
+if ! command -v jq &>/dev/null; then
+  log "jq not found, exiting"
+  exit 0
+fi
+
+file_path=$(echo "$input" | jq -r '.tool_input.file_path // empty' 2>/dev/null)
+if [ -z "$file_path" ]; then
+  log "file_path empty or missing, exiting"
+  exit 0
+fi
+log "file_path: $file_path"
+
+# ── Resolve absolute path ──────────────────────────────────────────────────────
+if command -v realpath &>/dev/null; then
+  abs_path=$(realpath -m "$file_path" 2>/dev/null || echo "$file_path")
+else
+  abs_path=$(cd "$(dirname "$file_path")" 2>/dev/null && echo "$(pwd)/$(basename "$file_path")" || echo "$file_path")
+fi
+log "abs_path: $abs_path"
+
+# ── Vault boundary check ───────────────────────────────────────────────────────
+vault_root="${CLAUDE_PROJECT_DIR%/}"
+abs_path="${abs_path%/}"
+
+if [ -z "$vault_root" ]; then
+  log "CLAUDE_PROJECT_DIR not set, exiting"
+  exit 0
+fi
+
+if [[ "$abs_path" != "$vault_root"/* ]]; then
+  log "file outside vault, exiting"
+  exit 0
+fi
+
+# ── Read content folders from vault.yml ───────────────────────────────────────
+# Pure bash — no Python required
+read_content_folders() {
+  # $vault_root is set from $CLAUDE_PROJECT_DIR (trailing slash already stripped)
+  local yml="$vault_root/vault.yml"
+  [ -f "$yml" ] || return 1
+  local in_folders=0 result=""
+  local content_keys="inbox projects areas knowledge resources"
+  while IFS= read -r line || [ -n "$line" ]; do
+    # Exit folders block on any non-indented, non-comment line after block started
+    if [ "$in_folders" -eq 1 ] && printf '%s' "$line" | grep -qE '^[^[:space:]#]'; then
+      break
+    fi
+    if printf '%s' "$line" | grep -qE '^\s*folders:\s*$'; then
+      in_folders=1; continue
+    fi
+    if [ "$in_folders" -eq 1 ] && printf '%s' "$line" | grep -qE '^\s+\w+:\s+\S'; then
+      local key value
+      key=$(printf '%s' "$line" | sed 's/^[[:space:]]*//' | cut -d: -f1 | tr -d ' ')
+      value=$(printf '%s' "$line" | sed 's/^[[:space:]]*[^:]*:[[:space:]]*//' | tr -d ' \r')
+      for ck in $content_keys; do
+        [ "$key" = "$ck" ] && result="${result}${value}|" && break
+      done
+    fi
+  done < "$yml"
+  printf '%s' "${result%|}"
+}
+
+folders_raw=$(read_content_folders 2>/dev/null || true)
+if [ -z "$folders_raw" ]; then
+  folders_raw="00-inbox|01-projects|02-areas|03-knowledge|04-resources"
+fi
+log "content folders: $folders_raw"
+
+# ── Content folder filter ──────────────────────────────────────────────────────
+matched=0
+IFS='|' read -ra folders <<< "$folders_raw"
+for folder in "${folders[@]}"; do
+  [ -z "$folder" ] && continue
+  if [[ "$abs_path" == "$vault_root/$folder"/* ]] || [[ "$abs_path" == "$vault_root/$folder" ]]; then
+    matched=1
+    break
+  fi
+done
+
+if [ "$matched" -eq 0 ]; then
+  log "file not in content folder, exiting"
+  exit 0
+fi
+
+# ── URL-encode path ────────────────────────────────────────────────────────────
+# Node.js is always available (Claude Code requires it) — use as primary encoder
+encoded=$(FP="$abs_path" node -e \
+  "const p=process.env.FP;process.stdout.write(encodeURIComponent(p).replace(/%2F/gi,'/').replace(/%3A/gi,':'));" \
+  2>/dev/null \
+  || python3 -c "import urllib.parse,sys;sys.stdout.write(urllib.parse.quote(sys.argv[1],safe='/:@'))" "$abs_path" 2>/dev/null \
+  || python -c "import urllib,sys;sys.stdout.write(urllib.quote(sys.argv[1],safe='/:@'))" "$abs_path" 2>/dev/null \
+  || true)
+
+if [ -z "$encoded" ]; then
+  log "URL encoding failed (node/python3/python all absent), exiting"
+  exit 0
+fi
+
+uri="obsidian://open?path=${encoded}"
+log "opening URI: $uri"
+
+# ── Platform detection and open ───────────────────────────────────────────────
+case "$OSTYPE" in
+  darwin*)
+    open "$uri"
+    ;;
+  linux-gnu*)
+    if grep -qiE 'microsoft|wsl' /proc/sys/kernel/osrelease 2>/dev/null; then
+      cmd.exe /c start "" "$uri" 2>/dev/null || \
+        /mnt/c/Windows/System32/cmd.exe /c start "" "$uri" 2>/dev/null || true
+    else
+      xdg-open "$uri" &>/dev/null &
+    fi
+    ;;
+  msys*|cygwin*)
+    cmd.exe /c start "" "$uri"
+    ;;
+  *)
+    log "unknown OSTYPE: $OSTYPE, exiting"
+    exit 0
+    ;;
+esac
+
+log "done"
+exit 0

--- a/.claude/plugins/onebrain/hooks/open-in-obsidian.sh
+++ b/.claude/plugins/onebrain/hooks/open-in-obsidian.sh
@@ -14,9 +14,9 @@ if [ "${DEBUG:-}" = "1" ]; then
   LOG="/tmp/onebrain-hook-debug.log"
   # Truncate log if over 1MB to prevent unbounded growth
   [ -f "$LOG" ] && [ "$(wc -c < "$LOG")" -gt 1048576 ] && : > "$LOG"
-  echo "[$(date -Iseconds)] open-in-obsidian.sh started" >> "$LOG"
+  echo "[$(date -u +"%Y-%m-%dT%H:%M:%SZ")] open-in-obsidian.sh started" >> "$LOG"
 fi
-log() { [ -n "$LOG" ] && echo "[$(date -Iseconds)] $*" >> "$LOG" || true; }
+log() { [ -n "$LOG" ] && echo "[$(date -u +"%Y-%m-%dT%H:%M:%SZ")] $*" >> "$LOG" || true; }
 
 # ── Read stdin ────────────────────────────────────────────────────────────────
 input=$(cat)
@@ -35,7 +35,10 @@ fi
 log "file_path: $file_path"
 
 # ── Resolve absolute path ──────────────────────────────────────────────────────
-if command -v realpath &>/dev/null; then
+if [[ "$file_path" == /* ]]; then
+  # Already absolute (Claude Code always provides absolute paths)
+  abs_path="$file_path"
+elif command -v realpath &>/dev/null; then
   abs_path=$(realpath -m "$file_path" 2>/dev/null || echo "$file_path")
 else
   abs_path=$(cd "$(dirname "$file_path")" 2>/dev/null && echo "$(pwd)/$(basename "$file_path")" || echo "$file_path")
@@ -75,7 +78,7 @@ read_content_folders() {
     if [ "$in_folders" -eq 1 ] && printf '%s' "$line" | grep -qE '^\s+\w+:\s+\S'; then
       local key value
       key=$(printf '%s' "$line" | sed 's/^[[:space:]]*//' | cut -d: -f1 | tr -d ' ')
-      value=$(printf '%s' "$line" | sed 's/^[[:space:]]*[^:]*:[[:space:]]*//' | tr -d ' \r')
+      value=$(printf '%s' "$line" | sed 's/^[[:space:]]*[^:]*:[[:space:]]*//' | tr -d ' \r"'"'"'')
       for ck in $content_keys; do
         [ "$key" = "$ck" ] && result="${result}${value}|" && break
       done
@@ -126,7 +129,7 @@ log "opening URI: $uri"
 # ── Platform detection and open ───────────────────────────────────────────────
 case "$OSTYPE" in
   darwin*)
-    open "$uri"
+    open "$uri" 2>/dev/null
     ;;
   linux-gnu*)
     if grep -qiE 'microsoft|wsl' /proc/sys/kernel/osrelease 2>/dev/null; then


### PR DESCRIPTION
## Summary

- Registers a `PostToolUse` hook on `Write|Edit` tool calls that automatically opens edited vault files in Obsidian for live review
- Bash script (`open-in-obsidian.sh`) handles macOS, Linux, WSL/WSL2, and Git Bash; PowerShell script (`open-in-obsidian.ps1`) handles native Windows — single `hooks.json` entry uses `bash || powershell` fallback
- Reads content folder names from `vault.yml` at runtime (falls back to defaults if absent); enforces vault boundary so only files inside the current vault are opened
- Bumps plugin version to 1.1.0

## Implementation Details

- URL encoding via Node.js (always available — Claude Code requires it), with python3/python fallback
- Pure bash vault.yml parsing — no Python dependency for folder resolution
- Cross-platform date format (`date -u +"%Y-%m-%dT%H:%M:%SZ"`) for debug logging
- All code paths exit 0 — hook never blocks Claude Code

## Test Plan

- [ ] Restart Claude Code to load new hook
- [ ] Ask AI to create a note in `00-inbox/` → file opens in Obsidian
- [ ] Ask AI to edit a note in `03-knowledge/` → file opens in Obsidian
- [ ] Ask AI to update `05-agent/MEMORY.md` → Obsidian does NOT open (agent folder excluded)
- [ ] Verify `DEBUG=1` logs to `/tmp/onebrain-hook-debug.log`