### PR TITLE
docs: add TASKS.md to vault structure in INSTRUCTIONS.md

### DIFF
--- a/.claude/plugins/onebrain/INSTRUCTIONS.md
+++ b/.claude/plugins/onebrain/INSTRUCTIONS.md
@@ -23,6 +23,7 @@ Be proactive: surface connections, flag stale tasks, suggest next actions based 
 06-archive/        Completed projects and archived areas
 07-logs/           Session logs (YYYY-MM-DD-session-NN.md in YYYY/MM/)
 attachments/       Copied files from /import --attach (pdf/, images/, video/)
+TASKS.md           Live task dashboard (created by /tasks, read-only query blocks)
 ```
 
 ## Task Syntax (Obsidian Tasks Plugin)


### PR DESCRIPTION
## Summary
- `TASKS.md` is a permanent file at the vault root, created by `/tasks`
- `README.md` already documented it in the vault structure diagram
- `INSTRUCTIONS.md` vault structure section now matches

## Test plan
- [ ] Confirm `INSTRUCTIONS.md` vault structure lists `TASKS.md`
- [ ] Confirm `README.md` and `INSTRUCTIONS.md` are consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)