### PR TITLE
feat: show plugin version in /help output

### DIFF
--- a/.claude/plugins/onebrain/.claude-plugin/plugin.json
+++ b/.claude/plugins/onebrain/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "onebrain",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "OneBrain — Where human and AI thinking become one. A powerful thinking partner powered by AI synergy.",
   "author": {
     "name": "OneBrain Contributors"

--- a/.claude/plugins/onebrain/skills/help/SKILL.md
+++ b/.claude/plugins/onebrain/skills/help/SKILL.md
@@ -10,7 +10,7 @@ When this skill is invoked, present all available OneBrain commands to the user.
 ## Step 0: Show Plugin Version and Install Location
 
 1. Read `.claude/plugins/onebrain/.claude-plugin/plugin.json` to get the version
-2. Determine install location: use Glob to check if `.claude/plugins/onebrain/.claude-plugin/plugin.json` exists in the current working directory
+2. Determine install location: use Glob to check if `.claude/plugins/onebrain/.claude-plugin/plugin.json` exists in the project root
    - If it exists → this is a **project plugin**
    - If it does not exist → this is a **global plugin** (installed at `~/.claude/plugins/`)
 3. Display as the first line of your response:

--- a/.claude/plugins/onebrain/skills/help/SKILL.md
+++ b/.claude/plugins/onebrain/skills/help/SKILL.md
@@ -7,11 +7,15 @@ description: List all available OneBrain commands with descriptions and use case
 
 When this skill is invoked, present all available OneBrain commands to the user.
 
-## Step 0: Show Plugin Version
+## Step 0: Show Plugin Version and Install Location
 
-Read `.claude/plugins/onebrain/.claude-plugin/plugin.json` and display the version as the first line of your response:
-
-**OneBrain v{version}**
+1. Read `.claude/plugins/onebrain/.claude-plugin/plugin.json` to get the version
+2. Determine install location: use Glob to check if `.claude/plugins/onebrain/.claude-plugin/plugin.json` exists in the current working directory
+   - If it exists → this is a **project plugin**
+   - If it does not exist → this is a **global plugin** (installed at `~/.claude/plugins/`)
+3. Display as the first line of your response:
+   - If project plugin: **OneBrain v{version}** (project plugin)
+   - If global plugin: **OneBrain v{version}** (global plugin)
 
 ## Step 1: Present the Command Table
 

--- a/.claude/plugins/onebrain/skills/help/SKILL.md
+++ b/.claude/plugins/onebrain/skills/help/SKILL.md
@@ -7,6 +7,12 @@ description: List all available OneBrain commands with descriptions and use case
 
 When this skill is invoked, present all available OneBrain commands to the user.
 
+## Step 0: Show Plugin Version
+
+Read `.claude/plugins/onebrain/.claude-plugin/plugin.json` and display the version as the first line of your response:
+
+**OneBrain v{version}**
+
 ## Step 1: Present the Command Table
 
 Display a formatted table with all available commands:


### PR DESCRIPTION
## Summary
- Adds Step 0 to `/help` skill: reads version from `plugin.json` and displays it as the first line of the response
- Bumps plugin version to `1.5.2`

## Test plan
- [ ] Run `/help` and verify `**OneBrain v1.5.2**` appears at the top of the output