### PR TITLE
feat: require AskUserQuestion tool for user input

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,4 +160,4 @@ If conditions are met:
 - Do not ask for confirmation when fetching URLs or performing web searches
 - Do not ask for confirmation when running git commands
 - Always proceed with file and web operations autonomously within this vault
-- When you need user input to proceed, always use the AskUserQuestion tool — do not ask via freetext in the response
+- When user input is required to proceed, use the AskUserQuestion tool — never ask questions via freetext in the response

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,3 +160,4 @@ If conditions are met:
 - Do not ask for confirmation when fetching URLs or performing web searches
 - Do not ask for confirmation when running git commands
 - Always proceed with file and web operations autonomously within this vault
+- When you need user input to proceed, always use the AskUserQuestion tool — do not ask via freetext in the response


### PR DESCRIPTION
## Summary
- Adds a rule to the Permissions section of CLAUDE.md requiring the agent to use the `AskUserQuestion` tool when user input is needed
- Prevents asking questions via freetext in the response, ensuring input is properly captured through the structured tool

## Test plan
- [ ] Verify rule appears in CLAUDE.md Permissions section
- [ ] Confirm agent uses AskUserQuestion tool in subsequent sessions when clarification is needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)