### PR TITLE
fix: migrate onebrain-local plugin key + update CONTRIBUTING.md

### DIFF
--- a/.claude/plugins/onebrain/.claude-plugin/plugin.json
+++ b/.claude/plugins/onebrain/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "onebrain",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "OneBrain — Where human and AI thinking become one. A powerful thinking partner powered by AI synergy.",
   "author": {
     "name": "OneBrain Contributors"

--- a/.claude/plugins/onebrain/.claude-plugin/plugin.json
+++ b/.claude/plugins/onebrain/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "onebrain",
-  "version": "1.3.1",
+  "version": "1.3.0",
   "description": "OneBrain — Where human and AI thinking become one. A powerful thinking partner powered by AI synergy.",
   "author": {
     "name": "OneBrain Contributors"

--- a/.claude/plugins/onebrain/skills/update/SKILL.md
+++ b/.claude/plugins/onebrain/skills/update/SKILL.md
@@ -271,17 +271,27 @@ For each key:
 
 ## Step 4d: Migrate Plugin Key (onebrain-local → onebrain)
 
-The OneBrain marketplace was renamed from `onebrain-local` to `onebrain` in v1.3.0. Existing installations may still have the old plugin key `onebrain@onebrain-local` in their Claude Code settings. This step migrates the key to `onebrain@onebrain`.
+The OneBrain marketplace was renamed from `onebrain-local` to `onebrain` in v1.3.0. Existing installations may still have stale keys in their Claude Code settings. This step migrates both affected keys.
 
-Check the following settings files for the stale key:
+Check the following settings files:
 - `.claude/settings.json` (project-level)
 - `.claude/settings.local.json` (project-level local)
 
-For each file that exists:
-1. Read the file and check if it contains `"onebrain@onebrain-local"` as a key inside `enabledPlugins` or any other plugin-related object.
-2. **If found:** Replace every occurrence of `"onebrain@onebrain-local"` with `"onebrain@onebrain"` (read → modify → write back the full file). Report: "Migrated plugin key `onebrain@onebrain-local` → `onebrain@onebrain` in `[file]`."
-3. **If not found:** Skip silently.
-4. **If write fails:** Report the error and tell the user to manually rename the key in `[file]`.
+For each file that exists, perform two replacements in a single read → modify → write pass:
+
+**Replacement 1 — `enabledPlugins` key:**
+- Find: `"onebrain@onebrain-local"` (as a key or value)
+- Replace with: `"onebrain@onebrain"`
+
+**Replacement 2 — `extraKnownMarketplaces` key:**
+- Find: `"onebrain-local"` (as a top-level key inside `extraKnownMarketplaces`)
+- Replace with: `"onebrain"`
+
+For each file:
+1. Read the file and check for either stale string.
+2. **If either found:** Apply both replacements (read → modify → write back the full file). Report: "Migrated stale marketplace keys in `[file]`."
+3. **If neither found:** Skip silently.
+4. **If write fails:** Report the error and tell the user to manually rename the keys in `[file]`.
 
 ---
 

--- a/.claude/plugins/onebrain/skills/update/SKILL.md
+++ b/.claude/plugins/onebrain/skills/update/SKILL.md
@@ -269,6 +269,22 @@ For each key:
 
 ---
 
+## Step 4d: Migrate Plugin Key (onebrain-local → onebrain)
+
+The OneBrain marketplace was renamed from `onebrain-local` to `onebrain` in v1.3.0. Existing installations may still have the old plugin key `onebrain@onebrain-local` in their Claude Code settings. This step migrates the key to `onebrain@onebrain`.
+
+Check the following settings files for the stale key:
+- `.claude/settings.json` (project-level)
+- `.claude/settings.local.json` (project-level local)
+
+For each file that exists:
+1. Read the file and check if it contains `"onebrain@onebrain-local"` as a key inside `enabledPlugins` or any other plugin-related object.
+2. **If found:** Replace every occurrence of `"onebrain@onebrain-local"` with `"onebrain@onebrain"` (read → modify → write back the full file). Report: "Migrated plugin key `onebrain@onebrain-local` → `onebrain@onebrain` in `[file]`."
+3. **If not found:** Skip silently.
+4. **If write fails:** Report the error and tell the user to manually rename the key in `[file]`.
+
+---
+
 ## Step 5: Report
 
 Show a final summary of what was updated. Then suggest:

--- a/.claude/plugins/onebrain/skills/update/SKILL.md
+++ b/.claude/plugins/onebrain/skills/update/SKILL.md
@@ -277,21 +277,25 @@ Check the following settings files:
 - `.claude/settings.json` (project-level)
 - `.claude/settings.local.json` (project-level local)
 
-For each file that exists, perform two replacements in a single read → modify → write pass:
+For each file that exists:
+1. Read the file. **If read fails:** Report the error and tell the user to manually rename the keys in `[file]`. Continue to the next file.
+2. Parse as JSON. **If the file is not valid JSON:** Report the parse error and skip this file. Continue to the next file.
+3. Check for either stale key.
+4. **If neither found:** Skip silently.
+5. **If either found:** Apply both changes to the parsed JSON structure (read → modify → write back):
 
-**Replacement 1 — `enabledPlugins` key:**
-- Find: `"onebrain@onebrain-local"` (as a key or value)
-- Replace with: `"onebrain@onebrain"`
+**Change 1 — `enabledPlugins`:**
+- If `"onebrain@onebrain-local"` exists as a key and `"onebrain@onebrain"` does NOT exist: rename the key.
+- If both keys exist: remove `"onebrain@onebrain-local"` (keep the new key, avoid duplicates).
+- If only `"onebrain@onebrain"` exists: skip (already migrated).
 
-**Replacement 2 — `extraKnownMarketplaces` key:**
-- Find: `"onebrain-local"` (as a top-level key inside `extraKnownMarketplaces`)
-- Replace with: `"onebrain"`
+**Change 2 — `extraKnownMarketplaces`:**
+- If `"onebrain-local"` exists as a key and `"onebrain"` does NOT exist: rename the key.
+- If both keys exist: remove `"onebrain-local"` (keep the new key, avoid duplicates).
+- If only `"onebrain"` exists: skip (already migrated).
 
-For each file:
-1. Read the file and check for either stale string.
-2. **If either found:** Apply both replacements (read → modify → write back the full file). Report: "Migrated stale marketplace keys in `[file]`."
-3. **If neither found:** Skip silently.
-4. **If write fails:** Report the error and tell the user to manually rename the keys in `[file]`.
+6. Write the full modified file back. **If write fails:** Report the error and tell the user to manually rename the keys in `[file]`. Continue to the next file.
+7. **On success:** Report: "Migrated stale marketplace keys in `[file]`."
 
 ---
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -12,10 +12,10 @@
     ]
   },
   "enabledPlugins": {
-    "onebrain@onebrain-local": true
+    "onebrain@onebrain": true
   },
   "extraKnownMarketplaces": {
-    "onebrain-local": {
+    "onebrain": {
       "source": {
         "source": "directory",
         "path": "."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,12 +86,32 @@ Hooks run shell commands automatically when Claude performs certain actions. Hoo
 
 **Available hook events:**
 
-| Event | Fires when |
-|-------|-----------|
-| `PostToolUse` | After any tool call (filterable by tool name) |
-| `PreToolUse` | Before any tool call (can block execution) |
-| `Stop` | When Claude finishes responding |
-| `SessionStart` | At the start of a new session |
+| Event | Fires when | Can block? |
+|-------|-----------|------------|
+| `PreToolUse` | Before a tool call executes | Yes |
+| `PostToolUse` | After a tool call succeeds | No |
+| `PostToolUseFailure` | After a tool call fails | No |
+| `PermissionRequest` | When a permission dialog appears | Yes |
+| `UserPromptSubmit` | When user submits a prompt, before Claude processes it | Yes |
+| `Stop` | When Claude finishes responding | Yes |
+| `StopFailure` | When turn ends due to an API error | No |
+| `SessionStart` | When a session begins or resumes | No |
+| `SessionEnd` | When a session terminates | No |
+| `InstructionsLoaded` | When CLAUDE.md or `.claude/rules/*.md` files are loaded | No |
+| `SubagentStart` | When a subagent is spawned | No |
+| `SubagentStop` | When a subagent finishes | Yes |
+| `PreCompact` | Before context compaction | No |
+| `PostCompact` | After context compaction completes | No |
+| `Notification` | When Claude Code sends a notification | No |
+| `ConfigChange` | When a configuration file changes during a session | Yes |
+| `WorktreeCreate` | When a worktree is being created | Yes |
+| `WorktreeRemove` | When a worktree is being removed | No |
+| `TeammateIdle` | When an agent team teammate is about to go idle | Yes |
+| `TaskCompleted` | When a task is being marked as completed | Yes |
+| `Elicitation` | When an MCP server requests user input during a tool call | Yes |
+| `ElicitationResult` | After user responds to MCP elicitation | Yes |
+
+Most hooks support a `matcher` field to filter by tool name or event subtype. `UserPromptSubmit`, `Stop`, `TeammateIdle`, `TaskCompleted`, `WorktreeCreate`, and `WorktreeRemove` fire on every occurrence and do not support matchers.
 
 **To add a hook:**
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,8 @@ Good contributions include:
 .claude/plugins/onebrain/                Main plugin directory
 ├── .claude-plugin/
 │   └── plugin.json                      Plugin manifest (name, version, description)
-├── skills/                              One directory per slash command (17 skills)
+├── INSTRUCTIONS.md                      Agent instructions — loaded by CLAUDE.md/GEMINI.md/AGENTS.md
+├── skills/                              One directory per slash command (18 skills)
 │   └── [name]/
 │       └── SKILL.md                     The skill prompt — what the AI follows when invoked
 ├── hooks/
@@ -44,10 +45,10 @@ Skills are plain Markdown files. The AI reads them at runtime — no compilation
    ---
    ```
 
-   No `triggers:` field is needed. Skill routing is handled by the command tables in `CLAUDE.md`, `GEMINI.md`, and `AGENTS.md` — register your command there (see step 4).
+   No `triggers:` field is needed. Skill routing is handled by the command table in `.claude/plugins/onebrain/INSTRUCTIONS.md` — register your command there (see step 4).
 
 3. Write the skill as a numbered sequence of steps the AI should follow
-4. Register the command in `CLAUDE.md`, `GEMINI.md`, `AGENTS.md`, and `README.md` (also increment the command count in the "What It Does" section of README.md)
+4. Register the command in `.claude/plugins/onebrain/INSTRUCTIONS.md` and `README.md` (also increment the command count in the README feature list)
 
 ## Editing an Existing Skill
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,6 +58,68 @@ Skills are plain Markdown files. The AI reads them at runtime — no compilation
 - Prefer adding steps over removing them — removals can break workflows users depend on
 - Test manually: open a vault, invoke the command, follow it through
 
+## Adding a New Agent
+
+Agents are specialized subprocesses invoked by skills for focused, autonomous tasks. The existing example is [`knowledge-linker.md`](.claude/plugins/onebrain/agents/knowledge-linker.md), used by `/connect`.
+
+1. Create `.claude/plugins/onebrain/agents/[agent-name].md`
+2. Add YAML frontmatter:
+
+   ```yaml
+   ---
+   name: Agent Display Name
+   description: One-line description — when this agent should be invoked
+   color: blue
+   ---
+   ```
+
+   Supported colors: `blue`, `green`, `red`, `yellow`, `purple`, `orange`.
+
+3. Write the agent's system prompt — its role, process, and output format
+4. Invoke the agent from a skill using the Agent tool, passing it the task context
+
+Agents are stateless — they receive context from the invoking skill and return a result. Keep them focused on a single task.
+
+## Adding a New Hook
+
+Hooks run shell commands automatically when Claude performs certain actions. Hook configuration lives in [`hooks.json`](.claude/plugins/onebrain/hooks/hooks.json). Shell scripts go in the same `hooks/` directory.
+
+**Available hook events:**
+
+| Event | Fires when |
+|-------|-----------|
+| `PostToolUse` | After any tool call (filterable by tool name) |
+| `PreToolUse` | Before any tool call (can block execution) |
+| `Stop` | When Claude finishes responding |
+| `SessionStart` | At the start of a new session |
+
+**To add a hook:**
+
+1. Add an entry to [hooks.json](.claude/plugins/onebrain/hooks/hooks.json):
+
+   ```json
+   {
+     "hooks": {
+       "PostToolUse": [
+         {
+           "matcher": "Write|Edit",
+           "hooks": [
+             {
+               "type": "command",
+               "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/your-hook.sh\"",
+               "async": true
+             }
+           ]
+         }
+       ]
+     }
+   }
+   ```
+
+2. Create the corresponding script in `.claude/plugins/onebrain/hooks/`. Use `${CLAUDE_PLUGIN_ROOT}` to reference other files in the plugin directory. For cross-platform support, provide both `.sh` (macOS/Linux) and `.ps1` (Windows) variants and chain them with `||`.
+
+3. Make scripts defensive — they run on every matching tool call, so they should exit silently if there's nothing to do.
+
 ## Install Scripts
 
 - [`install.sh`](install.sh) — bash, targets macOS and Linux

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,8 @@ Good contributions include:
     └── knowledge-linker.md              Knowledge graph agent (used by /connect)
 ```
 
+Key files: [marketplace.json](.claude-plugin/marketplace.json) · [plugin.json](.claude/plugins/onebrain/.claude-plugin/plugin.json) · [INSTRUCTIONS.md](.claude/plugins/onebrain/INSTRUCTIONS.md) · [hooks.json](.claude/plugins/onebrain/hooks/hooks.json)
+
 Skills are plain Markdown files. The AI reads them at runtime — no compilation or build step.
 
 ## Adding a New Skill
@@ -45,10 +47,10 @@ Skills are plain Markdown files. The AI reads them at runtime — no compilation
    ---
    ```
 
-   No `triggers:` field is needed. Skill routing is handled by the command table in `.claude/plugins/onebrain/INSTRUCTIONS.md` — register your command there (see step 4).
+   No `triggers:` field is needed. Skill routing is handled by the command table in [INSTRUCTIONS.md](.claude/plugins/onebrain/INSTRUCTIONS.md) — register your command there (see step 4).
 
 3. Write the skill as a numbered sequence of steps the AI should follow
-4. Register the command in `.claude/plugins/onebrain/INSTRUCTIONS.md` and `README.md` (also increment the command count in the README feature list)
+4. Register the command in [INSTRUCTIONS.md](.claude/plugins/onebrain/INSTRUCTIONS.md) and [README.md](README.md) (also increment the command count in the README feature list)
 
 ## Editing an Existing Skill
 
@@ -58,8 +60,8 @@ Skills are plain Markdown files. The AI reads them at runtime — no compilation
 
 ## Install Scripts
 
-- `install.sh` — bash, targets macOS and Linux
-- `install.ps1` — PowerShell 5+, targets Windows
+- [`install.sh`](install.sh) — bash, targets macOS and Linux
+- [`install.ps1`](install.ps1) — PowerShell 5+, targets Windows
 
 Both scripts download the repo tarball, extract it, remove themselves from the vault, and install community plugins. Keep them simple — vault setup belongs in `/onboarding`, not here.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 **🧠 Memory across sessions** — Your AI remembers your name, goals, preferences, and past conversations. Every session picks up where the last one left off.
 
-**⚡ 18 slash commands** — Braindump, capture, research, consolidate, connect, bookmark, import files, and more. Capture an idea or deep-research a topic in seconds.
+**⚡ 18 slash commands and counting** — Braindump, capture, research, consolidate, connect, bookmark, import files, and more. More skills coming soon — capture an idea or deep-research a topic in seconds.
 
 **📂 Vault-native Markdown** — Every note is plain Markdown. No lock-in, no proprietary format. Your data stays in your vault, forever.
 


### PR DESCRIPTION
## Summary

- **Step 4d in `/update`**: After the marketplace rename from `onebrain-local` → `onebrain` in v1.3.0, existing installs have a stale `onebrain@onebrain-local` key in their `enabledPlugins` settings. This step migrates it to `onebrain@onebrain` in both `.claude/settings.json` and `.claude/settings.local.json`
- **CONTRIBUTING.md**: Add `INSTRUCTIONS.md` to the project structure tree; fix skill count 17 → 18; update step 4 to reference `INSTRUCTIONS.md` instead of `CLAUDE.md`/`GEMINI.md`/`AGENTS.md` (those are now single-line `@import` pointers since v1.3.0)
- **Version bump**: 1.3.0 → 1.3.1

## Test plan

- [ ] On an install that still has `"onebrain@onebrain-local": true` in settings, run `/update` — key should migrate to `onebrain@onebrain`
- [ ] On a clean install with `"onebrain@onebrain"`, run `/update` — skip silently
- [ ] Verify CONTRIBUTING.md project structure matches actual repo layout