### PR TITLE
feat: add live Obsidian task dashboard to /tasks with keyword filtering

### DIFF
--- a/.claude/plugins/onebrain/.claude-plugin/plugin.json
+++ b/.claude/plugins/onebrain/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "onebrain",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "OneBrain — Where human and AI thinking become one. A powerful thinking partner powered by AI synergy.",
   "author": {
     "name": "OneBrain Contributors"

--- a/.claude/plugins/onebrain/INSTRUCTIONS.md
+++ b/.claude/plugins/onebrain/INSTRUCTIONS.md
@@ -37,7 +37,7 @@ Use these priority markers when relevant:
 - `⏫` Medium priority
 - `🔽` Low priority
 
-Tasks live inline in project/knowledge notes — never in a standalone tasks file.
+Tasks live inline in project/knowledge notes — never author tasks directly in a standalone file. `TASKS.md` at the vault root is a read-only dashboard (live query blocks), not a place to create tasks.
 
 ## Note Linking
 

--- a/.claude/plugins/onebrain/INSTRUCTIONS.md
+++ b/.claude/plugins/onebrain/INSTRUCTIONS.md
@@ -82,7 +82,7 @@ These workflows are documented in `.claude/plugins/onebrain/skills/`:
 | `/import` | `import/SKILL.md` | Import local files (PDF, docs, images, scripts) → vault notes |
 | `/reading-notes` | `reading-notes/SKILL.md` | Book/article → structured notes |
 | `/weekly` | `weekly/SKILL.md` | Weekly reflection |
-| `/tasks` | `tasks/SKILL.md` | Task dashboard — overdue, due soon, open, completed |
+| `/tasks` | `tasks/SKILL.md` | Open live task dashboard in Obsidian — optionally filter by keyword (e.g., `/tasks project-name`) |
 | `/wrapup` | `wrapup/SKILL.md` | Wrap up session → session log |
 | `/learn` | `learn/SKILL.md` | Teach the agent — facts or behavioral preferences |
 | `/clone` | `clone/SKILL.md` | Package agent context for vault transfer |

--- a/.claude/plugins/onebrain/INSTRUCTIONS.md
+++ b/.claude/plugins/onebrain/INSTRUCTIONS.md
@@ -82,7 +82,7 @@ These workflows are documented in `.claude/plugins/onebrain/skills/`:
 | `/import` | `import/SKILL.md` | Import local files (PDF, docs, images, scripts) → vault notes |
 | `/reading-notes` | `reading-notes/SKILL.md` | Book/article → structured notes |
 | `/weekly` | `weekly/SKILL.md` | Weekly reflection |
-| `/tasks` | `tasks/SKILL.md` | Open live task dashboard in Obsidian — optionally filter by keyword (e.g., `/tasks project-name`) |
+| `/tasks` | `tasks/SKILL.md` | Create or update live task dashboard (TASKS.md) and open in Obsidian — optionally filter by keyword (e.g., `/tasks project-name`) |
 | `/wrapup` | `wrapup/SKILL.md` | Wrap up session → session log |
 | `/learn` | `learn/SKILL.md` | Teach the agent — facts or behavioral preferences |
 | `/clone` | `clone/SKILL.md` | Package agent context for vault transfer |

--- a/.claude/plugins/onebrain/skills/help/SKILL.md
+++ b/.claude/plugins/onebrain/skills/help/SKILL.md
@@ -23,7 +23,7 @@ Display a formatted table with all available commands:
 | `/summarize` | Fetch a URL and create a structured summary note | When you want to deeply process an article or page into a permanent vault note |
 | `/import` | Import local files (PDF, Word, Excel, images, video, scripts) into vault notes | When you have files on disk you want distilled into your knowledge base |
 | `/reading-notes` | Book or article → structured progressive summary | When finishing a book or long article and want to capture it |
-| `/tasks` | Task dashboard — overdue, due soon, open, completed | When you want an overview of what needs doing |
+| `/tasks` | Open live task dashboard in Obsidian — creates/updates `TASKS.md` with live query sections. Filter with `/tasks <keyword>` | When you want an overview of what needs doing, or to focus on a specific project |
 | `/weekly` | Weekly reflection — review sessions, patterns, intentions | At the end of each week for review and planning |
 | `/wrapup` | Save a session summary to your session log | At the end of a work session to capture what you did |
 | `/learn` | Teach the agent something — facts about your world or behavioral preferences | When you want the agent to remember something across all future sessions |

--- a/.claude/plugins/onebrain/skills/tasks/SKILL.md
+++ b/.claude/plugins/onebrain/skills/tasks/SKILL.md
@@ -17,7 +17,7 @@ Usage:
 
 Read `vault.yml` from the current working directory. The directory containing `vault.yml` is the vault root. If `vault.yml` does not exist, warn the user:
 
-> "vault.yml not found — using current working directory as vault root: `<cwd>`. Run `/onboarding` to set up your vault configuration."
+> "vault.yml not found — using current working directory as vault root: [path]. Run `/onboarding` to set up your vault configuration."
 
 Then proceed with cwd as vault root.
 
@@ -65,7 +65,7 @@ updated: YYYY-MM-DD
 > sort by due
 > ```
 
-> [!note] All Open
+> [!note] Unscheduled
 > ```tasks
 > not done
 > no due date
@@ -91,7 +91,7 @@ updated: YYYY-MM-DD
 
 If the write fails, stop immediately and tell the user:
 
-> "Could not create TASKS.md at `<tasks_path>`. Error: `<error>`. Check that the vault path is correct and that you have write permission. Vault root used: `<vault_root>`"
+> "Could not create TASKS.md at [tasks_path]. Error: [error]. Check that the vault path is correct and that you have write permission. Vault root used: [vault_root]"
 
 Do not proceed to Steps 4, 5, or 6 if the write failed.
 
@@ -99,10 +99,8 @@ Do not proceed to Steps 4, 5, or 6 if the write failed.
 
 Read the file. Check the `updated:` value in frontmatter:
 - If `updated:` already equals today's date → skip the frontmatter write (no-op)
-- If `updated:` key is missing entirely → add `updated: YYYY-MM-DD` before the closing `---`
-- Otherwise → update only the `updated: YYYY-MM-DD` line to today's date using the Edit tool
-
-If the edit fails, stop and report the error to the user. Do not proceed.
+- If `updated:` key is missing entirely → add `updated: YYYY-MM-DD` before the closing `---`. If this edit fails, stop and report the error to the user. Do not proceed.
+- Otherwise → update only the `updated: YYYY-MM-DD` line to today's date using the Edit tool. If the edit fails, stop and report the error to the user. Do not proceed.
 
 ---
 
@@ -115,27 +113,27 @@ Look for an existing `> [!search]` callout block in TASKS.md (a line that starts
 - If found: replace the entire `> [!search]` block (all consecutive `> ` prefixed lines that follow it, until the first non-`> ` line or blank line) with the new block below
 - If not found: insert the block immediately before the `# Task Dashboard` heading line (preserve any blank line that already exists between the frontmatter `---` and the heading; insert the block between that blank line and the heading)
 
-Insert/replace with (replace `<keyword>` with the actual keyword text):
+Insert/replace with (substitute the actual keyword text for `<keyword>`):
 
 ```
 > [!search] Filtered: "<keyword>"
 > _Matches tasks where description or path contains "<keyword>"_
 > ```tasks
 > not done
-> (description includes <keyword>) OR (path includes <keyword>)
+> (description includes "<keyword>") OR (path includes "<keyword>")
 > sort by priority
 > sort by due
 > ```
 
 ```
 
-(Note: `[!search]` is not a native Obsidian callout type — it renders as a generic note style, which is intentional. Include a blank line after the closing ` ``` ` before the next section.)
+(Note: `[!search]` is not a native Obsidian callout type — it renders as a generic note style, which is intentional. Keyword is quoted in the query to support multi-word searches. Include a blank line after the closing ` ``` ` before the next section.)
 
-If the edit fails, stop and report the error to the user.
+If the edit fails, stop and report the error to the user. Do not proceed.
 
 **If no keyword:**
 
-Check if a `> [!search]` callout block exists in TASKS.md. If it does, remove it entirely (including the blank line that follows it). If the removal fails, report the error to the user.
+Check if a `> [!search]` callout block exists in TASKS.md. If it does, remove it entirely — including the blank line that follows it and the blank line that precedes it (to avoid leaving a double blank line between the frontmatter `---` and the `# Task Dashboard` heading). If the removal fails, report the error to the user and do not proceed.
 
 ---
 
@@ -144,11 +142,11 @@ Check if a `> [!search]` callout block exists in TASKS.md. If it does, remove it
 Build the `obsidian://` URI using path-based addressing:
 
 1. Take the absolute path to `TASKS.md`
-2. URL-encode it, keeping `/` and `:` as literal characters (do not percent-encode them):
+2. URL-encode it, keeping `/`, `:`, and `@` as literal characters (do not percent-encode them):
    - Priority order: Python3 first, then Node.js
-   - Python3: `urllib.parse.quote(path, safe='/:')`
-   - Node.js: `encodeURIComponent(path).replace(/%2F/gi, '/').replace(/%3A/gi, ':')`
-   - If neither runtime is available, warn the user: "Could not URL-encode the path — open TASKS.md manually in Obsidian." Then skip to Step 6 with the failure branch.
+   - Python3: `urllib.parse.quote(path, safe='/:@')`
+   - Node.js: `encodeURIComponent(path).replace(/%2F/gi, '/').replace(/%3A/gi, ':').replace(/%40/gi, '@')`
+   - If neither runtime is available: go to Step 6 encoding-failure branch (do not attempt to open)
 3. `uri = "obsidian://open?path=" + encoded_path`
 
 Open via Bash based on platform (detect from `$OSTYPE`). Capture the exit code:
@@ -159,7 +157,7 @@ Open via Bash based on platform (detect from `$OSTYPE`). Capture the exit code:
 
 **If the open command succeeds (exit code 0):** proceed to Step 6 success branch.
 
-**If the open command fails (non-zero exit code):** proceed to Step 6 failure branch. Do not suppress the failure.
+**If the open command fails (non-zero exit code):** proceed to Step 6 open-failure branch.
 
 ---
 
@@ -169,7 +167,7 @@ Open via Bash based on platform (detect from `$OSTYPE`). Capture the exit code:
 - With keyword: `TASKS.md opened in Obsidian — filtered by "<keyword>".`
 - Without keyword: `TASKS.md opened in Obsidian.`
 
-**Failure (open command failed or encoding unavailable):**
+**Open-failure (open command returned non-zero, encoding succeeded):**
 
 > "TASKS.md was updated but could not be opened automatically in Obsidian.
 >
@@ -178,3 +176,9 @@ Open via Bash based on platform (detect from `$OSTYPE`). Capture the exit code:
 > - Via URI: `obsidian://open?path=<encoded_path>`
 >
 > If Obsidian is not installed, visit https://obsidian.md"
+
+**Encoding-failure (no Python3 or Node.js available):**
+
+> "TASKS.md was updated but could not be opened automatically — URL encoding is unavailable on this system (Python3 and Node.js both missing).
+>
+> Open it manually in Obsidian by navigating to `TASKS.md` in your vault."

--- a/.claude/plugins/onebrain/skills/tasks/SKILL.md
+++ b/.claude/plugins/onebrain/skills/tasks/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: tasks
-description: Open the live task dashboard in Obsidian (creates TASKS.md if needed). Optionally filter by keyword.
+description: Create or update the live task dashboard (TASKS.md) in Obsidian and open it. Optionally filter by keyword.
 ---
 
 # Task Dashboard
 
-Opens a live task dashboard (`TASKS.md`) in Obsidian. The file uses Obsidian Tasks plugin query blocks — always current, no vault scanning needed.
+Creates or updates a permanent `TASKS.md` at the vault root using Obsidian Tasks plugin live query blocks, then opens it in Obsidian. The file is always current — no vault scanning needed.
 
 Usage:
 - `/tasks` — open the full dashboard
@@ -13,9 +13,13 @@ Usage:
 
 ---
 
-## Step 1: Read vault.yml
+## Step 1: Locate vault root
 
-Read `vault.yml` from the vault root to confirm the vault root path. If vault.yml does not exist, use the current working directory as the vault root.
+Read `vault.yml` from the current working directory. The directory containing `vault.yml` is the vault root. If `vault.yml` does not exist, warn the user:
+
+> "vault.yml not found — using current working directory as vault root: `<cwd>`. Run `/onboarding` to set up your vault configuration."
+
+Then proceed with cwd as vault root.
 
 ---
 
@@ -64,9 +68,8 @@ updated: YYYY-MM-DD
 > [!note] All Open
 > ```tasks
 > not done
-> ((no due date) OR (due after in 7 days))
+> no due date
 > sort by priority
-> sort by due
 > ```
 
 > [!tip] Due Later
@@ -86,11 +89,20 @@ updated: YYYY-MM-DD
 > ```
 ```
 
+If the write fails, stop immediately and tell the user:
+
+> "Could not create TASKS.md at `<tasks_path>`. Error: `<error>`. Check that the vault path is correct and that you have write permission. Vault root used: `<vault_root>`"
+
+Do not proceed to Steps 4, 5, or 6 if the write failed.
+
 **If TASKS.md already exists:**
 
 Read the file. Check the `updated:` value in frontmatter:
 - If `updated:` already equals today's date → skip the frontmatter write (no-op)
+- If `updated:` key is missing entirely → add `updated: YYYY-MM-DD` before the closing `---`
 - Otherwise → update only the `updated: YYYY-MM-DD` line to today's date using the Edit tool
+
+If the edit fails, stop and report the error to the user. Do not proceed.
 
 ---
 
@@ -98,12 +110,12 @@ Read the file. Check the `updated:` value in frontmatter:
 
 **If keyword is provided:**
 
-Look for an existing `> [!search]` callout block in TASKS.md (it starts with `> [!search]` on a line).
+Look for an existing `> [!search]` callout block in TASKS.md (a line that starts with `> [!search]`).
 
-- If found: replace the entire `> [!search]` block (all consecutive `> ` lines that follow it) with the new block below
-- If not found: insert the block immediately after the closing `---` of the frontmatter and before the `# Task Dashboard` heading
+- If found: replace the entire `> [!search]` block (all consecutive `> ` prefixed lines that follow it, until the first non-`> ` line or blank line) with the new block below
+- If not found: insert the block immediately before the `# Task Dashboard` heading line (preserve any blank line that already exists between the frontmatter `---` and the heading; insert the block between that blank line and the heading)
 
-Insert/replace with:
+Insert/replace with (replace `<keyword>` with the actual keyword text):
 
 ```
 > [!search] Filtered: "<keyword>"
@@ -117,11 +129,13 @@ Insert/replace with:
 
 ```
 
-(Replace `<keyword>` with the actual keyword text. Include a blank line after the closing ` ``` ` before the next section.)
+(Note: `[!search]` is not a native Obsidian callout type — it renders as a generic note style, which is intentional. Include a blank line after the closing ` ``` ` before the next section.)
+
+If the edit fails, stop and report the error to the user.
 
 **If no keyword:**
 
-Check if a `> [!search]` callout block exists in TASKS.md. If it does, remove it entirely (including the blank line that follows it).
+Check if a `> [!search]` callout block exists in TASKS.md. If it does, remove it entirely (including the blank line that follows it). If the removal fails, report the error to the user.
 
 ---
 
@@ -131,21 +145,36 @@ Build the `obsidian://` URI using path-based addressing:
 
 1. Take the absolute path to `TASKS.md`
 2. URL-encode it, keeping `/` and `:` as literal characters (do not percent-encode them):
+   - Priority order: Python3 first, then Node.js
+   - Python3: `urllib.parse.quote(path, safe='/:')`
    - Node.js: `encodeURIComponent(path).replace(/%2F/gi, '/').replace(/%3A/gi, ':')`
-   - Python3: `urllib.parse.quote(path, safe='/:@')`
-3. URI = `obsidian://open?path=` + encoded path
+   - If neither runtime is available, warn the user: "Could not URL-encode the path — open TASKS.md manually in Obsidian." Then skip to Step 6 with the failure branch.
+3. `uri = "obsidian://open?path=" + encoded_path`
 
-Open via Bash based on platform (detect from `$OSTYPE`):
-- macOS: `open "obsidian://open?path={encoded}" 2>/dev/null || true`
-- Linux (non-WSL): `xdg-open "obsidian://open?path={encoded}" &>/dev/null & true`
-- Linux (WSL): `cmd.exe /c start "" "obsidian://open?path={encoded}" 2>/dev/null || true`
-- Windows (msys/cygwin): `cmd.exe /c start "" "obsidian://open?path={encoded}" 2>/dev/null || true`
+Open via Bash based on platform (detect from `$OSTYPE`). Capture the exit code:
+- macOS: `open "<uri>"`
+- Linux (non-WSL): `xdg-open "<uri>"`
+- Linux (WSL): `cmd.exe /c start "" "<uri>"`
+- Windows (msys/cygwin): `cmd.exe /c start "" "<uri>"`
 
-If the open command fails (Obsidian not installed, URI rejected, etc.), fail silently — never surface an error to the user.
+**If the open command succeeds (exit code 0):** proceed to Step 6 success branch.
+
+**If the open command fails (non-zero exit code):** proceed to Step 6 failure branch. Do not suppress the failure.
 
 ---
 
 ## Step 6: Print confirmation
 
+**Success:**
 - With keyword: `TASKS.md opened in Obsidian — filtered by "<keyword>".`
 - Without keyword: `TASKS.md opened in Obsidian.`
+
+**Failure (open command failed or encoding unavailable):**
+
+> "TASKS.md was updated but could not be opened automatically in Obsidian.
+>
+> Open it manually:
+> - In Obsidian: navigate to `TASKS.md` in your vault
+> - Via URI: `obsidian://open?path=<encoded_path>`
+>
+> If Obsidian is not installed, visit https://obsidian.md"

--- a/.claude/plugins/onebrain/skills/tasks/SKILL.md
+++ b/.claude/plugins/onebrain/skills/tasks/SKILL.md
@@ -5,7 +5,7 @@ description: Create or update the live task dashboard (TASKS.md) in Obsidian and
 
 # Task Dashboard
 
-Creates or updates a permanent `TASKS.md` at the vault root using Obsidian Tasks plugin live query blocks, then opens it in Obsidian. The file is always current — no vault scanning needed.
+Creates or updates a permanent `TASKS.md` at the vault root using Obsidian Tasks plugin live query blocks, then opens it in Obsidian. The file is always current — no vault scanning needed. Mark tasks complete directly in Obsidian by clicking the checkboxes.
 
 Usage:
 - `/tasks` — open the full dashboard
@@ -27,7 +27,7 @@ Then proceed with cwd as vault root.
 
 Check if any text was passed after `/tasks`:
 - `/tasks` → `keyword = none`
-- `/tasks <keyword>` → `keyword = everything after "/tasks "` (preserve spaces, do not trim)
+- `/tasks <keyword>` → `keyword = everything after "/tasks "` (trim leading/trailing whitespace; preserve internal spaces for multi-word keywords)
 
 ---
 
@@ -108,12 +108,12 @@ Read the file. Check the `updated:` value in frontmatter:
 
 **If keyword is provided:**
 
-Look for an existing `> [!search]` callout block in TASKS.md (a line that starts with `> [!search]`).
+Look for an existing `> [!search]` callout block in TASKS.md (a line starting with `> [!search]`).
 
-- If found: replace the entire `> [!search]` block (all consecutive `> ` prefixed lines that follow it, until the first non-`> ` line or blank line) with the new block below
-- If not found: insert the block immediately before the `# Task Dashboard` heading line (preserve any blank line that already exists between the frontmatter `---` and the heading; insert the block between that blank line and the heading)
+- If found: replace the entire block (all consecutive `> ` prefixed lines until the first non-`> ` line or blank line) with the new block below
+- If not found: insert immediately before the `# Task Dashboard` heading (between the existing blank line after frontmatter `---` and the heading)
 
-Insert/replace with (substitute the actual keyword text for `<keyword>`):
+Insert/replace with (substitute actual keyword for `<keyword>`; keyword is quoted to support multi-word searches):
 
 ```
 > [!search] Filtered: "<keyword>"
@@ -127,13 +127,13 @@ Insert/replace with (substitute the actual keyword text for `<keyword>`):
 
 ```
 
-(Note: `[!search]` is not a native Obsidian callout type — it renders as a generic note style, which is intentional. Keyword is quoted in the query to support multi-word searches. Include a blank line after the closing ` ``` ` before the next section.)
+(Note: `[!search]` renders as a generic note style in Obsidian — not a native callout type. Include a blank line after the closing ` ``` ` before the next section.)
 
 If the edit fails, stop and report the error to the user. Do not proceed.
 
 **If no keyword:**
 
-Check if a `> [!search]` callout block exists in TASKS.md. If it does, remove it entirely — including the blank line that follows it and the blank line that precedes it (to avoid leaving a double blank line between the frontmatter `---` and the `# Task Dashboard` heading). If the removal fails, report the error to the user and do not proceed.
+Check if a `> [!search]` block exists in TASKS.md. If it does, remove it entirely — including the blank line that follows it and the blank line that precedes it (to avoid a double blank line between frontmatter `---` and `# Task Dashboard`). If removal fails, report the error and do not proceed.
 
 ---
 
@@ -142,11 +142,11 @@ Check if a `> [!search]` callout block exists in TASKS.md. If it does, remove it
 Build the `obsidian://` URI using path-based addressing:
 
 1. Take the absolute path to `TASKS.md`
-2. URL-encode it, keeping `/`, `:`, and `@` as literal characters (do not percent-encode them):
+2. URL-encode it, keeping `/`, `:`, and `@` as literal characters:
    - Priority order: Python3 first, then Node.js
    - Python3: `urllib.parse.quote(path, safe='/:@')`
    - Node.js: `encodeURIComponent(path).replace(/%2F/gi, '/').replace(/%3A/gi, ':').replace(/%40/gi, '@')`
-   - If neither runtime is available: go to Step 6 encoding-failure branch (do not attempt to open)
+   - If neither runtime is available: go to Step 6 encoding-failure branch
 3. `uri = "obsidian://open?path=" + encoded_path`
 
 Open via Bash based on platform (detect from `$OSTYPE`). Capture the exit code:
@@ -155,9 +155,8 @@ Open via Bash based on platform (detect from `$OSTYPE`). Capture the exit code:
 - Linux (WSL): `cmd.exe /c start "" "<uri>"`
 - Windows (msys/cygwin): `cmd.exe /c start "" "<uri>"`
 
-**If the open command succeeds (exit code 0):** proceed to Step 6 success branch.
-
-**If the open command fails (non-zero exit code):** proceed to Step 6 open-failure branch.
+**If exit code 0:** proceed to Step 6 success branch.
+**If non-zero exit code:** proceed to Step 6 open-failure branch.
 
 ---
 
@@ -173,12 +172,10 @@ Open via Bash based on platform (detect from `$OSTYPE`). Capture the exit code:
 >
 > Open it manually:
 > - In Obsidian: navigate to `TASKS.md` in your vault
-> - Via URI: `obsidian://open?path=<encoded_path>`
+> - Via URI: `obsidian://open?path=[encoded_path]`
 >
 > If Obsidian is not installed, visit https://obsidian.md"
 
 **Encoding-failure (no Python3 or Node.js available):**
 
-> "TASKS.md was updated but could not be opened automatically — URL encoding is unavailable on this system (Python3 and Node.js both missing).
->
-> Open it manually in Obsidian by navigating to `TASKS.md` in your vault."
+> "TASKS.md was updated but could not be opened automatically — URL encoding is unavailable (Python3 and Node.js both missing). Open TASKS.md manually in Obsidian."

--- a/.claude/plugins/onebrain/skills/tasks/SKILL.md
+++ b/.claude/plugins/onebrain/skills/tasks/SKILL.md
@@ -1,132 +1,151 @@
 ---
 name: tasks
-description: Show a dashboard of all tasks across the vault — overdue, due soon, open, and recently completed
+description: Open the live task dashboard in Obsidian (creates TASKS.md if needed). Optionally filter by keyword.
 ---
 
 # Task Dashboard
 
-Shows all tasks across the vault, organized by urgency, with quick actions to update them.
+Opens a live task dashboard (`TASKS.md`) in Obsidian. The file uses Obsidian Tasks plugin query blocks — always current, no vault scanning needed.
+
+Usage:
+- `/tasks` — open the full dashboard
+- `/tasks <keyword>` — open with a filtered view (e.g., `/tasks onebrain`, `/tasks client project`)
 
 ---
 
-## Step 1: Scan the Vault
+## Step 1: Read vault.yml
 
-Use the Grep tool to find all task lines across active vault folders.
-
-Search for `- \[.\]` (regex) recursively in these directories only:
-- `00-inbox/`
-- `01-projects/**`
-- `02-areas/**`
-- `03-knowledge/**`
-- `04-resources/**`
-- `07-logs/**`
-
-**Skip entirely:** `05-agent/`, `06-archive/`, `.obsidian/`, `.claude/`, `CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, `README.md`
-
-These excluded files contain template examples or system instructions, not real tasks.
+Read `vault.yml` from the vault root to confirm the vault root path. If vault.yml does not exist, use the current working directory as the vault root.
 
 ---
 
-## Step 2: Parse Each Task Line
+## Step 2: Parse keyword argument
 
-For each matched line, extract:
-
-| Field | How to extract |
-|-------|---------------|
-| **Status** | `- [ ]` = open, `- [x]` = completed |
-| **Description** | Text after the checkbox, minus emoji markers |
-| **Due date** | `📅 YYYY-MM-DD` if present |
-| **Priority** | `🔺` high, `⏫` medium, `🔽` low (absent = none) |
-| **Source** | File path → strip extension and leading path → `[[Note Name]]` |
+Check if any text was passed after `/tasks`:
+- `/tasks` → `keyword = none`
+- `/tasks <keyword>` → `keyword = everything after "/tasks "` (preserve spaces, do not trim)
 
 ---
 
-## Step 3: Categorize by Urgency
+## Step 3: Ensure TASKS.md exists and frontmatter is current
 
-Today's date is available from the system. Using it:
+Determine `tasks_path = {vault_root}/TASKS.md`.
 
-- **Overdue** — open tasks with due date < today
-- **Due Soon** — open tasks with due date within the next 7 days (today through today+7)
-- **All Open** — open tasks with no due date, or due date > 7 days out
-- **Completed This Week** — completed (`- [x]`) tasks found in files modified in the last 7 days
+**If TASKS.md does not exist:**
 
-Within each section, sort by:
-1. Priority: 🔺 → ⏫ → 🔽 → none
-2. Then by due date (earliest first)
+Create it with this exact content (replace `YYYY-MM-DD` with today's date):
 
+```markdown
+---
+tags: [dashboard, tasks]
+created: YYYY-MM-DD
+updated: YYYY-MM-DD
 ---
 
-## Step 4: Display the Dashboard
+# Task Dashboard
 
-Print the dashboard in this format:
+> [!warning] Overdue
+> ```tasks
+> not done
+> due before today
+> sort by priority
+> sort by due
+> ```
 
-```
-## 🔴 Overdue (N)
-- [ ] Task description 📅 YYYY-MM-DD  🔺  ← [[Source Note]]
+> [!info] Due This Week
+> ```tasks
+> not done
+> due after yesterday
+> due before in 8 days
+> sort by priority
+> sort by due
+> ```
 
-## 🟡 Due Soon (N)
-- [ ] Task description 📅 YYYY-MM-DD  ← [[Source Note]]
+> [!note] All Open
+> ```tasks
+> not done
+> ((no due date) OR (due after in 7 days))
+> sort by priority
+> sort by due
+> ```
 
-## 📋 All Open (N)
-- [ ] Task description  ← [[Source Note]]
+> [!tip] Due Later
+> ```tasks
+> not done
+> due after in 7 days
+> sort by due
+> sort by priority
+> ```
 
-## ✅ Completed This Week (N)
-- [x] Task description 📅 YYYY-MM-DD  ← [[Source Note]]
-```
-
-If a section has no tasks, show:
-> None — you're clear!
-
-Show the count `(N)` in every section header, even when zero.
-
----
-
-## Step 5: Quick Actions
-
-After the dashboard, say:
-
-> **Quick actions:**
-> 1. ✅ Mark tasks complete — tell me which ones
-> 2. ➕ Add a quick task — I'll ask for details
-> 3. 👋 Done — no changes needed
-
-Wait for the user's choice, then follow the matching branch below.
-
-### Branch 1 — Mark Complete
-
-- Ask the user to identify tasks by number (based on dashboard order) or description.
-- Read the source file for each identified task.
-- Change `- [ ]` to `- [x]` for the matching line(s).
-- Confirm: "Marked N task(s) complete in [[Source Note]]."
-
-### Branch 2 — Add a Task
-
-Ask in sequence:
-1. **Description** — what's the task?
-2. **Due date** — any deadline? (optional, skip if none)
-3. **Priority** — high 🔺, medium ⏫, low 🔽, or none?
-4. **Where to add it** — suggest existing project notes by name; default to `00-inbox/YYYY-MM-DD-tasks.md` if no preference.
-
-Write the task in Obsidian Tasks format:
-```
-- [ ] Task description 📅 YYYY-MM-DD  🔺
+> [!success] Completed
+> _Note: Shows tasks marked complete in Obsidian with a done-date (✅). Tasks completed via terminal do not appear here._
+> ```tasks
+> done
+> sort by done date
+> limit 20
+> ```
 ```
 
-Confirm: "Added to [[Note Name]]."
+**If TASKS.md already exists:**
 
-### Branch 3 — Done
-
-Say:
-> All good — your task list is up to date. See you next time!
+Read the file. Check the `updated:` value in frontmatter:
+- If `updated:` already equals today's date → skip the frontmatter write (no-op)
+- Otherwise → update only the `updated: YYYY-MM-DD` line to today's date using the Edit tool
 
 ---
 
-## Step 6: Empty State
+## Step 4: Handle keyword filter
 
-If no tasks are found anywhere after scanning:
+**If keyword is provided:**
 
-> No tasks found in your vault yet. Tasks get created when you use `/braindump`, `/weekly`, or add them manually to notes.
->
-> Want to add one now?
+Look for an existing `> [!search]` callout block in TASKS.md (it starts with `> [!search]` on a line).
 
-If yes, proceed with Branch 2 above.
+- If found: replace the entire `> [!search]` block (all consecutive `> ` lines that follow it) with the new block below
+- If not found: insert the block immediately after the closing `---` of the frontmatter and before the `# Task Dashboard` heading
+
+Insert/replace with:
+
+```
+> [!search] Filtered: "<keyword>"
+> _Matches tasks where description or path contains "<keyword>"_
+> ```tasks
+> not done
+> (description includes <keyword>) OR (path includes <keyword>)
+> sort by priority
+> sort by due
+> ```
+
+```
+
+(Replace `<keyword>` with the actual keyword text. Include a blank line after the closing ` ``` ` before the next section.)
+
+**If no keyword:**
+
+Check if a `> [!search]` callout block exists in TASKS.md. If it does, remove it entirely (including the blank line that follows it).
+
+---
+
+## Step 5: Open in Obsidian
+
+Build the `obsidian://` URI using path-based addressing:
+
+1. Take the absolute path to `TASKS.md`
+2. URL-encode it, keeping `/` and `:` as literal characters (do not percent-encode them):
+   - Node.js: `encodeURIComponent(path).replace(/%2F/gi, '/').replace(/%3A/gi, ':')`
+   - Python3: `urllib.parse.quote(path, safe='/:@')`
+3. URI = `obsidian://open?path=` + encoded path
+
+Open via Bash based on platform (detect from `$OSTYPE`):
+- macOS: `open "obsidian://open?path={encoded}" 2>/dev/null || true`
+- Linux (non-WSL): `xdg-open "obsidian://open?path={encoded}" &>/dev/null & true`
+- Linux (WSL): `cmd.exe /c start "" "obsidian://open?path={encoded}" 2>/dev/null || true`
+- Windows (msys/cygwin): `cmd.exe /c start "" "obsidian://open?path={encoded}" 2>/dev/null || true`
+
+If the open command fails (Obsidian not installed, URI rejected, etc.), fail silently — never surface an error to the user.
+
+---
+
+## Step 6: Print confirmation
+
+- With keyword: `TASKS.md opened in Obsidian — filtered by "<keyword>".`
+- Without keyword: `TASKS.md opened in Obsidian.`

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Under the hood, OneBrain uses a **three-layer memory system**: your identity (al
 | `/import [path]` | Import local files (PDF, Word, images, scripts) into vault notes |
 | `/reading-notes` | Turn a book or article into structured notes |
 | `/weekly` | Review the week, surface patterns, set intentions |
-| `/tasks` | Task dashboard — overdue, due soon, open, and completed this week |
+| `/tasks [keyword]` | Live task dashboard in Obsidian — creates/updates `TASKS.md` with always-current query sections. Filter with `/tasks <keyword>` |
 | `/wrapup` | Wrap up session and save summary to session log |
 | `/learn` | Teach the agent something — facts about your world or behavioral preferences |
 | `/clone` | Package your agent context for transfer to a new vault |
@@ -160,6 +160,7 @@ onebrain/
 │   ├── pdf/
 │   ├── images/
 │   └── video/
+├── TASKS.md           Live task dashboard (created by /tasks, opened in Obsidian)
 ├── CLAUDE.md          Instructions for Claude Code
 ├── GEMINI.md          Instructions for Gemini CLI
 ├── AGENTS.md          Universal agent instructions
@@ -224,7 +225,7 @@ OneBrain uses the [Obsidian Tasks](https://publish.obsidian.md/tasks/) plugin fo
 - [ ] High priority task 🔺 📅 2026-03-22
 ```
 
-Tasks live inline in your notes — the Tasks plugin surfaces them across the vault.
+Tasks live inline in your notes — the Tasks plugin surfaces them across the vault. Run `/tasks` to open a live dashboard in Obsidian (`TASKS.md` at vault root) with sections for overdue, due this week, unscheduled, due later, and recently completed. Use `/tasks <keyword>` to filter by project or topic.
 
 </details>
 


### PR DESCRIPTION
## Summary

- Replaces the terminal vault scan in `/tasks` with a fast Obsidian-native flow
- Creates a permanent `TASKS.md` at vault root with live Obsidian Tasks plugin query blocks on first run
- Auto-opens `TASKS.md` in Obsidian every time `/tasks` runs
- Supports optional keyword filtering: `/tasks <keyword>` injects a filtered query section
- Running `/tasks` without a keyword removes any previous filter

## Changes

- `.claude/plugins/onebrain/skills/tasks/SKILL.md` — full rewrite: remove vault scan + terminal dashboard, add TASKS.md write/update logic, keyword filter handling, and Obsidian auto-open via `obsidian://open?path=`
- `.claude/plugins/onebrain/INSTRUCTIONS.md` — update `/tasks` command description
- `.claude/plugins/onebrain/.claude-plugin/plugin.json` — bump version 1.3.0 → 1.4.0

## Test plan

- [ ] Run `/tasks` on a fresh vault (no TASKS.md) → verify file is created at vault root with correct callout sections
- [ ] Run `/tasks` again → verify `updated:` frontmatter is refreshed (or skipped if same day)
- [ ] Run `/tasks onebrain` → verify `> [!search]` callout is inserted with keyword filter
- [ ] Run `/tasks` (no keyword) → verify `> [!search]` block is removed
- [ ] Open TASKS.md in Obsidian → verify Tasks plugin renders live queries in each section
- [ ] Verify PostToolUse hook does NOT fire for vault root TASKS.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)