### PR TITLE
fix: read plugin version from correct path for global installs

### DIFF
--- a/.claude/plugins/onebrain/.claude-plugin/plugin.json
+++ b/.claude/plugins/onebrain/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "onebrain",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "OneBrain — Where human and AI thinking become one. A powerful thinking partner powered by AI synergy.",
   "author": {
     "name": "OneBrain Contributors"

--- a/.claude/plugins/onebrain/skills/help/SKILL.md
+++ b/.claude/plugins/onebrain/skills/help/SKILL.md
@@ -9,15 +9,16 @@ When this skill is invoked, present all available OneBrain commands to the user.
 
 ## Step 0: Show Plugin Version and Install Location
 
-1. Determine install location: use Glob to check if `.claude/plugins/onebrain/.claude-plugin/plugin.json` exists in the project root
+1. Determine install location: use Glob to check if `.claude/plugins/onebrain/.claude-plugin/plugin.json` exists relative to the vault root
    - If it exists → this is a **project plugin**
    - If it does not exist → this is a **global plugin** (installed at `~/.claude/plugins/`)
 2. Read the version from the correct path:
    - If project plugin: read from `.claude/plugins/onebrain/.claude-plugin/plugin.json`
-   - If global plugin: use Glob on `~/.claude/plugins/cache/onebrain/onebrain/*/.claude-plugin/plugin.json` to find the installed version, then read that file
+   - If global plugin: use Glob on `~/.claude/plugins/cache/onebrain/onebrain/*/.claude-plugin/plugin.json` to find all cached versions. If multiple matches are returned, use the one with the highest version number (compare the version directory name as semver). If no matches are found, skip the version display.
 3. Display as the first line of your response:
    - If project plugin: **OneBrain v{version}** (project plugin)
    - If global plugin: **OneBrain v{version}** (global plugin)
+   - If version could not be determined: **OneBrain** (version unknown)
 
 ## Step 1: Present the Command Table
 

--- a/.claude/plugins/onebrain/skills/help/SKILL.md
+++ b/.claude/plugins/onebrain/skills/help/SKILL.md
@@ -9,10 +9,12 @@ When this skill is invoked, present all available OneBrain commands to the user.
 
 ## Step 0: Show Plugin Version and Install Location
 
-1. Read `.claude/plugins/onebrain/.claude-plugin/plugin.json` to get the version
-2. Determine install location: use Glob to check if `.claude/plugins/onebrain/.claude-plugin/plugin.json` exists in the project root
+1. Determine install location: use Glob to check if `.claude/plugins/onebrain/.claude-plugin/plugin.json` exists in the project root
    - If it exists → this is a **project plugin**
    - If it does not exist → this is a **global plugin** (installed at `~/.claude/plugins/`)
+2. Read the version from the correct path:
+   - If project plugin: read from `.claude/plugins/onebrain/.claude-plugin/plugin.json`
+   - If global plugin: use Glob on `~/.claude/plugins/cache/onebrain/onebrain/*/.claude-plugin/plugin.json` to find the installed version, then read that file
 3. Display as the first line of your response:
    - If project plugin: **OneBrain v{version}** (project plugin)
    - If global plugin: **OneBrain v{version}** (global plugin)

--- a/.claude/plugins/onebrain/skills/help/SKILL.md
+++ b/.claude/plugins/onebrain/skills/help/SKILL.md
@@ -18,7 +18,7 @@ When this skill is invoked, present all available OneBrain commands to the user.
 3. Display as the first line of your response:
    - If project plugin: **OneBrain v{version}** (project plugin)
    - If global plugin: **OneBrain v{version}** (global plugin)
-   - If version could not be determined: **OneBrain** (version unknown)
+   - If version could not be determined: **OneBrain**
 
 ## Step 1: Present the Command Table
 


### PR DESCRIPTION
## Summary

- Reorders Step 0 in `/help` skill to determine install type (project vs global) before reading the version
- For global installs, reads version via Glob on `~/.claude/plugins/cache/onebrain/onebrain/*/.claude-plugin/plugin.json` instead of the missing project path
- Bumps plugin version to `1.5.3`

## Test plan

- [ ] Run `/help` in a vault with project-installed plugin — verify version and "(project plugin)" display
- [ ] Run `/help` in a vault with global-installed plugin — verify version is resolved from the cache path