### PR TITLE
feat: update installation banner and fix color consistency

### DIFF
--- a/.claude/plugins/onebrain/skills/update/SKILL.md
+++ b/.claude/plugins/onebrain/skills/update/SKILL.md
@@ -15,7 +15,7 @@ Your notes, memory, and personal settings are never touched.
 Tell the user what will and won't be updated:
 
 **WILL update (system files only):**
-- `CLAUDE.md`, `GEMINI.md`, `AGENTS.md`, `README.md`, `.gitignore`
+- `CLAUDE.md`, `GEMINI.md`, `AGENTS.md`, `.gitignore`
 - `.claude/plugins/onebrain/` — all skills, hooks, and agents
 - `.claude/plugins/obsidian-skills/` — Obsidian Skills plugin (kepano/obsidian-skills)
 - `.obsidian/plugins/` — bundled plugin files
@@ -31,7 +31,8 @@ Tell the user what will and won't be updated:
 - `.obsidian/hotkeys.json` — your keybindings
 - `.claude/settings.local.json` — your local Claude settings
 - `.claude/onebrain.local.md` — your local plugin config
-- `install.sh` — only used for fresh installs
+- `install.sh`, `install.ps1` — only used for fresh installs
+- `README.md`, `CONTRIBUTING.md`, `LICENSE`, `assets/` — repo-only files, not part of the vault
 
 Ask: **"Proceed with update?"** and wait for confirmation before continuing.
 
@@ -60,7 +61,6 @@ For each path in the allowlist, compare the upstream version against the local v
 | `CLAUDE.md` | file |
 | `GEMINI.md` | file |
 | `AGENTS.md` | file |
-| `README.md` | file |
 | `.gitignore` | file |
 | `.claude/plugins/onebrain/` | directory |
 | `.obsidian/plugins/` | directory |

--- a/install.ps1
+++ b/install.ps1
@@ -2,6 +2,12 @@
 $ErrorActionPreference = 'Stop'
 
 # ─── Colors ───────────────────────────────────────────────────────────────────
+if ($Host.UI.SupportsVirtualTerminal) {
+  $script:Bold      = [char]0x1b + "[1m"
+  $script:BoldReset = [char]0x1b + "[0m"
+} else {
+  $script:Bold = ""; $script:BoldReset = ""
+}
 function Print-Info    { param($msg) Write-Host "  $msg" -ForegroundColor Cyan }
 function Print-Success { param($msg) Write-Host "  $msg" -ForegroundColor Green }
 function Print-Error   { param($msg) Write-Host "  error: $msg" -ForegroundColor Red }
@@ -17,7 +23,7 @@ function Print-Banner {
   Write-Host "| |_| | | | |  __/ |_) | | | (_| | | | | |" -ForegroundColor Cyan
   Write-Host " \___/|_| |_|\___|____/|_|  \__,_|_|_| |_|" -ForegroundColor Cyan
   Write-Host
-  Write-Host " > Think. Sync. OneBrain." -ForegroundColor Yellow
+  Write-Host " > Two Minds, Think as One, in OneBrain" -ForegroundColor Yellow
   Write-Host
 }
 
@@ -78,7 +84,7 @@ function Install-Plugins {
     return ,@($failedPlugins)
   }
 
