### PR TITLE
feat: remove obsidian-skills bundling, point users to install independently

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,11 +8,6 @@
       "name": "onebrain",
       "source": "./.claude/plugins/onebrain",
       "description": "OneBrain — Where human and AI thinking become one"
-    },
-    {
-      "name": "obsidian",
-      "source": "./.claude/plugins/obsidian-skills",
-      "description": "Claude Skills for Obsidian — markdown, bases, canvas, CLI, and web extraction"
     }
   ]
 }

--- a/.claude/plugins/onebrain/skills/update/SKILL.md
+++ b/.claude/plugins/onebrain/skills/update/SKILL.md
@@ -17,7 +17,6 @@ Tell the user what will and won't be updated:
 **WILL update (system files only):**
 - `CLAUDE.md`, `GEMINI.md`, `AGENTS.md`, `.gitignore`
 - `.claude/plugins/onebrain/` — all skills, hooks, and agents
-- `.claude/plugins/obsidian-skills/` — Obsidian Skills plugin (kepano/obsidian-skills)
 - `.obsidian/plugins/` — bundled plugin files
 - `.obsidian/core-plugins.json`, `.obsidian/community-plugins.json`
 
@@ -222,46 +221,7 @@ For each key:
 
 ---
 
-## Step 5: Update Obsidian Skills Plugin
-
-Update the kepano/obsidian-skills plugin to the latest version.
-
-**If `.claude/plugins/obsidian-skills/` does NOT exist:**
-
-Ask the user:
-> The Obsidian Skills plugin is not installed. Would you like to install it now?
-
-If yes:
-1. Run: `git clone --depth 1 https://github.com/kepano/obsidian-skills.git .claude/plugins/obsidian-skills`
-   - If the clone fails: warn the user, clean up `obsidian-skills/` unconditionally (it may be partially created), and skip this step.
-2. Remove `.claude/plugins/obsidian-skills/.git`:
-   - If this fails: warn the user. Tell them to either remove the whole directory and re-run `/update` (`rm -rf .claude/plugins/obsidian-skills/`), or if they know the skill files are complete, remove only the nested `.git` (`rm -rf .claude/plugins/obsidian-skills/.git`). Skip this step.
-
-If no, skip this step.
-
-**If `.claude/plugins/obsidian-skills/` exists:**
-
-First check: if `.claude/plugins/obsidian-skills/.git` still exists (incomplete previous install), stop and tell the user to remove the whole directory and re-run `/update`: `rm -rf .claude/plugins/obsidian-skills/` — or, if the skill files are known complete, remove only the nested `.git`: `rm -rf .claude/plugins/obsidian-skills/.git`.
-
-Otherwise, since the `.git` directory was removed at install time, update by re-cloning to a temp location first, then swapping:
-
-1. Clone to temp: `git clone --depth 1 https://github.com/kepano/obsidian-skills.git .claude/plugins/obsidian-skills-new`
-   - If the clone fails: warn the user, keep the existing version intact, and stop. Clean up `obsidian-skills-new` unconditionally. If that cleanup also fails, warn the user to remove it manually (`rm -rf .claude/plugins/obsidian-skills-new`) before the next update attempt.
-
-2. Remove `.claude/plugins/obsidian-skills-new/.git`:
-   - If this fails: warn the user, keep the existing version intact, and stop. Clean up `obsidian-skills-new`.
-
-3. Delete `.claude/plugins/obsidian-skills/`:
-   - If this fails: warn the user, keep both directories, and stop. Tell the user to manually remove `obsidian-skills/` and rename `obsidian-skills-new` to `obsidian-skills`.
-
-4. Rename `obsidian-skills-new` → `obsidian-skills`:
-   - If this fails (e.g., cross-device move): warn the user that the old directory was removed and the new one is at `obsidian-skills-new`. Tell the user to manually rename it: `mv .claude/plugins/obsidian-skills-new .claude/plugins/obsidian-skills`
-
-Report: "Obsidian Skills plugin updated to latest version." on success, or the specific failure message if any step failed.
-
----
-
-## Step 6: Report
+## Step 5: Report
 
 Show a final summary of what was updated. Then suggest:
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -12,8 +12,7 @@
     ]
   },
   "enabledPlugins": {
-    "onebrain@onebrain-local": true,
-    "obsidian@onebrain-local": true
+    "onebrain@onebrain-local": true
   },
   "extraKnownMarketplaces": {
     "onebrain-local": {

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@ Thumbs.db
 # ── AI Agents ─────────────────────────────────────────────────────────────────
 .claude/settings.local.json
 .claude/onebrain.local.md
-.claude/plugins/obsidian-skills/
 
 # ── Git ───────────────────────────────────────────────────────────────────────
 .worktrees/

--- a/README.md
+++ b/README.md
@@ -237,7 +237,11 @@ These are recommended but optional:
 
 ### Claude Code Skills (Optional)
 
-For Obsidian-specific Claude Code skills (markdown, bases, canvas, and more), install the [Obsidian Skills](https://github.com/kepano/obsidian-skills) plugin separately by cloning it into your vault's `.claude/plugins/` directory.
+For Obsidian-specific Claude Code skills (markdown, bases, canvas, and more), install the [Obsidian Skills](https://github.com/kepano/obsidian-skills) plugin separately:
+
+```bash
+git clone --depth 1 https://github.com/kepano/obsidian-skills .claude/plugins/obsidian-skills
+```
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -235,6 +235,10 @@ These are recommended but optional:
 - **QuickAdd** — fast capture workflows
 - **Obsidian Git** — version control for your vault
 
+### Claude Code Skills (Optional)
+
+For Obsidian-specific Claude Code skills (markdown, bases, canvas, and more), install the [Obsidian Skills](https://github.com/kepano/obsidian-skills) plugin separately by cloning it into your vault's `.claude/plugins/` directory.
+
 </details>
 
 ---

--- a/install.ps1
+++ b/install.ps1
@@ -390,7 +390,7 @@ function Main {
       }
     }
 
-    # ── Step 4b: Install community plugins ──────────────────────────────────
+    # ── Step 4: Install community plugins ───────────────────────────────────
     $script:FailedPlugins = @(Install-Plugins $vaultPath)
 
   } catch {
@@ -439,7 +439,7 @@ function Main {
   Write-Host "     (Onboarding personalizes your vault and creates your folders)"
   $step++
   Write-Host "  $step. (Optional) Add Obsidian-specific Claude Code skills:"
-  Write-Host "     https://github.com/kepano/obsidian-skills" -ForegroundColor Cyan
+  Write-Host "     git clone --depth 1 https://github.com/kepano/obsidian-skills .claude\plugins\obsidian-skills" -ForegroundColor Cyan
   Write-Host
 }
 

--- a/install.ps1
+++ b/install.ps1
@@ -240,78 +240,6 @@ function Install-Plugins {
   return ,@($failedPlugins)
 }
 
-# ─── Obsidian Skills plugin (kepano/obsidian-skills) ─────────────────────────
-# Install-ObsidianSkills <VaultPath>
-# Shallow-clones kepano/obsidian-skills into .claude\plugins\obsidian-skills\
-# so the Obsidian-specific Claude Code skills from that repo are available
-# immediately after vault setup. See https://github.com/kepano/obsidian-skills
-# for the current skill list. Non-fatal: warns on failure and continues.
-# Idempotent: skips if directory already exists in a valid state.
-function Install-ObsidianSkills {
-  param([string]$VaultPath)
-
-  $targetDir = Join-Path $VaultPath ".claude\plugins\obsidian-skills"
-  $repoUrl   = "https://github.com/kepano/obsidian-skills.git"
-
-  # Already installed in a valid state — show confirmation and skip
-  if ((Test-Path $targetDir -PathType Container) -and
-      -not (Test-Path (Join-Path $targetDir ".git") -PathType Container)) {
-    Write-Done "Obsidian Skills already present"
-    return
-  }
-
-  # Partial install: directory exists but still has a .git (previous .git removal failed,
-  # or clone was interrupted before checkout completed). Remove the whole directory so the
-  # next run can retry cleanly — a partial clone's skill files may be incomplete too.
-  if ((Test-Path $targetDir -PathType Container) -and
-      (Test-Path (Join-Path $targetDir ".git") -PathType Container)) {
-    Write-Host "  ⚠️  Obsidian Skills: incomplete previous install — retrying..." -ForegroundColor Yellow
-    try {
-      Remove-Item -Path $targetDir -Recurse -Force -ErrorAction Stop
-    } catch {
-      Write-Host "  ❌ Obsidian Skills install failed" -ForegroundColor Red
-      Print-Info "Could not remove partial install at: $targetDir"
-      Print-Info "Remove it manually, then re-run the installer:"
-      Print-Info "  Remove-Item -Path `"$targetDir`" -Recurse -Force"
-      return  # Non-fatal — overall install continues without this plugin
-    }
-  }
-
-  # Clone the repo (shallow, quiet); join all output lines for readable error display
-  $cloneOutput = (git clone --depth 1 -q $repoUrl $targetDir 2>&1) -join "`n"
-  if ($LASTEXITCODE -ne 0) {
-    Write-Host "  ❌ Obsidian Skills install failed" -ForegroundColor Red
-    Print-Info "Could not clone obsidian-skills:"
-    Print-Info "  $cloneOutput"
-    # Clean up any partial directory git may have created before failing.
-    # Warn if removal fails so the user knows to clean up before retrying.
-    try {
-      Remove-Item -Path $targetDir -Recurse -Force -ErrorAction Stop
-    } catch {
-      Write-Host "  ⚠️  Could not remove partial clone at: $targetDir" -ForegroundColor Yellow
-      Print-Info "Remove it manually: Remove-Item -Path `"$targetDir`" -Recurse -Force"
-    }
-    Print-Info "You can install it later:"
-    Print-Info "  git clone --depth 1 $repoUrl `"$targetDir`""
-    return  # Non-fatal — overall install continues without this plugin
-  }
-
-  # Remove the nested .git so the parent repo does not treat this directory as
-  # an embedded repository. Without removal, 'git add' warns about an embedded
-  # repo and 'git status' silently ignores the subtree, which is confusing.
-  # The .gitignore entry suppresses tracking, but does not suppress the warning.
-  try {
-    Remove-Item -Path (Join-Path $targetDir ".git") -Recurse -Force -ErrorAction Stop
-  } catch {
-    Write-Host "  ❌ Obsidian Skills install failed" -ForegroundColor Red
-    Print-Info "Cloned obsidian-skills but could not remove its nested .git directory."
-    Print-Info "Without removing it, 'git add' will warn about an embedded repository."
-    Print-Info "Fix manually before running git commands in this vault:"
-    Print-Info "  Remove-Item -Path `"$targetDir\.git`" -Recurse -Force"
-    return  # Non-fatal — overall install continues without this plugin
-  }
-
-}
 
 # ─── Main ─────────────────────────────────────────────────────────────────────
 $script:FailedPlugins = @()
@@ -465,9 +393,6 @@ function Main {
     # ── Step 4b: Install community plugins ──────────────────────────────────
     $script:FailedPlugins = @(Install-Plugins $vaultPath)
 
-    # ── Step 4c: Install Obsidian Skills Claude plugin ───────────────────────
-    Install-ObsidianSkills $vaultPath
-
   } catch {
     # Sentinel "error:already-printed" means a specific message was already shown to the user.
     # Any other exception is unexpected and gets the generic fallback message.
@@ -512,6 +437,9 @@ function Main {
   Write-Host "  $step. Run the onboarding command:"
   Write-Host "     /onboarding" -ForegroundColor Cyan
   Write-Host "     (Onboarding personalizes your vault and creates your folders)"
+  $step++
+  Write-Host "  $step. (Optional) Add Obsidian-specific Claude Code skills:"
+  Write-Host "     https://github.com/kepano/obsidian-skills" -ForegroundColor Cyan
   Write-Host
 }
 

--- a/install.sh
+++ b/install.sh
@@ -401,71 +401,6 @@ install_plugins() {
   FAILED_PLUGINS=("${failed_plugins[@]}")
 }
 
-# ─── Obsidian Skills plugin (kepano/obsidian-skills) ─────────────────────────
-# install_obsidian_skills <vault_path>
-# Shallow-clones kepano/obsidian-skills into .claude/plugins/obsidian-skills/
-# so the Obsidian-specific Claude Code skills from that repo are available
-# immediately after vault setup. See https://github.com/kepano/obsidian-skills
-# for the current skill list. Non-fatal: warns on failure and continues.
-# Idempotent: skips if directory already exists in a valid state.
-install_obsidian_skills() {
-  local vault="$1"
-  local target_dir="$vault/.claude/plugins/obsidian-skills"
-  local repo_url="https://github.com/kepano/obsidian-skills.git"
-
-  # Already installed in a valid state — show confirmation and skip
-  if [ -d "$target_dir" ] && [ ! -d "$target_dir/.git" ]; then
-    print_success "Obsidian Skills already present"
-    return 0
-  fi
-
-  # Partial install: directory exists but still has a .git (previous .git removal failed,
-  # or clone was interrupted before checkout completed). Remove the whole directory so the
-  # next run can retry cleanly — a partial clone's skill files may be incomplete too.
-  if [ -d "$target_dir" ] && [ -d "$target_dir/.git" ]; then
-    print_error "Obsidian Skills: incomplete previous install"
-    print_info "${YELLOW}Found an incomplete obsidian-skills install. Removing and retrying...${RESET}"
-    if ! rm -rf "$target_dir"; then
-      print_info "${YELLOW}Could not remove partial install at:${RESET} $target_dir"
-      print_info "Remove it manually, then re-run the installer:"
-      print_info "  ${CYAN}rm -rf \"$target_dir\"${RESET}"
-      return 0  # Non-fatal — overall install continues without this plugin
-    fi
-  fi
-
-  # Capture both output and exit code; `if ! cmd=$(...)` discards $? after negation.
-  local clone_err clone_exit
-  clone_err=$(git clone --depth 1 -q "$repo_url" "$target_dir" 2>&1)
-  clone_exit=$?
-  if [ $clone_exit -ne 0 ]; then
-    print_error "Obsidian Skills install failed"
-    print_info "${YELLOW}Could not clone obsidian-skills (exit ${clone_exit}):${RESET}"
-    print_info "  ${clone_err:-no output from git}"
-    # Clean up any partial directory git may have created before failing.
-    # Warn if removal fails so the user knows to clean up before retrying.
-    if ! rm -rf "$target_dir"; then
-      print_info "${YELLOW}Could not remove partial clone at:${RESET} $target_dir"
-      print_info "Remove it manually: ${CYAN}rm -rf \"$target_dir\"${RESET}"
-    fi
-    print_info "You can install it later:"
-    print_info "  ${CYAN}git clone --depth 1 $repo_url \"$target_dir\"${RESET}"
-    return 0  # Non-fatal — overall install continues without this plugin
-  fi
-
-  # Remove the nested .git so the parent repo does not treat this directory as
-  # an embedded repository. Without removal, 'git add' warns about an embedded
-  # repo and 'git status' silently ignores the subtree, which is confusing.
-  # The .gitignore entry suppresses tracking, but does not suppress the warning.
-  if ! rm -rf "$target_dir/.git"; then
-    print_error "Obsidian Skills install failed"
-    print_info "${YELLOW}Cloned obsidian-skills but could not remove its nested .git directory.${RESET}"
-    print_info "Without removing it, 'git add' will warn about an embedded repository."
-    print_info "Fix manually before running git commands in this vault:"
-    print_info "  ${CYAN}rm -rf \"$target_dir/.git\"${RESET}"
-    return 0  # Non-fatal — overall install continues without this plugin
-  fi
-
-}
 
 # ─── Main ─────────────────────────────────────────────────────────────────────
 FAILED_PLUGINS=()
@@ -625,9 +560,6 @@ main() {
   # ── Step 4b: Install community plugins ──────────────────────────────────
   install_plugins "$vault_path"
 
-  # ── Step 4c: Install Obsidian Skills Claude plugin ───────────────────────
-  install_obsidian_skills "$vault_path"
-
   # ── Step 5: Success ──────────────────────────────────────────────────────────
   echo
   echo "${GREEN}  $ICON_DONE OneBrain is ready!${RESET}"
@@ -655,6 +587,9 @@ main() {
   echo "  ${step}. Run the onboarding command:"
   echo "     ${CYAN}/onboarding${RESET}"
   echo "     (Onboarding personalizes your vault and creates your folders)"
+  step=$((step + 1))
+  echo "  ${step}. (Optional) Add Obsidian-specific Claude Code skills:"
+  echo "     ${CYAN}https://github.com/kepano/obsidian-skills${RESET}"
   echo
 }
 

--- a/install.sh
+++ b/install.sh
@@ -557,7 +557,7 @@ main() {
     exit 1
   fi
 
-  # ── Step 4b: Install community plugins ──────────────────────────────────
+  # ── Step 4: Install community plugins ───────────────────────────────────
   install_plugins "$vault_path"
 
   # ── Step 5: Success ──────────────────────────────────────────────────────────
@@ -589,7 +589,7 @@ main() {
   echo "     (Onboarding personalizes your vault and creates your folders)"
   step=$((step + 1))
   echo "  ${step}. (Optional) Add Obsidian-specific Claude Code skills:"
-  echo "     ${CYAN}https://github.com/kepano/obsidian-skills${RESET}"
+  echo "     ${CYAN}git clone --depth 1 https://github.com/kepano/obsidian-skills .claude/plugins/obsidian-skills${RESET}"
   echo
 }
 


### PR DESCRIPTION
## Summary

- Removes the `obsidian` plugin entry from the local marketplace (`marketplace.json`) — the path `./.claude/plugins/obsidian-skills` resolved relative to the repo root where the directory doesn't exist, causing a \"Plugin directory not found\" error on startup
- Removes `install_obsidian_skills` / `Install-ObsidianSkills` functions from both installers and the Step 4c call sites
- Removes the obsidian-skills update logic (Step 5) from the `/update` skill
- Removes `obsidian@onebrain-local` from `settings.json` and the `.gitignore` entry
- Adds an optional "Next steps" note in both installers pointing users to https://github.com/kepano/obsidian-skills
- Adds a brief optional section in README pointing users to install obsidian-skills independently

## Test plan

- [ ] Restart Claude Code in the repo — confirm no "Plugin directory not found" error
- [ ] Run `grep -r "obsidian-skills" .` — only URL references in README and installers should remain (no config/install code)
- [ ] Run the bash installer end-to-end — confirm "Next steps" numbering is correct and the optional obsidian-skills line appears
- [ ] Confirm `/update` skill reads cleanly with no obsidian-skills references

🤖 Generated with [Claude Code](https://claude.com/claude-code)