### PR TITLE
fix: /tasks keyword quote bug and logs folder exclusion

### DIFF
--- a/.claude/plugins/onebrain/skills/tasks/SKILL.md
+++ b/.claude/plugins/onebrain/skills/tasks/SKILL.md
@@ -41,7 +41,7 @@ Determine `tasks_path = {vault_root}/TASKS.md`.
 
 **If TASKS.md does not exist:**
 
-Create it with this exact content (replace `YYYY-MM-DD` with today's date):
+Create it with this exact content (replace `YYYY-MM-DD` with today's date and `[logs_folder]` with the actual logs folder path extracted in Step 1, e.g., `07-logs`):
 
 ```markdown
 ---
@@ -110,7 +110,7 @@ Read the file.
 
 Frontmatter: read `created:` from the existing frontmatter and preserve it (if absent, use today's date); update `updated:` to today's date.
 
-Body: regenerate all content from the `# Task Dashboard` heading onward using the same five-block template above (with `exclude path includes [logs_folder]`). Leave everything before `# Task Dashboard` — including the frontmatter and any `[!search]` block — untouched.
+Body: regenerate all content from the `# Task Dashboard` heading onward using the same five-block template above (substitute `[logs_folder]` with the actual logs folder path extracted in Step 1, e.g., `07-logs`). Leave everything before `# Task Dashboard` — including the frontmatter and any `[!search]` block — untouched.
 
 Write the updated file (frontmatter and any content above `# Task Dashboard` preserved, body from `# Task Dashboard` onward regenerated). If the write fails, stop immediately and tell the user:
 

--- a/.claude/plugins/onebrain/skills/tasks/SKILL.md
+++ b/.claude/plugins/onebrain/skills/tasks/SKILL.md
@@ -55,6 +55,7 @@ updated: YYYY-MM-DD
 > [!warning] Overdue
 > ```tasks
 > not done
+> exclude path includes [logs_folder]
 > due before today
 > sort by priority
 > sort by due
@@ -63,6 +64,7 @@ updated: YYYY-MM-DD
 > [!info] Due This Week
 > ```tasks
 > not done
+> exclude path includes [logs_folder]
 > due after yesterday
 > due before in 8 days
 > sort by priority
@@ -72,6 +74,7 @@ updated: YYYY-MM-DD
 > [!note] Unscheduled
 > ```tasks
 > not done
+> exclude path includes [logs_folder]
 > no due date
 > sort by priority
 > ```
@@ -79,6 +82,7 @@ updated: YYYY-MM-DD
 > [!tip] Due Later
 > ```tasks
 > not done
+> exclude path includes [logs_folder]
 > due after in 7 days
 > sort by due
 > sort by priority
@@ -88,6 +92,7 @@ updated: YYYY-MM-DD
 > _Note: Shows tasks marked complete in Obsidian with a done-date (✅). Tasks completed via terminal do not appear here._
 > ```tasks
 > done
+> exclude path includes [logs_folder]
 > sort by done date
 > limit 20
 > ```

--- a/.claude/plugins/onebrain/skills/tasks/SKILL.md
+++ b/.claude/plugins/onebrain/skills/tasks/SKILL.md
@@ -21,6 +21,8 @@ Read `vault.yml` from the current working directory. The directory containing `v
 
 Then proceed with cwd as vault root.
 
+Also extract `folders.logs` from `vault.yml` (default: `07-logs`) and store as `[logs_folder]`. This value is used in Steps 3 and 4 to exclude session log tasks from dashboard queries.
+
 ---
 
 ## Step 2: Parse keyword argument

--- a/.claude/plugins/onebrain/skills/tasks/SKILL.md
+++ b/.claude/plugins/onebrain/skills/tasks/SKILL.md
@@ -130,7 +130,7 @@ Do not proceed to Steps 4, 5, or 6 if the write failed.
 
 **If keyword is provided:**
 
-Look for an existing `## 🔍 Filtered:` section in TASKS.md (a line starting with `## 🔍 Filtered:`).
+Look for an existing `## 🔍 Filtered:` section in TASKS.md (a line starting with `## 🔍 Filtered:`). Note: Step 3 always regenerates the body from `# Task Dashboard` onward, so this section will not be present — the "if not found" path always applies. The "if found" path is kept as a safety fallback for manually edited files.
 
 - If found: replace from that heading line through the closing ` ``` ` of its tasks block with the new block below
 - If not found: insert immediately after the `# Task Dashboard` heading line (followed by a blank line, then the new block)

--- a/.claude/plugins/onebrain/skills/tasks/SKILL.md
+++ b/.claude/plugins/onebrain/skills/tasks/SKILL.md
@@ -106,10 +106,17 @@ Do not proceed to Steps 4, 5, or 6 if the write failed.
 
 **If TASKS.md already exists:**
 
-Read the file. Check the `updated:` value in frontmatter:
-- If `updated:` already equals today's date → skip the frontmatter write (no-op)
-- If `updated:` key is missing entirely → add `updated: YYYY-MM-DD` before the closing `---`. If this edit fails, stop and report the error to the user. Do not proceed.
-- Otherwise → update only the `updated: YYYY-MM-DD` line to today's date using the Edit tool. If the edit fails, stop and report the error to the user. Do not proceed.
+Read the file.
+
+Frontmatter: read `created:` from the existing frontmatter and preserve it (if absent, use today's date); update `updated:` to today's date.
+
+Body: regenerate all content from the `# Task Dashboard` heading onward using the same five-block template above (with `exclude path includes [logs_folder]`). Leave everything before `# Task Dashboard` — including the frontmatter and any `[!search]` block — untouched.
+
+Write the updated file (frontmatter and any content above `# Task Dashboard` preserved, body from `# Task Dashboard` onward regenerated). If the write fails, stop immediately and tell the user:
+
+> "Could not update TASKS.md at [tasks_path]. Error: [error]. Check that the vault path is correct and that you have write permission."
+
+Do not proceed to Steps 4, 5, or 6 if the write failed.
 
 ---
 

--- a/.claude/plugins/onebrain/skills/tasks/SKILL.md
+++ b/.claude/plugins/onebrain/skills/tasks/SKILL.md
@@ -116,7 +116,7 @@ Read the file.
 
 Frontmatter: read `created:` from the existing frontmatter and preserve it; update `updated:` to today's date. If `created:` is absent, use today's date and tell the user: "`created:` was missing from TASKS.md frontmatter — set to today's date. Edit it manually if you know the original date."
 
-Body: regenerate all content from the `# Task Dashboard` heading onward using the same five-block template above (substitute `[logs_folder]` with the actual logs folder path extracted in Step 1, e.g., `07-logs`). Leave everything before `# Task Dashboard` — including the frontmatter and any `## 🔍 Filtered:` section — intact during this regeneration step. (Step 4 may subsequently modify the `## 🔍 Filtered:` section.)
+Body: regenerate all content from the `# Task Dashboard` heading onward using the same five-block template above (substitute `[logs_folder]` with the actual logs folder path extracted in Step 1, e.g., `07-logs`). Leave everything before `# Task Dashboard` — including the frontmatter — intact. Any existing `## 🔍 Filtered:` section (which lives after `# Task Dashboard`) will be overwritten by this regeneration; Step 4 will re-add or remove it as needed.
 
 Write the updated file (frontmatter and any content above `# Task Dashboard` preserved, body from `# Task Dashboard` onward regenerated). If the write fails, stop immediately and tell the user:
 
@@ -156,7 +156,7 @@ sort by due
 
 If the edit fails, stop immediately and tell the user:
 
-> "Could not update the keyword filter in TASKS.md at [tasks_path]. Error: [error]. Check write permissions."
+> "Could not update the keyword filter in TASKS.md at [tasks_path]. Error: [error]. Check write permissions. Vault root used: [vault_root]"
 
 Do not proceed.
 
@@ -164,7 +164,7 @@ Do not proceed.
 
 Check if a `## 🔍 Filtered:` section exists in TASKS.md. If it does, remove it entirely — the heading line, the blank line after it, the subtitle line, the blank line before the tasks block, the tasks block itself, and the blank line that follows — so there is no extra blank line between `# Task Dashboard` and `## 🔴 Overdue`. If removal fails, tell the user:
 
-> "Could not remove the keyword filter from TASKS.md at [tasks_path]. Error: [error]. Check write permissions."
+> "Could not remove the keyword filter from TASKS.md at [tasks_path]. Error: [error]. Check write permissions. Vault root used: [vault_root]"
 
 Do not proceed.
 
@@ -211,4 +211,4 @@ Open via Bash based on platform (detect from `$OSTYPE`). Capture the exit code:
 
 **Encoding-failure (no Python3 or Node.js available):**
 
-> "TASKS.md was updated but could not be opened automatically — URL encoding is unavailable (Python3 and Node.js both missing). Open TASKS.md manually in Obsidian."
+> "TASKS.md was updated but could not be opened automatically — URL encoding is unavailable (Python3 and Node.js both missing). Open it manually in Obsidian by navigating to `[tasks_path]`."

--- a/.claude/plugins/onebrain/skills/tasks/SKILL.md
+++ b/.claude/plugins/onebrain/skills/tasks/SKILL.md
@@ -52,50 +52,56 @@ updated: YYYY-MM-DD
 
 # Task Dashboard
 
-> [!warning] Overdue
-> ```tasks
-> not done
-> exclude path includes [logs_folder]
-> due before today
-> sort by priority
-> sort by due
-> ```
+## 🔴 Overdue
 
-> [!info] Due This Week
-> ```tasks
-> not done
-> exclude path includes [logs_folder]
-> due after yesterday
-> due before in 8 days
-> sort by priority
-> sort by due
-> ```
+```tasks
+not done
+exclude path includes [logs_folder]
+due before today
+sort by priority
+sort by due
+```
 
-> [!note] Unscheduled
-> ```tasks
-> not done
-> exclude path includes [logs_folder]
-> no due date
-> sort by priority
-> ```
+## 🗓 Due This Week
 
-> [!tip] Due Later
-> ```tasks
-> not done
-> exclude path includes [logs_folder]
-> due after in 7 days
-> sort by due
-> sort by priority
-> ```
+```tasks
+not done
+exclude path includes [logs_folder]
+due after yesterday
+due before in 8 days
+sort by priority
+sort by due
+```
 
-> [!success] Completed
-> _Note: Shows tasks marked complete in Obsidian with a done-date (✅). Tasks completed via terminal do not appear here._
-> ```tasks
-> done
-> exclude path includes [logs_folder]
-> sort by done date
-> limit 20
-> ```
+## 📋 Unscheduled
+
+```tasks
+not done
+exclude path includes [logs_folder]
+no due date
+sort by priority
+```
+
+## 🔵 Due Later
+
+```tasks
+not done
+exclude path includes [logs_folder]
+due after in 7 days
+sort by due
+sort by priority
+```
+
+## ✅ Completed
+
+_Note: Shows tasks marked complete in Obsidian with a done-date (✅). Tasks completed via terminal do not appear here._
+
+```tasks
+done
+exclude path includes [logs_folder]
+sort by done date
+limit 20
+```
 ```
 
 If the write fails, stop immediately and tell the user:
@@ -124,27 +130,29 @@ Do not proceed to Steps 4, 5, or 6 if the write failed.
 
 **If keyword is provided:**
 
-Look for an existing `> [!search]` callout block in TASKS.md (a line starting with `> [!search]`).
+Look for an existing `## 🔍 Filtered:` section in TASKS.md (a line starting with `## 🔍 Filtered:`).
 
-- If found: replace the entire block (all consecutive `> ` prefixed lines until the first non-`> ` line or blank line) with the new block below
-- If not found: insert immediately before the `# Task Dashboard` heading (between the existing blank line after frontmatter `---` and the heading)
+- If found: replace from that heading line through the closing ` ``` ` of its tasks block with the new block below
+- If not found: insert immediately after the `# Task Dashboard` heading line (followed by a blank line, then the new block)
 
 Insert/replace with (substitute actual keyword for `<keyword>` and actual logs folder path for `[logs_folder]`, e.g., `07-logs`):
 
 ```
-> [!search] Filtered: <keyword>
-> _Matches tasks where description or path contains <keyword>_
-> ```tasks
-> not done
-> exclude path includes [logs_folder]
-> (description includes <keyword>) OR (path includes <keyword>)
-> sort by priority
-> sort by due
-> ```
+## 🔍 Filtered: <keyword>
+
+_Matches tasks where description or path contains <keyword>_
+
+```tasks
+not done
+exclude path includes [logs_folder]
+(description includes <keyword>) OR (path includes <keyword>)
+sort by priority
+sort by due
+```
 
 ```
 
-(Note: `[!search]` renders as a generic note style in Obsidian — not a native callout type. Include a blank line after the closing ` ``` ` before the next section.)
+(Include a blank line after the closing ` ``` ` before the next section.)
 
 If the edit fails, stop immediately and tell the user:
 
@@ -154,7 +162,7 @@ Do not proceed.
 
 **If no keyword:**
 
-Check if a `> [!search]` block exists in TASKS.md. If it does, remove it entirely — including the blank line that follows it and the blank line that precedes it (to avoid a double blank line between frontmatter `---` and `# Task Dashboard`). If removal fails, tell the user:
+Check if a `## 🔍 Filtered:` section exists in TASKS.md. If it does, remove it entirely — the heading line, the blank line after it, the subtitle line, the blank line before the tasks block, the tasks block itself, and the blank line that follows — so there is no extra blank line between `# Task Dashboard` and `## 🔴 Overdue`. If removal fails, tell the user:
 
 > "Could not remove the keyword filter from TASKS.md at [tasks_path]. Error: [error]. Check write permissions."
 

--- a/.claude/plugins/onebrain/skills/tasks/SKILL.md
+++ b/.claude/plugins/onebrain/skills/tasks/SKILL.md
@@ -31,6 +31,8 @@ Check if any text was passed after `/tasks`:
 - `/tasks` → `keyword = none`
 - `/tasks <keyword>` → `keyword = everything after "/tasks "` (trim leading/trailing whitespace; preserve internal spaces for multi-word keywords)
 
+After extracting the keyword, strip surrounding quote characters if the entire argument is wrapped in matching `"..."` or `'...'`. Only outermost surrounding quotes are removed — internal spaces and characters are preserved (e.g., `/tasks "client project"` → keyword `client project`).
+
 ---
 
 ## Step 3: Ensure TASKS.md exists and frontmatter is current

--- a/.claude/plugins/onebrain/skills/tasks/SKILL.md
+++ b/.claude/plugins/onebrain/skills/tasks/SKILL.md
@@ -129,14 +129,15 @@ Look for an existing `> [!search]` callout block in TASKS.md (a line starting wi
 - If found: replace the entire block (all consecutive `> ` prefixed lines until the first non-`> ` line or blank line) with the new block below
 - If not found: insert immediately before the `# Task Dashboard` heading (between the existing blank line after frontmatter `---` and the heading)
 
-Insert/replace with (substitute actual keyword for `<keyword>`; keyword is quoted to support multi-word searches):
+Insert/replace with (substitute actual keyword for `<keyword>`):
 
 ```
-> [!search] Filtered: "<keyword>"
-> _Matches tasks where description or path contains "<keyword>"_
+> [!search] Filtered: <keyword>
+> _Matches tasks where description or path contains <keyword>_
 > ```tasks
 > not done
-> (description includes "<keyword>") OR (path includes "<keyword>")
+> exclude path includes [logs_folder]
+> (description includes <keyword>) OR (path includes <keyword>)
 > sort by priority
 > sort by due
 > ```
@@ -179,7 +180,7 @@ Open via Bash based on platform (detect from `$OSTYPE`). Capture the exit code:
 ## Step 6: Print confirmation
 
 **Success:**
-- With keyword: `TASKS.md opened in Obsidian — filtered by "<keyword>".`
+- With keyword: `TASKS.md opened in Obsidian — filtered by <keyword>.`
 - Without keyword: `TASKS.md opened in Obsidian.`
 
 **Open-failure (open command returned non-zero, encoding succeeded):**

--- a/.claude/plugins/onebrain/skills/tasks/SKILL.md
+++ b/.claude/plugins/onebrain/skills/tasks/SKILL.md
@@ -31,7 +31,7 @@ Check if any text was passed after `/tasks`:
 - `/tasks` → `keyword = none`
 - `/tasks <keyword>` → `keyword = everything after "/tasks "` (trim leading/trailing whitespace; preserve internal spaces for multi-word keywords)
 
-After extracting the keyword, strip surrounding quote characters if the entire argument is wrapped in matching `"..."` or `'...'`. Only outermost surrounding quotes are removed — internal spaces and characters are preserved (e.g., `/tasks "client project"` → keyword `client project`).
+If a keyword was extracted, strip surrounding quote characters if the entire argument is wrapped in matching `"..."` or `'...'`. Only outermost surrounding quotes are removed — internal spaces and characters are preserved (e.g., `/tasks "client project"` → keyword `client project`).
 
 ---
 

--- a/.claude/plugins/onebrain/skills/tasks/SKILL.md
+++ b/.claude/plugins/onebrain/skills/tasks/SKILL.md
@@ -116,7 +116,7 @@ Read the file.
 
 Frontmatter: read `created:` from the existing frontmatter and preserve it; update `updated:` to today's date. If `created:` is absent, use today's date and tell the user: "`created:` was missing from TASKS.md frontmatter — set to today's date. Edit it manually if you know the original date."
 
-Body: regenerate all content from the `# Task Dashboard` heading onward using the same five-block template above (substitute `[logs_folder]` with the actual logs folder path extracted in Step 1, e.g., `07-logs`). Leave everything before `# Task Dashboard` — including the frontmatter and any `[!search]` block — intact during this regeneration step. (Step 4 may subsequently modify the `[!search]` block.)
+Body: regenerate all content from the `# Task Dashboard` heading onward using the same five-block template above (substitute `[logs_folder]` with the actual logs folder path extracted in Step 1, e.g., `07-logs`). Leave everything before `# Task Dashboard` — including the frontmatter and any `## 🔍 Filtered:` section — intact during this regeneration step. (Step 4 may subsequently modify the `## 🔍 Filtered:` section.)
 
 Write the updated file (frontmatter and any content above `# Task Dashboard` preserved, body from `# Task Dashboard` onward regenerated). If the write fails, stop immediately and tell the user:
 

--- a/.claude/plugins/onebrain/skills/tasks/SKILL.md
+++ b/.claude/plugins/onebrain/skills/tasks/SKILL.md
@@ -21,7 +21,7 @@ Read `vault.yml` from the current working directory. The directory containing `v
 
 Then proceed with cwd as vault root.
 
-Also extract `folders.logs` from `vault.yml` (default: `07-logs`) and store as `[logs_folder]`. This value is used in Steps 3 and 4 to exclude session log tasks from dashboard queries.
+Also extract `folders.logs` from `vault.yml` and store as `[logs_folder]`. If the key is absent (or vault.yml was not found), use `07-logs` as the default and proceed without warning. This value is used in Steps 3 and 4 to exclude session log tasks from dashboard queries.
 
 ---
 
@@ -108,13 +108,13 @@ Do not proceed to Steps 4, 5, or 6 if the write failed.
 
 Read the file.
 
-Frontmatter: read `created:` from the existing frontmatter and preserve it (if absent, use today's date); update `updated:` to today's date.
+Frontmatter: read `created:` from the existing frontmatter and preserve it; update `updated:` to today's date. If `created:` is absent, use today's date and tell the user: "`created:` was missing from TASKS.md frontmatter — set to today's date. Edit it manually if you know the original date."
 
-Body: regenerate all content from the `# Task Dashboard` heading onward using the same five-block template above (substitute `[logs_folder]` with the actual logs folder path extracted in Step 1, e.g., `07-logs`). Leave everything before `# Task Dashboard` — including the frontmatter and any `[!search]` block — untouched.
+Body: regenerate all content from the `# Task Dashboard` heading onward using the same five-block template above (substitute `[logs_folder]` with the actual logs folder path extracted in Step 1, e.g., `07-logs`). Leave everything before `# Task Dashboard` — including the frontmatter and any `[!search]` block — intact during this regeneration step. (Step 4 may subsequently modify the `[!search]` block.)
 
 Write the updated file (frontmatter and any content above `# Task Dashboard` preserved, body from `# Task Dashboard` onward regenerated). If the write fails, stop immediately and tell the user:
 
-> "Could not update TASKS.md at [tasks_path]. Error: [error]. Check that the vault path is correct and that you have write permission."
+> "Could not update TASKS.md at [tasks_path]. Error: [error]. Check that the vault path is correct and that you have write permission. Vault root used: [vault_root]"
 
 Do not proceed to Steps 4, 5, or 6 if the write failed.
 
@@ -129,7 +129,7 @@ Look for an existing `> [!search]` callout block in TASKS.md (a line starting wi
 - If found: replace the entire block (all consecutive `> ` prefixed lines until the first non-`> ` line or blank line) with the new block below
 - If not found: insert immediately before the `# Task Dashboard` heading (between the existing blank line after frontmatter `---` and the heading)
 
-Insert/replace with (substitute actual keyword for `<keyword>`):
+Insert/replace with (substitute actual keyword for `<keyword>` and actual logs folder path for `[logs_folder]`, e.g., `07-logs`):
 
 ```
 > [!search] Filtered: <keyword>
@@ -146,11 +146,19 @@ Insert/replace with (substitute actual keyword for `<keyword>`):
 
 (Note: `[!search]` renders as a generic note style in Obsidian — not a native callout type. Include a blank line after the closing ` ``` ` before the next section.)
 
-If the edit fails, stop and report the error to the user. Do not proceed.
+If the edit fails, stop immediately and tell the user:
+
+> "Could not update the keyword filter in TASKS.md at [tasks_path]. Error: [error]. Check write permissions."
+
+Do not proceed.
 
 **If no keyword:**
 
-Check if a `> [!search]` block exists in TASKS.md. If it does, remove it entirely — including the blank line that follows it and the blank line that precedes it (to avoid a double blank line between frontmatter `---` and `# Task Dashboard`). If removal fails, report the error and do not proceed.
+Check if a `> [!search]` block exists in TASKS.md. If it does, remove it entirely — including the blank line that follows it and the blank line that precedes it (to avoid a double blank line between frontmatter `---` and `# Task Dashboard`). If removal fails, tell the user:
+
+> "Could not remove the keyword filter from TASKS.md at [tasks_path]. Error: [error]. Check write permissions."
+
+Do not proceed.
 
 ---
 


### PR DESCRIPTION
## Summary

- Removes quotes from the keyword filter query template — Obsidian Tasks does not support quoted strings in `description includes`, so `/tasks onebrain` was generating `(description includes "onebrain")` and matching nothing
- Strips surrounding quotes from the `/tasks` argument in Step 2 so `/tasks "onebrain"` and `/tasks onebrain` produce identical queries
- Reads `folders.logs` from `vault.yml` (default: `07-logs`) and adds `exclude path includes [logs_folder]` to all query blocks — prevents `/wrapup` action items from appearing in the task dashboard
- Regenerates the query body of existing `TASKS.md` files on every `/tasks` run (from `# Task Dashboard` onward), so old vaults get the logs exclusion automatically without deleting their file
- Bumps plugin `v1.4.0` → `v1.5.0`

## Test Plan

- [ ] `/tasks onebrain` → query uses `description includes onebrain` (no quotes), results appear
- [ ] `/tasks "onebrain"` → quotes stripped, identical query to above
- [ ] Task dashboard shows no tasks from `07-logs/` or configured logs folder
- [ ] Existing `TASKS.md` without exclusion lines is auto-updated on next `/tasks` run
- [ ] Custom `folders.logs` in `vault.yml` is respected in the exclusion line

🤖 Generated with [Claude Code](https://claude.com/claude-code)