-  Print-Header "Installing community plugins..."
+  Print-Header "Installing Obsidian community plugins..."
 
   # Fetch Obsidian plugin registry once
   try {
@@ -88,8 +94,6 @@ function Install-Plugins {
     Write-Host "  All plugins will need to be installed manually." -ForegroundColor Yellow
     return ,@($pluginIds)  # all plugins are "failed"
   }
-  Write-Done "Registry fetched"
-
   # Wrap New-Item in try/catch: a filesystem error here must not propagate to the outer
   # Main catch as a fatal abort — plugin installation is a non-fatal step.
   $pluginsDir = Join-Path $VaultPath ".obsidian\plugins"
@@ -307,14 +311,13 @@ function Install-ObsidianSkills {
     return  # Non-fatal — overall install continues without this plugin
   }
 
-  Write-Done "Obsidian Skills installed"
 }
 
 # ─── Main ─────────────────────────────────────────────────────────────────────
 $script:FailedPlugins = @()
 function Main {
   Print-Banner
-  Write-Host "This script downloads OneBrain and sets up a fresh Obsidian vault." -ForegroundColor Cyan
+  Write-Host "$($script:Bold)This script downloads OneBrain and sets up a fresh Obsidian vault.$($script:BoldReset)" -ForegroundColor Cyan
   Write-Host
 
   Check-Deps
@@ -359,7 +362,7 @@ function Main {
   }
 
   Write-Host
-  Write-Host "Vault will be created at: $vaultPath" -ForegroundColor Cyan
+  Write-Host "$($script:Bold)Vault will be created at: $vaultPath$($script:BoldReset)" -ForegroundColor Cyan
   Write-Host
 
   # ── Step 3: Download and extract ────────────────────────────────────────────
@@ -486,7 +489,7 @@ function Main {
   Write-Host
   Print-Success "Vault path: $vaultPath"
   Write-Host
-  Write-Host "Next steps:" -ForegroundColor Cyan
+  Write-Host "$($script:Bold)Next steps:$($script:BoldReset)" -ForegroundColor Cyan
   Write-Host
   Write-Host "  1. Open Obsidian"
   Write-Host "     File → Open Folder as Vault → select: $vaultPath"

--- a/install.ps1
+++ b/install.ps1
@@ -81,7 +81,6 @@ function Install-Plugins {
   Print-Header "Installing community plugins..."
 
   # Fetch Obsidian plugin registry once
-  Write-Step "📦" "Fetching plugin registry..."
   try {
     $registry = Invoke-RestMethod -Uri $registryUrl -ErrorAction Stop
   } catch {
@@ -125,8 +124,6 @@ function Install-Plugins {
       continue
     }
     $repo = $entry.repo
-
-    Write-Step "🔌" "Installing $pluginId..."
 
     try {
       $release = Invoke-RestMethod `
@@ -252,8 +249,6 @@ function Install-ObsidianSkills {
   $targetDir = Join-Path $VaultPath ".claude\plugins\obsidian-skills"
   $repoUrl   = "https://github.com/kepano/obsidian-skills.git"
 
-  Write-Step "📦" "Installing Obsidian Skills plugin..."
-
   # Already installed in a valid state — show confirmation and skip
   if ((Test-Path $targetDir -PathType Container) -and
       -not (Test-Path (Join-Path $targetDir ".git") -PathType Container)) {
@@ -276,7 +271,6 @@ function Install-ObsidianSkills {
       Print-Info "  Remove-Item -Path `"$targetDir`" -Recurse -Force"
       return  # Non-fatal — overall install continues without this plugin
     }
-    Write-Step "📦" "Installing Obsidian Skills plugin..."
   }
 
   # Clone the repo (shallow, quiet); join all output lines for readable error display
@@ -366,6 +360,7 @@ function Main {
 
   Write-Host
   Write-Host "Vault will be created at: $vaultPath" -ForegroundColor Cyan
+  Write-Host
 
   # ── Step 3: Download and extract ────────────────────────────────────────────
   $repoUrl = "https://github.com/kengio/onebrain/archive/refs/heads/main.zip"
@@ -501,7 +496,7 @@ function Main {
   if ($script:FailedPlugins.Count -gt 0) {
     Write-Host "  $step. Install missing plugins manually (Settings → Community plugins → Browse):"
     foreach ($p in $script:FailedPlugins) {
-      Write-Host "     $p" -ForegroundColor Cyan
+      if ($p) { Write-Host "     $p" -ForegroundColor Cyan }
     }
     $step++
   }

--- a/install.ps1
+++ b/install.ps1
@@ -11,18 +11,11 @@ function Write-Done    { param($msg) Write-Host "  ✅ $msg" -ForegroundColor Gr
 
 function Print-Banner {
   Write-Host
-  Write-Host " ██████╗ ███╗   ██╗███████╗" -ForegroundColor Blue
-  Write-Host "██╔═══██╗████╗  ██║██╔════╝" -ForegroundColor Blue
-  Write-Host "██║   ██║██╔██╗ ██║█████╗  " -ForegroundColor Blue
-  Write-Host "██║   ██║██║╚██╗██║██╔══╝  " -ForegroundColor Blue
-  Write-Host "╚██████╔╝██║ ╚████║███████╗" -ForegroundColor Blue
-  Write-Host " ╚═════╝ ╚═╝  ╚═══╝╚══════╝" -ForegroundColor Blue
-  Write-Host "██████╗ ██████╗  █████╗ ██╗███╗   ██╗" -ForegroundColor Blue
-  Write-Host "██╔══██╗██╔══██╗██╔══██╗██║████╗  ██║" -ForegroundColor Blue
-  Write-Host "██████╔╝██████╔╝███████║██║██╔██╗ ██║" -ForegroundColor Blue
-  Write-Host "██╔══██╗██╔══██╗██╔══██║██║██║╚██╗██║" -ForegroundColor Blue
-  Write-Host "██████╔╝██║  ██║██║  ██║██║██║ ╚████║" -ForegroundColor Blue
-  Write-Host "╚═════╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚═╝╚═╝  ╚═══╝" -ForegroundColor Blue
+  Write-Host "  ___             ____            _       " -ForegroundColor Blue
+  Write-Host " / _ \ _ __   ___| __ ) _ __ __ _(_)_ __  " -ForegroundColor Blue
+  Write-Host "| | | | '_ \ / _ \  _ \| '__/ _`` | | '_ \ " -ForegroundColor Blue
+  Write-Host "| |_| | | | |  __/ |_) | | | (_| | | | | |" -ForegroundColor Blue
+  Write-Host " \___/|_| |_|\___|____/|_|  \__,_|_|_| |_|" -ForegroundColor Blue
   Write-Host
   Write-Host " > Think. Sync. OneBrain." -ForegroundColor Yellow
   Write-Host

--- a/install.ps1
+++ b/install.ps1
@@ -2,8 +2,8 @@
 $ErrorActionPreference = 'Stop'
 
 # ─── Colors ───────────────────────────────────────────────────────────────────
-function Print-Info    { param($msg) Write-Host "   $msg" -ForegroundColor Cyan }
-function Print-Success { param($msg) Write-Host "   $msg" -ForegroundColor Green }
+function Print-Info    { param($msg) Write-Host "  $msg" -ForegroundColor Cyan }
+function Print-Success { param($msg) Write-Host "  $msg" -ForegroundColor Green }
 function Print-Error   { param($msg) Write-Host "  error: $msg" -ForegroundColor Red }
 function Print-Header  { param($msg) Write-Host; Write-Host $msg -ForegroundColor Cyan; Write-Host }
 function Write-Step    { param($emoji, $msg) Write-Host "  $emoji $msg" }
@@ -38,8 +38,12 @@ function Check-Deps {
 
 # ─── Prompt helpers ───────────────────────────────────────────────────────────
 function Prompt-WithDefault {
-  param([string]$Question, [string]$Default)
-  $answer = Read-Host "  ? $Question [$Default]"
+  param([string]$Number, [string]$Question, [string]$Default)
+  Write-Host "  $Number) " -NoNewline -ForegroundColor Yellow
+  Write-Host "$Question " -NoNewline
+  Write-Host "[$Default]" -ForegroundColor Cyan
+  Write-Host "  > " -NoNewline -ForegroundColor Yellow
+  $answer = $host.UI.ReadLine()
   if ([string]::IsNullOrWhiteSpace($answer)) { $Default } else { $answer }
 }
 
@@ -74,9 +78,7 @@ function Install-Plugins {
     return ,@($failedPlugins)
   }
 
-  Write-Host
-  Write-Host "  Installing community plugins..." -ForegroundColor Cyan
-  Write-Host
+  Print-Header "Installing community plugins..."
 
   # Fetch Obsidian plugin registry once
   Write-Step "📦" "Fetching plugin registry..."
@@ -227,11 +229,11 @@ function Install-Plugins {
 
   if ($failedPlugins.Count -gt 0) {
     Write-Host
-    Write-Host "  Some plugins could not be installed automatically:" -ForegroundColor Yellow
+    Print-Info "Some plugins could not be installed automatically:"
     foreach ($p in $failedPlugins) {
-      Write-Host "    • $p" -ForegroundColor Yellow
+      Print-Info "  • $p"
     }
-    Write-Host "  Install them manually: Settings -> Community plugins -> Browse" -ForegroundColor Yellow
+    Print-Info "Install them manually: Settings -> Community plugins -> Browse"
   }
 
   return ,@($failedPlugins)
@@ -318,17 +320,20 @@ function Install-ObsidianSkills {
 $script:FailedPlugins = @()
 function Main {
   Print-Banner
-  Print-Info "This script downloads OneBrain and sets up a fresh Obsidian vault."
+  Write-Host "This script downloads OneBrain and sets up a fresh Obsidian vault." -ForegroundColor Cyan
   Write-Host
 
   Check-Deps
 
   # ── Step 1: Install location ────────────────────────────────────────────────
   $defaultLocation = (Get-Location).Path
-  $installLocation = Prompt-WithDefault "Where should the vault be created?" $defaultLocation
+  $installLocation = Prompt-WithDefault "1" "Where should the vault be created?" $defaultLocation
 
   if (-not (Test-Path $installLocation)) {
-    $confirm = Read-Host "  ? Directory '$installLocation' does not exist. Create it? [Y/n]"
+    Write-Host "  ? " -NoNewline -ForegroundColor Yellow
+    Write-Host "Directory '$installLocation' does not exist. Create it? [Y/n]"
+    Write-Host "  > " -NoNewline -ForegroundColor Yellow
+    $confirm = $host.UI.ReadLine()
     if ($confirm -eq '' -or $confirm -match '^[Yy]') {
       try {
         New-Item -ItemType Directory -Path $installLocation -Force | Out-Null
@@ -344,7 +349,8 @@ function Main {
   }
 
   # ── Step 2: Vault name ──────────────────────────────────────────────────────
-  $vaultName = Prompt-WithDefault "Vault name?" "onebrain"
+  Write-Host
+  $vaultName = Prompt-WithDefault "2" "Vault name?" "onebrain"
 
   if ($vaultName -match '[\s/\\]') {
     Print-Error "Vault name must not contain spaces or slashes. Got: '$vaultName'"
@@ -360,7 +366,7 @@ function Main {
   }
 
   Write-Host
-  Print-Info "Vault will be created at: $vaultPath"
+  Write-Host "Vault will be created at: $vaultPath" -ForegroundColor Cyan
   Write-Host
 
   # ── Step 3: Download and extract ────────────────────────────────────────────
@@ -420,25 +426,31 @@ function Main {
     }
 
     # ── Step 4: Clean up installed vault ────────────────────────────────────
-    # Remove install scripts — they shouldn't live in the vault.
+    # Remove install scripts, README and assets from the vault — they belong to the repo, not the vault.
     # Test-Path first so we error only on real failures (permissions/locks),
     # not on the file simply being absent from the archive.
-    $shPath  = Join-Path $vaultPath "install.sh"
-    $ps1Path = Join-Path $vaultPath "install.ps1"
-    if (Test-Path $shPath) {
-      try {
-        Remove-Item $shPath -Force -ErrorAction Stop
-      } catch {
-        Print-Error "Could not remove install.sh from '$vaultPath'. Check directory permissions."
-        Print-Error $_.Exception.Message
-        throw "error:already-printed"
+    $shPath     = Join-Path $vaultPath "install.sh"
+    $ps1Path    = Join-Path $vaultPath "install.ps1"
+    $readmePath = Join-Path $vaultPath "README.md"
+    $assetsPath = Join-Path $vaultPath "assets"
+    $contributingPath = Join-Path $vaultPath "CONTRIBUTING.md"
+    $licensePath      = Join-Path $vaultPath "LICENSE"
+    foreach ($filePath in @($shPath, $ps1Path, $readmePath, $contributingPath, $licensePath)) {
+      if (Test-Path $filePath) {
+        try {
+          Remove-Item $filePath -Force -ErrorAction Stop
+        } catch {
+          Print-Error "Could not remove '$filePath'. Check directory permissions."
+          Print-Error $_.Exception.Message
+          throw "error:already-printed"
+        }
       }
     }
-    if (Test-Path $ps1Path) {
+    if (Test-Path $assetsPath) {
       try {
-        Remove-Item $ps1Path -Force -ErrorAction Stop
+        Remove-Item $assetsPath -Recurse -Force -ErrorAction Stop
       } catch {
-        Print-Error "Could not remove install.ps1 from '$vaultPath'. Check directory permissions."
+        Print-Error "Could not remove assets directory from '$vaultPath'. Check directory permissions."
         Print-Error $_.Exception.Message
         throw "error:already-printed"
       }
@@ -483,19 +495,25 @@ function Main {
   Write-Host
   Print-Success "Vault path: $vaultPath"
   Write-Host
-  Write-Host "Next steps:" -ForegroundColor White
+  Write-Host "Next steps:" -ForegroundColor Cyan
+  Write-Host
   Write-Host "  1. Open Obsidian"
   Write-Host "     File -> Open Folder as Vault -> select: $vaultPath"
   $step = 2
   if ($script:FailedPlugins.Count -gt 0) {
-    Write-Host "  $step. Install missing plugins manually (Settings -> Community plugins -> Browse):" -ForegroundColor White
+    Write-Host "  $step. Install missing plugins manually (Settings -> Community plugins -> Browse):"
     foreach ($p in $script:FailedPlugins) {
       Write-Host "     $p" -ForegroundColor Cyan
     }
     $step++
   }
-  Write-Host "  $step. Open your terminal in the vault directory and run your AI agent:"
-  Write-Host "     claude  or  gemini" -ForegroundColor Cyan
+  Write-Host "  $step. Open your terminal in the vault directory:"
+  Write-Host "     cd `"$vaultPath`"" -ForegroundColor Cyan
+  $step++
+  Write-Host "  $step. Start your AI assistant:"
+  Write-Host "     claude" -NoNewline -ForegroundColor Cyan
+  Write-Host "  or  " -NoNewline
+  Write-Host "gemini" -ForegroundColor Cyan
   $step++
   Write-Host "  $step. Run the onboarding command:"
   Write-Host "     /onboarding" -ForegroundColor Cyan

--- a/install.ps1
+++ b/install.ps1
@@ -373,7 +373,6 @@ function Main {
   }
 
   try {
-    Write-Step "📦" "Downloading OneBrain..."
     $zipPath = Join-Path $tmpDir "onebrain.zip"
 
     try {
@@ -385,7 +384,6 @@ function Main {
     }
     Write-Done "Downloaded"
 
-    Write-Step "🔧" "Extracting..."
     try {
       Expand-Archive -Path $zipPath -DestinationPath $tmpDir -Force
     } catch {

--- a/install.ps1
+++ b/install.ps1
@@ -11,11 +11,11 @@ function Write-Done    { param($msg) Write-Host "  ✅ $msg" -ForegroundColor Gr
 
 function Print-Banner {
   Write-Host
-  Write-Host "  ___             ____            _       " -ForegroundColor Blue
-  Write-Host " / _ \ _ __   ___| __ ) _ __ __ _(_)_ __  " -ForegroundColor Blue
-  Write-Host "| | | | '_ \ / _ \  _ \| '__/ _`` | | '_ \ " -ForegroundColor Blue
-  Write-Host "| |_| | | | |  __/ |_) | | | (_| | | | | |" -ForegroundColor Blue
-  Write-Host " \___/|_| |_|\___|____/|_|  \__,_|_|_| |_|" -ForegroundColor Blue
+  Write-Host "  ___             ____            _       " -ForegroundColor Cyan
+  Write-Host " / _ \ _ __   ___| __ ) _ __ __ _(_)_ __  " -ForegroundColor Cyan
+  Write-Host "| | | | '_ \ / _ \  _ \| '__/ _`` | | '_ \ " -ForegroundColor Cyan
+  Write-Host "| |_| | | | |  __/ |_) | | | (_| | | | | |" -ForegroundColor Cyan
+  Write-Host " \___/|_| |_|\___|____/|_|  \__,_|_|_| |_|" -ForegroundColor Cyan
   Write-Host
   Write-Host " > Think. Sync. OneBrain." -ForegroundColor Yellow
   Write-Host

--- a/install.ps1
+++ b/install.ps1
@@ -233,7 +233,7 @@ function Install-Plugins {
     foreach ($p in $failedPlugins) {
       Print-Info "  • $p"
     }
-    Print-Info "Install them manually: Settings -> Community plugins -> Browse"
+    Print-Info "Install them manually: Settings → Community plugins → Browse"
   }
 
   return ,@($failedPlugins)
@@ -331,8 +331,7 @@ function Main {
 
   if (-not (Test-Path $installLocation)) {
     Write-Host "  ? " -NoNewline -ForegroundColor Yellow
-    Write-Host "Directory '$installLocation' does not exist. Create it? [Y/n]"
-    Write-Host "  > " -NoNewline -ForegroundColor Yellow
+    Write-Host "Directory '$installLocation' does not exist. Create it? [Y/n] " -NoNewline
     $confirm = $host.UI.ReadLine()
     if ($confirm -eq '' -or $confirm -match '^[Yy]') {
       try {
@@ -367,7 +366,6 @@ function Main {
 
   Write-Host
   Write-Host "Vault will be created at: $vaultPath" -ForegroundColor Cyan
-  Write-Host
 
   # ── Step 3: Download and extract ────────────────────────────────────────────
   $repoUrl = "https://github.com/kengio/onebrain/archive/refs/heads/main.zip"
@@ -498,10 +496,10 @@ function Main {
   Write-Host "Next steps:" -ForegroundColor Cyan
   Write-Host
   Write-Host "  1. Open Obsidian"
-  Write-Host "     File -> Open Folder as Vault -> select: $vaultPath"
+  Write-Host "     File → Open Folder as Vault → select: $vaultPath"
   $step = 2
   if ($script:FailedPlugins.Count -gt 0) {
-    Write-Host "  $step. Install missing plugins manually (Settings -> Community plugins -> Browse):"
+    Write-Host "  $step. Install missing plugins manually (Settings → Community plugins → Browse):"
     foreach ($p in $script:FailedPlugins) {
       Write-Host "     $p" -ForegroundColor Cyan
     }

--- a/install.sh
+++ b/install.sh
@@ -40,7 +40,7 @@ print_banner() {
   echo "${CYAN}${BOLD}| |_| | | | |  __/ |_) | | | (_| | | | | |${RESET}"
   echo "${CYAN}${BOLD} \\___/|_| |_|\\___|____/|_|  \\__,_|_|_| |_|${RESET}"
   echo
-  echo "${YELLOW} > Think. Sync. OneBrain.${RESET}"
+  echo "${YELLOW} > Two Minds, Think as One, in OneBrain${RESET}"
   echo
 }
 
@@ -209,7 +209,7 @@ install_plugins() {
     return 0
   fi
 
-  print_header "Installing community plugins..."
+  print_header "Installing Obsidian community plugins..."
 
   # Fetch the Obsidian community plugin registry once.
   # Reuse _INSTALL_TMPDIR (cleaned by the EXIT trap) to avoid a separate tempfile leak.
@@ -227,8 +227,12 @@ install_plugins() {
     FAILED_PLUGINS=("${failed_plugins[@]}")
     return 0
   fi
-  spinner_stop "$ICON_OK" "Registry fetched"
-
+  if [ -n "${SPINNER_PID:-}" ]; then
+    kill "$SPINNER_PID" 2>/dev/null || true
+    wait "$SPINNER_PID" 2>/dev/null || true
+    SPINNER_PID=""
+    printf "\r\033[K" >&2
+  fi
   local plugins_dir="$vault/.obsidian/plugins"
   local mkdir_err
   if ! mkdir_err=$(mkdir -p "$plugins_dir" 2>&1); then
@@ -409,11 +413,9 @@ install_obsidian_skills() {
   local target_dir="$vault/.claude/plugins/obsidian-skills"
   local repo_url="https://github.com/kepano/obsidian-skills.git"
 
-  spinner_start "Installing Obsidian Skills plugin..."
-
   # Already installed in a valid state — show confirmation and skip
   if [ -d "$target_dir" ] && [ ! -d "$target_dir/.git" ]; then
-    spinner_stop "$ICON_OK" "Obsidian Skills already present"
+    print_success "Obsidian Skills already present"
     return 0
   fi
 
@@ -421,7 +423,7 @@ install_obsidian_skills() {
   # or clone was interrupted before checkout completed). Remove the whole directory so the
   # next run can retry cleanly — a partial clone's skill files may be incomplete too.
   if [ -d "$target_dir" ] && [ -d "$target_dir/.git" ]; then
-    spinner_stop "$ICON_FAIL" "Obsidian Skills: incomplete previous install"
+    print_error "Obsidian Skills: incomplete previous install"
     print_info "${YELLOW}Found an incomplete obsidian-skills install. Removing and retrying...${RESET}"
     if ! rm -rf "$target_dir"; then
       print_info "${YELLOW}Could not remove partial install at:${RESET} $target_dir"
@@ -429,7 +431,6 @@ install_obsidian_skills() {
       print_info "  ${CYAN}rm -rf \"$target_dir\"${RESET}"
       return 0  # Non-fatal — overall install continues without this plugin
     fi
-    spinner_start "Installing Obsidian Skills plugin..."
   fi
 
   # Capture both output and exit code; `if ! cmd=$(...)` discards $? after negation.
@@ -437,7 +438,7 @@ install_obsidian_skills() {
   clone_err=$(git clone --depth 1 -q "$repo_url" "$target_dir" 2>&1)
   clone_exit=$?
   if [ $clone_exit -ne 0 ]; then
-    spinner_stop "$ICON_FAIL" "Obsidian Skills install failed"
+    print_error "Obsidian Skills install failed"
     print_info "${YELLOW}Could not clone obsidian-skills (exit ${clone_exit}):${RESET}"
     print_info "  ${clone_err:-no output from git}"
     # Clean up any partial directory git may have created before failing.
@@ -456,7 +457,7 @@ install_obsidian_skills() {
   # repo and 'git status' silently ignores the subtree, which is confusing.
   # The .gitignore entry suppresses tracking, but does not suppress the warning.
   if ! rm -rf "$target_dir/.git"; then
-    spinner_stop "$ICON_FAIL" "Obsidian Skills install failed"
+    print_error "Obsidian Skills install failed"
     print_info "${YELLOW}Cloned obsidian-skills but could not remove its nested .git directory.${RESET}"
     print_info "Without removing it, 'git add' will warn about an embedded repository."
     print_info "Fix manually before running git commands in this vault:"
@@ -464,7 +465,6 @@ install_obsidian_skills() {
     return 0  # Non-fatal — overall install continues without this plugin
   fi
 
-  spinner_stop "$ICON_OK" "Obsidian Skills installed"
 }
 
 # ─── Main ─────────────────────────────────────────────────────────────────────

--- a/install.sh
+++ b/install.sh
@@ -18,9 +18,9 @@ else
 fi
 
 # ─── Print helpers ────────────────────────────────────────────────────────────
-print_info()    { echo "${CYAN}  ${RESET} $*"; }
-print_success() { echo "${GREEN}  ${RESET} $*"; }
-print_error()   { echo "${RED}  error:${RESET} $*" >&2; }
+print_info()    { echo "${CYAN}  $*${RESET}"; }
+print_success() { echo "${GREEN}  $*${RESET}"; }
+print_error()   { echo "${RED}  error: $*${RESET}" >&2; }
 print_prompt()  { printf "${YELLOW}  ? ${RESET}${BOLD}%s${RESET} " "$*" >&2; }
 print_header()  { echo; echo "${BOLD}${CYAN}$*${RESET}"; echo; }
 
@@ -34,18 +34,11 @@ fi
 # ─── Banner ───────────────────────────────────────────────────────────────────
 print_banner() {
   echo
-  echo "${BLUE}${BOLD} ██████╗ ███╗   ██╗███████╗${RESET}"
-  echo "${BLUE}${BOLD}██╔═══██╗████╗  ██║██╔════╝${RESET}"
-  echo "${BLUE}${BOLD}██║   ██║██╔██╗ ██║█████╗  ${RESET}"
-  echo "${BLUE}${BOLD}██║   ██║██║╚██╗██║██╔══╝  ${RESET}"
-  echo "${BLUE}${BOLD}╚██████╔╝██║ ╚████║███████╗${RESET}"
-  echo "${BLUE}${BOLD} ╚═════╝ ╚═╝  ╚═══╝╚══════╝${RESET}"
-  echo "${BLUE}${BOLD}██████╗ ██████╗  █████╗ ██╗███╗   ██╗${RESET}"
-  echo "${BLUE}${BOLD}██╔══██╗██╔══██╗██╔══██╗██║████╗  ██║${RESET}"
-  echo "${BLUE}${BOLD}██████╔╝██████╔╝███████║██║██╔██╗ ██║${RESET}"
-  echo "${BLUE}${BOLD}██╔══██╗██╔══██╗██╔══██║██║██║╚██╗██║${RESET}"
-  echo "${BLUE}${BOLD}██████╔╝██║  ██║██║  ██║██║██║ ╚████║${RESET}"
-  echo "${BLUE}${BOLD}╚═════╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚═╝╚═╝  ╚═══╝${RESET}"
+  echo "${BLUE}${BOLD}  ___             ____            _       ${RESET}"
+  echo "${BLUE}${BOLD} / _ \\ _ __   ___| __ ) _ __ __ _(_)_ __  ${RESET}"
+  echo "${BLUE}${BOLD}| | | | '_ \\ / _ \\  _ \\| '__/ _\` | | '_ \\ ${RESET}"
+  echo "${BLUE}${BOLD}| |_| | | | |  __/ |_) | | | (_| | | | | |${RESET}"
+  echo "${BLUE}${BOLD} \\___/|_| |_|\\___|____/|_|  \\__,_|_|_| |_|${RESET}"
   echo
   echo "${YELLOW} > Think. Sync. OneBrain.${RESET}"
   echo
@@ -629,13 +622,13 @@ main() {
 
   # ── Step 5: Success ──────────────────────────────────────────────────────────
   echo
-  echo "${BLUE}${BOLD}  $ICON_DONE OneBrain is ready!${RESET}"
+  echo "${GREEN}  $ICON_DONE OneBrain is ready!${RESET}"
   echo
-  print_success "Vault path: ${BOLD}${vault_path}${RESET}"
+  print_success "Vault path: ${vault_path}"
   echo
-  echo "${BOLD}Next steps:${RESET}"
+  echo "Next steps:"
   echo "  1. Open Obsidian"
-  echo "     File → Open Folder as Vault → select: ${CYAN}${vault_path}${RESET}"
+  echo "     File → Open Folder as Vault → select: ${vault_path}"
   local step=2
   if [ ${#FAILED_PLUGINS[@]} -gt 0 ]; then
     echo "  ${step}. Install missing plugins manually (Settings → Community plugins → Browse):"

--- a/install.sh
+++ b/install.sh
@@ -173,10 +173,12 @@ check_deps() {
 
 # ─── Prompt helpers ───────────────────────────────────────────────────────────
 prompt_with_default() {
-  local question="$1"
-  local default="$2"
+  local number="$1"
+  local question="$2"
+  local default="$3"
   local answer
-  print_prompt "$question [${default}]:"
+  echo "${YELLOW}  ${number}) ${RESET}${BOLD}$question${RESET} ${CYAN}[${default}]${RESET}" >&2
+  printf "${YELLOW}  > ${RESET}" >&2
   if ! read -r answer <&"$TTY_FD"; then
     echo >&2
     print_error "No input received (EOF). Aborted."
@@ -497,7 +499,7 @@ main() {
   fi
 
   print_banner
-  print_info "This script downloads OneBrain and sets up a fresh Obsidian vault."
+  echo "${BOLD}${CYAN}This script downloads OneBrain and sets up a fresh Obsidian vault.${RESET}"
   echo
 
   check_deps
@@ -505,7 +507,7 @@ main() {
   # ── Step 1: Install location ────────────────────────────────────────────────
   local default_location="$PWD"
   local install_location
-  install_location=$(prompt_with_default "Where should the vault be created?" "$default_location")
+  install_location=$(prompt_with_default 1 "Where should the vault be created?" "$default_location")
 
   # Expand a leading ~ to $HOME (note: ~username forms are not expanded)
   install_location="${install_location/#\~/$HOME}"
@@ -531,8 +533,9 @@ main() {
   fi
 
   # ── Step 2: Vault name ──────────────────────────────────────────────────────
+  echo >&2
   local vault_name
-  vault_name=$(prompt_with_default "Vault name?" "onebrain")
+  vault_name=$(prompt_with_default 2 "Vault name?" "onebrain")
 
   # Validate: no spaces or path-breaking characters
   if [[ "$vault_name" =~ [[:space:]/\\] ]]; then
@@ -549,7 +552,7 @@ main() {
   fi
 
   echo
-  print_info "Vault will be created at: ${BOLD}${vault_path}${RESET}"
+  echo "${BOLD}${CYAN}Vault will be created at: ${vault_path}${RESET}"
   echo
 
   # ── Step 3: Download and extract ────────────────────────────────────────────
@@ -600,10 +603,15 @@ main() {
   fi
 
   # ── Step 4: Clean up installed vault ────────────────────────────────────────
-  # Remove install scripts from the vault — they shouldn't live there.
+  # Remove install scripts, README and assets from the vault — they belong to the repo, not the vault.
   # rm -f silently succeeds if they are absent; the if-guard catches permission errors only.
-  if ! rm -f "$vault_path/install.sh" "$vault_path/install.ps1"; then
-    print_error "Could not remove install scripts from '$vault_path'. Check directory permissions."
+  if ! rm -f "$vault_path/install.sh" "$vault_path/install.ps1" "$vault_path/README.md" \
+             "$vault_path/CONTRIBUTING.md" "$vault_path/LICENSE"; then
+    print_error "Could not remove repo files from '$vault_path'. Check directory permissions."
+    exit 1
+  fi
+  if ! rm -rf "$vault_path/assets"; then
+    print_error "Could not remove assets directory from '$vault_path'. Check directory permissions."
     exit 1
   fi
 
@@ -626,7 +634,8 @@ main() {
   echo
   print_success "Vault path: ${vault_path}"
   echo
-  echo "Next steps:"
+  echo "${BOLD}${CYAN}Next steps:${RESET}"
+  echo
   echo "  1. Open Obsidian"
   echo "     File → Open Folder as Vault → select: ${vault_path}"
   local step=2

--- a/install.sh
+++ b/install.sh
@@ -34,11 +34,11 @@ fi
 # ─── Banner ───────────────────────────────────────────────────────────────────
 print_banner() {
   echo
-  echo "${BLUE}${BOLD}  ___             ____            _       ${RESET}"
-  echo "${BLUE}${BOLD} / _ \\ _ __   ___| __ ) _ __ __ _(_)_ __  ${RESET}"
-  echo "${BLUE}${BOLD}| | | | '_ \\ / _ \\  _ \\| '__/ _\` | | '_ \\ ${RESET}"
-  echo "${BLUE}${BOLD}| |_| | | | |  __/ |_) | | | (_| | | | | |${RESET}"
-  echo "${BLUE}${BOLD} \\___/|_| |_|\\___|____/|_|  \\__,_|_|_| |_|${RESET}"
+  echo "${CYAN}${BOLD}  ___             ____            _       ${RESET}"
+  echo "${CYAN}${BOLD} / _ \\ _ __   ___| __ ) _ __ __ _(_)_ __  ${RESET}"
+  echo "${CYAN}${BOLD}| | | | '_ \\ / _ \\  _ \\| '__/ _\` | | '_ \\ ${RESET}"
+  echo "${CYAN}${BOLD}| |_| | | | |  __/ |_) | | | (_| | | | | |${RESET}"
+  echo "${CYAN}${BOLD} \\___/|_| |_|\\___|____/|_|  \\__,_|_|_| |_|${RESET}"
   echo
   echo "${YELLOW} > Think. Sync. OneBrain.${RESET}"
   echo


### PR DESCRIPTION
## Summary

- Replace the large 12-line block-character ASCII banner with a compact 5-line open letterform style in both `install.sh` and `install.ps1`
- Fix color inconsistencies between the two scripts: `print_info`, `print_success`, and `print_error` now apply color to the full message text, not just the icon prefix
- Align success section colors: "OneBrain is ready!" changed from blue+bold to green, vault path and "Next steps:" formatting now match `install.ps1`

## Test plan

- [ ] Run `bash install.sh` and verify the new banner renders correctly in blue with yellow tagline
- [ ] Run `install.ps1` on Windows and verify banner matches
- [ ] Confirm info/success/error messages display full-line color (cyan/green/red respectively)
- [ ] Confirm "OneBrain is ready!" appears in green on both platforms