### PR TITLE
feat: integrate qmd for faster vault search

### DIFF
--- a/.claude/plugins/onebrain/.claude-plugin/plugin.json
+++ b/.claude/plugins/onebrain/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "onebrain",
-  "version": "1.5.6",
+  "version": "1.5.5",
   "description": "OneBrain — Where human and AI thinking become one. A powerful thinking partner powered by AI synergy.",
   "author": {
     "name": "OneBrain Contributors"

--- a/.claude/plugins/onebrain/.claude-plugin/plugin.json
+++ b/.claude/plugins/onebrain/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "onebrain",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "description": "OneBrain — Where human and AI thinking become one. A powerful thinking partner powered by AI synergy.",
   "author": {
     "name": "OneBrain Contributors"

--- a/.claude/plugins/onebrain/.claude-plugin/plugin.json
+++ b/.claude/plugins/onebrain/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "onebrain",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "description": "OneBrain — Where human and AI thinking become one. A powerful thinking partner powered by AI synergy.",
   "author": {
     "name": "OneBrain Contributors"

--- a/.claude/plugins/onebrain/.mcp.json
+++ b/.claude/plugins/onebrain/.mcp.json
@@ -1,0 +1,6 @@
+{
+  "qmd": {
+    "command": "qmd",
+    "args": ["mcp"]
+  }
+}

--- a/.claude/plugins/onebrain/INSTRUCTIONS.md
+++ b/.claude/plugins/onebrain/INSTRUCTIONS.md
@@ -98,8 +98,8 @@ When a user invokes a command, read the corresponding SKILL.md and follow it.
 
 When qmd MCP tools are available (look for `mcp__plugin_onebrain_qmd__query` in your tool list), prefer them for vault content searches:
 
-- **Use qmd `query`** for broad, natural-language searches: "find notes about machine learning", "what did I write about project X", topic exploration across the vault
-- **Use qmd `get` / `multi_get`** to retrieve full document content after identifying relevant results
+- **Use `mcp__plugin_onebrain_qmd__query`** for broad, natural-language searches: "find notes about machine learning", "what did I write about project X", topic exploration across the vault
+- **Use `mcp__plugin_onebrain_qmd__get` / `mcp__plugin_onebrain_qmd__multi_get`** to retrieve full document content after identifying relevant results
 - **Use Glob/Grep/Read** for precise lookups: specific file paths, exact string matches, frontmatter field checks, file existence checks
 
 When qmd tools are NOT available (not installed or not set up), use Glob/Grep/Read as normal — this is the default and requires no special handling.

--- a/.claude/plugins/onebrain/INSTRUCTIONS.md
+++ b/.claude/plugins/onebrain/INSTRUCTIONS.md
@@ -104,7 +104,7 @@ When qmd MCP tools are available (look for `mcp__plugin_onebrain_qmd__query` in 
 
 When qmd tools are NOT available (not installed or not set up), use Glob/Grep/Read as normal — this is the default and requires no special handling.
 
-To enable semantic/similarity search (finding conceptually related notes, not just keyword matches), the user must run `qmd embed` at least once. Suggest `/qmd embed` if the user asks for similarity-based or "related notes" queries and qmd is available but embeddings haven't been run.
+Without embeddings, `mcp__plugin_onebrain_qmd__query` uses BM25 keyword search only. To enable semantic/similarity search (finding conceptually related notes, not just keyword matches), the user must run `/qmd embed` at least once. Suggest this if the user asks for similarity-based or "related notes" queries and qmd is available but embeddings haven't been run.
 
 ## Session Behavior
 

--- a/.claude/plugins/onebrain/INSTRUCTIONS.md
+++ b/.claude/plugins/onebrain/INSTRUCTIONS.md
@@ -88,10 +88,23 @@ These workflows are documented in `.claude/plugins/onebrain/skills/`:
 | `/learn` | `learn/SKILL.md` | Teach the agent — facts or behavioral preferences |
 | `/clone` | `clone/SKILL.md` | Package agent context for vault transfer |
 | `/reorganize` | `reorganize/SKILL.md` | Migrate flat notes into subfolders (one-time) |
+| `/qmd` | `qmd/SKILL.md` | Set up and manage qmd search index |
 | `/update` | `update/SKILL.md` | Update system files from GitHub |
 | `/help` | `help/SKILL.md` | List available commands with use cases |
 
 When a user invokes a command, read the corresponding SKILL.md and follow it.
+
+## Search Strategy
+
+When qmd MCP tools are available (look for `mcp__plugin_onebrain_qmd__query` in your tool list), prefer them for vault content searches:
+
+- **Use qmd `query`** for broad, natural-language searches: "find notes about machine learning", "what did I write about project X", topic exploration across the vault
+- **Use qmd `get` / `multi_get`** to retrieve full document content after identifying relevant results
+- **Use Glob/Grep/Read** for precise lookups: specific file paths, exact string matches, frontmatter field checks, file existence checks
+
+When qmd tools are NOT available (not installed or not set up), use Glob/Grep/Read as normal — this is the default and requires no special handling.
+
+To enable semantic/similarity search (finding conceptually related notes, not just keyword matches), the user must run `qmd embed` at least once. Suggest `/qmd embed` if the user asks for similarity-based or "related notes" queries and qmd is available but embeddings haven't been run.
 
 ## Session Behavior
 

--- a/.claude/plugins/onebrain/hooks/hooks.json
+++ b/.claude/plugins/onebrain/hooks/hooks.json
@@ -8,6 +8,11 @@
             "type": "command",
             "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/open-in-obsidian.sh\" || powershell.exe -ExecutionPolicy Bypass -File \"${CLAUDE_PLUGIN_ROOT}/hooks/open-in-obsidian.ps1\"",
             "async": true
+          },
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/qmd-reindex.sh\" || powershell.exe -ExecutionPolicy Bypass -File \"${CLAUDE_PLUGIN_ROOT}/hooks/qmd-reindex.ps1\"",
+            "async": true
           }
         ]
       }

--- a/.claude/plugins/onebrain/hooks/qmd-reindex.ps1
+++ b/.claude/plugins/onebrain/hooks/qmd-reindex.ps1
@@ -69,9 +69,10 @@ Write-Log "collection: $collection"
 Write-Log "running: qmd update -c $collection"
 try {
     if ($LogFile) {
-        $LogFileErr = $LogFile -replace '\.log$', '-err.log'
+        $LogFileOut = $LogFile -replace '\.log$', '-qmd-out.log'
+        $LogFileErr = $LogFile -replace '\.log$', '-qmd-err.log'
         $proc = Start-Process -FilePath "qmd" -ArgumentList "update", "-c", $collection `
-            -NoNewWindow -PassThru -RedirectStandardOutput $LogFile -RedirectStandardError $LogFileErr
+            -NoNewWindow -PassThru -RedirectStandardOutput $LogFileOut -RedirectStandardError $LogFileErr
     } else {
         $proc = Start-Process -FilePath "qmd" -ArgumentList "update", "-c", $collection `
             -NoNewWindow -PassThru

--- a/.claude/plugins/onebrain/hooks/qmd-reindex.ps1
+++ b/.claude/plugins/onebrain/hooks/qmd-reindex.ps1
@@ -69,8 +69,9 @@ Write-Log "collection: $collection"
 Write-Log "running: qmd update -c $collection"
 try {
     if ($LogFile) {
+        $LogFileErr = $LogFile -replace '\.log$', '-err.log'
         $proc = Start-Process -FilePath "qmd" -ArgumentList "update", "-c", $collection `
-            -NoNewWindow -PassThru -RedirectStandardOutput $LogFile -RedirectStandardError $LogFile
+            -NoNewWindow -PassThru -RedirectStandardOutput $LogFile -RedirectStandardError $LogFileErr
     } else {
         $proc = Start-Process -FilePath "qmd" -ArgumentList "update", "-c", $collection `
             -NoNewWindow -PassThru

--- a/.claude/plugins/onebrain/hooks/qmd-reindex.ps1
+++ b/.claude/plugins/onebrain/hooks/qmd-reindex.ps1
@@ -3,39 +3,81 @@
 # Requires qmd installed and vault.yml containing a qmd_collection key.
 # Always exits 0 — never blocks Claude Code.
 
-$ErrorActionPreference = "SilentlyContinue"
+# ── Debug logging ─────────────────────────────────────────────────────────────
+$LogFile = $null
+if ($env:DEBUG -eq "1") {
+    $LogFile = "$env:TEMP\onebrain-qmd-debug.log"
+    if ((Test-Path $LogFile) -and (Get-Item $LogFile).Length -gt 1MB) {
+        Clear-Content $LogFile
+    }
+}
+function Write-Log {
+    param([string]$Message)
+    if ($LogFile) {
+        $ts = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+        Add-Content -Path $LogFile -Value "[$ts] $Message"
+    }
+}
 
-# Check qmd is installed
-if (-not (Get-Command qmd -ErrorAction SilentlyContinue)) {
+Write-Log "qmd-reindex.ps1 started"
+
+# ── Check qmd is installed ─────────────────────────────────────────────────────
+$qmdCmd = Get-Command qmd -ErrorAction SilentlyContinue
+if (-not $qmdCmd) {
+    Write-Log "qmd not found in PATH, exiting"
     exit 0
 }
 
-# Resolve vault root
+# ── Resolve vault root ─────────────────────────────────────────────────────────
 $vaultRoot = $env:CLAUDE_PROJECT_DIR
 if (-not $vaultRoot) {
+    Write-Log "CLAUDE_PROJECT_DIR not set, exiting"
     exit 0
 }
 $vaultRoot = $vaultRoot.TrimEnd('\', '/')
 
-# Read qmd_collection from vault.yml
+# ── Read qmd_collection from vault.yml ────────────────────────────────────────
 $vaultYml = Join-Path $vaultRoot "vault.yml"
 if (-not (Test-Path $vaultYml)) {
+    Write-Log "vault.yml not found at $vaultYml, exiting"
     exit 0
 }
 
 $collection = ""
-foreach ($line in Get-Content $vaultYml) {
-    if ($line -match '^qmd_collection:\s+(\S+)') {
-        $collection = $matches[1].Trim('"', "'")
-        break
+try {
+    foreach ($line in Get-Content $vaultYml -ErrorAction Stop) {
+        # Match top-level key: qmd_collection: <value>
+        # Strip inline YAML comments before extracting value
+        if ($line -match '^qmd_collection:\s+(\S.*)') {
+            $raw = $matches[1] -replace '\s*#.*$', '' # strip inline comments
+            $collection = $raw.Trim().Trim('"', "'")
+            break
+        }
     }
-}
-
-if (-not $collection) {
+} catch {
+    Write-Log "Error reading vault.yml: $_"
     exit 0
 }
 
-# Run qmd update in background
-Start-Process -FilePath "qmd" -ArgumentList "update", "-c", $collection -NoNewWindow -PassThru | Out-Null
+if (-not $collection) {
+    Write-Log "qmd_collection not set in vault.yml, exiting"
+    exit 0
+}
+Write-Log "collection: $collection"
+
+# ── Run qmd update ─────────────────────────────────────────────────────────────
+Write-Log "running: qmd update -c $collection"
+try {
+    if ($LogFile) {
+        $proc = Start-Process -FilePath "qmd" -ArgumentList "update", "-c", $collection `
+            -NoNewWindow -PassThru -RedirectStandardOutput $LogFile -RedirectStandardError $LogFile
+    } else {
+        $proc = Start-Process -FilePath "qmd" -ArgumentList "update", "-c", $collection `
+            -NoNewWindow -PassThru
+    }
+    Write-Log "qmd update dispatched (pid $($proc.Id))"
+} catch {
+    Write-Log "Failed to start qmd update: $_"
+}
 
 exit 0

--- a/.claude/plugins/onebrain/hooks/qmd-reindex.ps1
+++ b/.claude/plugins/onebrain/hooks/qmd-reindex.ps1
@@ -1,0 +1,41 @@
+# qmd-reindex.ps1 — PostToolUse hook (Windows)
+# Runs `qmd update` on the vault collection after Write/Edit tool use.
+# Requires qmd installed and vault.yml containing a qmd_collection key.
+# Always exits 0 — never blocks Claude Code.
+
+$ErrorActionPreference = "SilentlyContinue"
+
+# Check qmd is installed
+if (-not (Get-Command qmd -ErrorAction SilentlyContinue)) {
+    exit 0
+}
+
+# Resolve vault root
+$vaultRoot = $env:CLAUDE_PROJECT_DIR
+if (-not $vaultRoot) {
+    exit 0
+}
+$vaultRoot = $vaultRoot.TrimEnd('\', '/')
+
+# Read qmd_collection from vault.yml
+$vaultYml = Join-Path $vaultRoot "vault.yml"
+if (-not (Test-Path $vaultYml)) {
+    exit 0
+}
+
+$collection = ""
+foreach ($line in Get-Content $vaultYml) {
+    if ($line -match '^qmd_collection:\s+(\S+)') {
+        $collection = $matches[1].Trim('"', "'")
+        break
+    }
+}
+
+if (-not $collection) {
+    exit 0
+}
+
+# Run qmd update in background
+Start-Process -FilePath "qmd" -ArgumentList "update", "-c", $collection -NoNewWindow -PassThru | Out-Null
+
+exit 0

--- a/.claude/plugins/onebrain/hooks/qmd-reindex.sh
+++ b/.claude/plugins/onebrain/hooks/qmd-reindex.sh
@@ -38,7 +38,7 @@ read_qmd_collection() {
   while IFS= read -r line || [ -n "$line" ]; do
     # Match top-level key: qmd_collection: <value>
     if printf '%s' "$line" | grep -qE '^qmd_collection:[[:space:]]+\S'; then
-      collection=$(printf '%s' "$line" | sed 's/^qmd_collection:[[:space:]]*//' | tr -d ' \r"'"'"'')
+      collection=$(printf '%s' "$line" | sed 's/^qmd_collection:[[:space:]]*//' | sed 's/[[:space:]]*#.*//' | tr -d ' \r"'"'"'')
       break
     fi
   done < "$yml"
@@ -53,8 +53,9 @@ fi
 log "collection: $collection"
 
 # ── Run qmd update ─────────────────────────────────────────────────────────────
-log "running: qmd update -c $collection"
+log "running: qmd update -c ${collection}"
 qmd update -c "$collection" &>/dev/null &
-log "qmd update dispatched (pid $!)"
+disown $!
+log "qmd update dispatched"
 
 exit 0

--- a/.claude/plugins/onebrain/hooks/qmd-reindex.sh
+++ b/.claude/plugins/onebrain/hooks/qmd-reindex.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# qmd-reindex.sh — PostToolUse hook
+# Runs `qmd update` on the vault collection after Write/Edit tool use.
+# Requires qmd installed and vault.yml containing a qmd_collection key.
+# Always exits 0 — never blocks Claude Code.
+
+# No set -euo pipefail — hook script must be resilient; pipefail causes
+# silent crashes on unexpected input instead of graceful no-ops.
+
+# ── Debug logging ─────────────────────────────────────────────────────────────
+LOG=""
+if [ "${DEBUG:-}" = "1" ]; then
+  LOG="/tmp/onebrain-qmd-debug.log"
+  [ -f "$LOG" ] && [ "$(wc -c < "$LOG")" -gt 1048576 ] && : > "$LOG"
+  echo "[$(date -u +"%Y-%m-%dT%H:%M:%SZ")] qmd-reindex.sh started" >> "$LOG"
+fi
+log() { [ -n "$LOG" ] && echo "[$(date -u +"%Y-%m-%dT%H:%M:%SZ")] $*" >> "$LOG" || true; }
+
+# ── Check qmd is installed ─────────────────────────────────────────────────────
+if ! command -v qmd &>/dev/null; then
+  log "qmd not found in PATH, exiting"
+  exit 0
+fi
+
+# ── Resolve vault root ─────────────────────────────────────────────────────────
+vault_root="${CLAUDE_PROJECT_DIR%/}"
+if [ -z "$vault_root" ]; then
+  log "CLAUDE_PROJECT_DIR not set, exiting"
+  exit 0
+fi
+
+# ── Read qmd_collection from vault.yml ────────────────────────────────────────
+# POSIX tools only — no jq or Python required
+read_qmd_collection() {
+  local yml="$vault_root/vault.yml"
+  [ -f "$yml" ] || return 1
+  local collection=""
+  while IFS= read -r line || [ -n "$line" ]; do
+    # Match top-level key: qmd_collection: <value>
+    if printf '%s' "$line" | grep -qE '^qmd_collection:[[:space:]]+\S'; then
+      collection=$(printf '%s' "$line" | sed 's/^qmd_collection:[[:space:]]*//' | tr -d ' \r"'"'"'')
+      break
+    fi
+  done < "$yml"
+  printf '%s' "$collection"
+}
+
+collection=$(read_qmd_collection 2>/dev/null || true)
+if [ -z "$collection" ]; then
+  log "qmd_collection not set in vault.yml, exiting"
+  exit 0
+fi
+log "collection: $collection"
+
+# ── Run qmd update ─────────────────────────────────────────────────────────────
+log "running: qmd update -c $collection"
+qmd update -c "$collection" &>/dev/null &
+log "qmd update dispatched (pid $!)"
+
+exit 0

--- a/.claude/plugins/onebrain/hooks/qmd-reindex.sh
+++ b/.claude/plugins/onebrain/hooks/qmd-reindex.sh
@@ -45,7 +45,7 @@ read_qmd_collection() {
   printf '%s' "$collection"
 }
 
-collection=$(read_qmd_collection 2>/dev/null)
+collection=$(read_qmd_collection 2>/dev/null) || true
 if [ -z "$collection" ]; then
   log "qmd_collection not set in vault.yml, exiting"
   exit 0

--- a/.claude/plugins/onebrain/hooks/qmd-reindex.sh
+++ b/.claude/plugins/onebrain/hooks/qmd-reindex.sh
@@ -45,7 +45,7 @@ read_qmd_collection() {
   printf '%s' "$collection"
 }
 
-collection=$(read_qmd_collection 2>&1) || { log "vault.yml parse error: ${collection}"; collection=""; }
+collection=$(read_qmd_collection 2>/dev/null)
 if [ -z "$collection" ]; then
   log "qmd_collection not set in vault.yml, exiting"
   exit 0

--- a/.claude/plugins/onebrain/hooks/qmd-reindex.sh
+++ b/.claude/plugins/onebrain/hooks/qmd-reindex.sh
@@ -45,7 +45,7 @@ read_qmd_collection() {
   printf '%s' "$collection"
 }
 
-collection=$(read_qmd_collection 2>/dev/null || true)
+collection=$(read_qmd_collection 2>&1) || { log "vault.yml parse error: ${collection}"; collection=""; }
 if [ -z "$collection" ]; then
   log "qmd_collection not set in vault.yml, exiting"
   exit 0
@@ -54,8 +54,13 @@ log "collection: $collection"
 
 # ── Run qmd update ─────────────────────────────────────────────────────────────
 log "running: qmd update -c ${collection}"
-qmd update -c "$collection" &>/dev/null &
-disown $!
-log "qmd update dispatched"
+if [ -n "$LOG" ]; then
+  qmd update -c "$collection" >> "$LOG" 2>&1 &
+else
+  qmd update -c "$collection" &>/dev/null &
+fi
+pid=$!
+disown "$pid"
+log "qmd update dispatched (pid ${pid})"
 
 exit 0

--- a/.claude/plugins/onebrain/skills/help/SKILL.md
+++ b/.claude/plugins/onebrain/skills/help/SKILL.md
@@ -42,6 +42,7 @@ Display a formatted table with all available commands:
 | `/learn` | Teach the agent something — facts about your world or behavioral preferences | When you want the agent to remember something across all future sessions |
 | `/clone` | Package your agent context (agent folder including MEMORY.md) for vault transfer | When moving to a new vault and want to preserve your agent's memory |
 | `/reorganize` | Migrate existing flat notes into subfolders — one-time migration | After upgrading to a version with subfolder organization |
+| `/qmd` | Set up and manage qmd search index (setup, embed, status, reindex, uninstall) | When you want faster vault search or need to manage the search index |
 | `/update` | Update OneBrain system files from GitHub | When a new version is available |
 | `/help` | List all available commands | You're already here! |
 

--- a/.claude/plugins/onebrain/skills/onboarding/SKILL.md
+++ b/.claude/plugins/onebrain/skills/onboarding/SKILL.md
@@ -292,6 +292,23 @@ folders:
   logs: 07-logs
 ```
 
+
+---
+
+## Step 11b: qmd Setup (Optional)
+
+Ask the user using AskUserQuestion:
+- question: "Would you like to set up qmd for faster vault search? qmd is a local search engine that makes finding notes much faster."
+- header: "qmd Search"
+- multiSelect: false
+- options:
+  - label: "Yes, set up qmd", description: "Recommended — enables faster search, especially as your vault grows"
+  - label: "Skip for now", description: "You can always run /qmd setup later"
+
+If user selects "Yes, set up qmd": run the `/qmd setup` flow from `skills/qmd/SKILL.md` (skip the initial confirmation question — they already confirmed). If qmd setup fails for any reason, report the error and continue to Step 12 without stopping onboarding.
+
+If user selects "Skip for now": continue to Step 12.
+
 ---
 
 ## Step 12: Completion Message
@@ -310,6 +327,8 @@ Say:
 >   - `05-agent/` — AI context and memory
 >   - `06-archive/` — completed and archived items
 >   - `07-logs/` — session logs
+>
+> [If qmd was set up in Step 11b:] qmd search index active (collection: `<name>`) — the agent will use qmd automatically
 >
 > **First things to try:**
 > - `/braindump` — dump anything on your mind right now
@@ -480,6 +499,13 @@ Check if `vault.yml` already exists in the vault root:
 
 **If it does not exist:** Write `vault.yml` using the same template as Step 11 in the standard Path A flow.
 
+
+---
+
+## Path B — Step 12b: qmd Setup (Optional)
+
+Identical to Step 11b in Path A. Ask the user whether to set up qmd, and if yes, run the `/qmd setup` flow (skipping its initial confirmation question). Continue to Step 13 regardless of outcome.
+
 ---
 
 ## Path B — Step 13: Completion message
@@ -496,5 +522,7 @@ Say:
 > Use `/update` to keep OneBrain current — it works the same as a fresh vault install.
 >
 > The global plugin install is no longer needed for this vault. You can remove it with `/plugin uninstall onebrain@onebrain` if you like, but it's safe to leave as-is.
+>
+> [If qmd was set up in Step 12b:] qmd search index active (collection: `<name>`)
 >
 > What would you like to do first?

--- a/.claude/plugins/onebrain/skills/qmd/SKILL.md
+++ b/.claude/plugins/onebrain/skills/qmd/SKILL.md
@@ -1,0 +1,280 @@
+---
+name: qmd
+description: Set up and manage qmd search index for faster vault search. Subcommands: setup, embed, status, reindex, uninstall.
+---
+
+# /qmd — qmd Search Integration
+
+qmd is an optional local search engine that indexes your vault for fast keyword and semantic search. When active, the agent uses it automatically for vault-wide searches.
+
+**Usage:** `/qmd <subcommand>`
+
+Available subcommands: `setup`, `embed`, `status`, `reindex`, `uninstall`
+
+If no subcommand is given, show this help and list available subcommands.
+
+---
+
+## /qmd setup
+
+Set up qmd for this vault. Creates a collection, stores it in vault.yml, and runs an initial index.
+
+### Step 1: Confirm intent
+
+Ask using AskUserQuestion:
+- question: "Set up qmd for faster vault search?"
+- header: "qmd Setup"
+- multiSelect: false
+- options:
+  - label: "Yes, set up qmd", description: "Index this vault with qmd for faster search"
+  - label: "Cancel", description: "Skip qmd setup"
+
+If user selects Cancel, stop.
+
+### Step 2: Check for existing setup
+
+Read `vault.yml`. If `qmd_collection` key is already present:
+> qmd is already configured for this vault (collection: `<value>`). To reconfigure, run `/qmd uninstall` first, then `/qmd setup` again.
+
+Stop.
+
+### Step 3: Check qmd installation
+
+Run: `which qmd` (macOS/Linux) or `where qmd` (Windows).
+
+**If qmd is NOT found:**
+
+Ask using AskUserQuestion:
+- question: "qmd is not installed. Install it now?"
+- header: "Install qmd"
+- multiSelect: false
+- options:
+  - label: "Yes, install with npm", description: "Run: npm install -g @tobilu/qmd"
+  - label: "Yes, install with bun", description: "Run: bun install -g @tobilu/qmd"
+  - label: "Cancel", description: "Skip for now — install manually later"
+
+If Cancel: tell user "You can install qmd manually with `npm install -g @tobilu/qmd`, then run `/qmd setup` again." Stop.
+
+If npm: run `npm install -g @tobilu/qmd`. If it fails, show the error and stop.
+If bun: run `bun install -g @tobilu/qmd`. If it fails, show the error and stop.
+
+After installation, verify with `which qmd`. If still not found, tell user to check their PATH and stop.
+
+### Step 4: Generate collection name
+
+1. Get vault root directory name: `basename "$CLAUDE_PROJECT_DIR"` (or PowerShell equivalent)
+2. Generate a 6-character random hex string: `openssl rand -hex 3` or `python3 -c "import secrets; print(secrets.token_hex(3))"`
+3. Collection name = `<vault-dirname>-<hex>` (e.g., `onebrain-a3f2c1`)
+
+### Step 5: Read archive folder from vault.yml
+
+Read vault.yml. Get `folders.archive` value (default: `06-archive`).
+
+### Step 6: Create the qmd collection
+
+Run:
+```
+qmd collection add <vault-root-path> --name <collection-name>
+```
+
+Where `<vault-root-path>` is the value of `$CLAUDE_PROJECT_DIR`.
+
+If this command supports ignore patterns, also pass:
+```
+--ignore ".obsidian/**" --ignore ".claude/**" --ignore ".git/**" --ignore "docs/**" --ignore "<archive-folder>/**" --ignore "attachments/**"
+```
+
+If the command fails, show the error and stop.
+
+### Step 7: Add context description
+
+Run:
+```
+qmd context add "qmd://<collection-name>" "Personal Obsidian knowledge vault — notes, projects, areas, resources, and session logs"
+```
+
+If this command fails, report the error but continue (context is optional metadata).
+
+### Step 8: Store collection name in vault.yml
+
+Read vault.yml. Add `qmd_collection: <collection-name>` as a top-level key immediately after the `method:` line (before the `folders:` block). Write the full updated vault.yml back.
+
+Example of updated vault.yml:
+```yaml
+method: onebrain
+qmd_collection: onebrain-a3f2c1
+folders:
+  inbox: 00-inbox
+  ...
+```
+
+If the write fails, show the error. Tell the user to manually add `qmd_collection: <collection-name>` to vault.yml. Stop.
+
+### Step 9: Run initial index
+
+Run:
+```
+qmd update -c <collection-name>
+```
+
+Report progress. If it fails, show the error — the collection is created but not indexed. User can run `/qmd reindex` to retry.
+
+### Step 10: Confirm completion
+
+Say:
+> qmd is set up! Collection `<collection-name>` is indexed and ready.
+>
+> - The agent will now use qmd for vault-wide searches automatically
+> - The index updates after every file change (via hook)
+> - Run `/qmd embed` to enable semantic/similarity search (optional, slower first run)
+> - Run `/qmd status` to check index health
+> - Run `/qmd uninstall` to remove qmd integration from this vault
+
+---
+
+## /qmd embed
+
+Generate vector embeddings for semantic search.
+
+### Step 1: Check prerequisites
+
+Read vault.yml. If `qmd_collection` key is missing:
+> qmd is not configured for this vault. Run `/qmd setup` first.
+
+Stop.
+
+Check `which qmd`. If not found:
+> qmd is not installed. Run `/qmd setup` to install and configure it.
+
+Stop.
+
+### Step 2: Warn about time
+
+Tell user:
+> Generating embeddings for the first time may take several minutes depending on vault size. This runs locally — no data leaves your machine. Continue?
+
+Use AskUserQuestion with Yes / Cancel options.
+
+### Step 3: Run embed
+
+Run:
+```
+qmd embed -c <collection-name>
+```
+
+Where `<collection-name>` is read from vault.yml `qmd_collection`.
+
+Report completion or any errors.
+
+### Step 4: Confirm
+
+Say:
+> Embeddings generated. Semantic search is now active — use natural language queries like "find notes about project planning" and qmd will find conceptually related notes.
+
+---
+
+## /qmd status
+
+Show collection info and index health.
+
+### Step 1: Check prerequisites
+
+Read vault.yml for `qmd_collection`. If missing:
+> qmd is not configured for this vault. Run `/qmd setup` to enable it.
+
+Stop.
+
+Check `which qmd`. If not found:
+> qmd binary not found. It may have been uninstalled. Run `/qmd setup` to reinstall and reconfigure.
+
+Stop.
+
+### Step 2: Run status
+
+Run:
+```
+qmd collection list
+```
+
+Show the output to the user. Highlight the line for the vault's collection name.
+
+---
+
+## /qmd reindex
+
+Force a full BM25 reindex of the vault collection.
+
+### Step 1: Check prerequisites
+
+Read vault.yml for `qmd_collection`. If missing:
+> qmd is not configured for this vault. Run `/qmd setup` first.
+
+Stop.
+
+Check `which qmd`. If not found:
+> qmd is not installed. Run `/qmd setup` to install and configure it.
+
+Stop.
+
+### Step 2: Run update
+
+Run:
+```
+qmd update -c <collection-name>
+```
+
+Where `<collection-name>` is read from vault.yml `qmd_collection`.
+
+Report progress and any errors.
+
+### Step 3: Confirm
+
+Say:
+> Index updated. All vault notes are now searchable.
+
+---
+
+## /qmd uninstall
+
+Remove qmd integration from this vault. Does not uninstall the qmd binary.
+
+### Step 1: Check prerequisites
+
+Read vault.yml. If `qmd_collection` key is missing:
+> qmd is not configured for this vault. Nothing to uninstall.
+
+Stop.
+
+### Step 2: Confirm
+
+Ask using AskUserQuestion:
+- question: "Remove qmd integration from this vault?"
+- header: "Confirm"
+- multiSelect: false
+- options:
+  - label: "Yes, remove qmd", description: "Removes the collection and disables qmd search for this vault. Does not uninstall qmd itself."
+  - label: "Cancel", description: "Keep qmd as-is"
+
+If Cancel, stop.
+
+### Step 3: Remove collection from qmd
+
+Read `qmd_collection` from vault.yml. Run:
+```
+qmd collection remove <collection-name>
+```
+
+If qmd is not installed or the command fails, report the error but continue to Step 4 (still need to clean vault.yml).
+
+### Step 4: Remove qmd_collection from vault.yml
+
+Read vault.yml. Remove the `qmd_collection: ...` line. Write the full updated vault.yml back.
+
+If the write fails, show the error. Tell the user to manually remove the `qmd_collection` line from vault.yml.
+
+### Step 5: Confirm
+
+Say:
+> qmd search disabled for this vault. The agent will use standard Glob/Grep/Read search.
+>
+> You can re-enable anytime with `/qmd setup`.

--- a/.claude/plugins/onebrain/skills/qmd/SKILL.md
+++ b/.claude/plugins/onebrain/skills/qmd/SKILL.md
@@ -63,7 +63,7 @@ After installation, verify with `which qmd`. If still not found, tell user to ch
 ### Step 4: Generate collection name
 
 1. Get vault root directory name: `basename "$CLAUDE_PROJECT_DIR"` (or PowerShell equivalent)
-2. Generate a 6-character random hex string: `openssl rand -hex 3` or `python3 -c "import secrets; print(secrets.token_hex(3))"`
+2. Generate a 6-character random hex string: try `openssl rand -hex 3` first; if that fails, try `python3 -c "import secrets; print(secrets.token_hex(3))"`. If both fail, tell the user "Could not generate a unique collection name. Please run `/qmd setup` again." and stop.
 3. Collection name = `<vault-dirname>-<hex>` (e.g., `onebrain-a3f2c1`)
 
 ### Step 5: Read archive folder from vault.yml
@@ -74,15 +74,10 @@ Read vault.yml. Get `folders.archive` value (default: `06-archive`).
 
 Run:
 ```
-qmd collection add <vault-root-path> --name <collection-name>
+qmd collection add <vault-root-path> --name <collection-name> --ignore ".obsidian/**" --ignore ".claude/**" --ignore ".git/**" --ignore "docs/**" --ignore "<archive-folder>/**" --ignore "attachments/**"
 ```
 
-Where `<vault-root-path>` is the value of `$CLAUDE_PROJECT_DIR`.
-
-If this command supports ignore patterns, also pass:
-```
---ignore ".obsidian/**" --ignore ".claude/**" --ignore ".git/**" --ignore "docs/**" --ignore "<archive-folder>/**" --ignore "attachments/**"
-```
+Where `<vault-root-path>` is the value of `$CLAUDE_PROJECT_DIR` and `<archive-folder>` is the value read in Step 5.
 
 If the command fails, show the error and stop.
 
@@ -125,7 +120,7 @@ Say:
 > qmd is set up! Collection `<collection-name>` is indexed and ready.
 >
 > - The agent will now use qmd for vault-wide searches automatically
-> - The index updates after every file change (via hook)
+> - The index updates whenever Claude writes or edits files in this vault (via hook)
 > - Run `/qmd embed` to enable semantic/similarity search (optional, slower first run)
 > - Run `/qmd status` to check index health
 > - Run `/qmd uninstall` to remove qmd integration from this vault
@@ -150,10 +145,15 @@ Stop.
 
 ### Step 2: Warn about time
 
-Tell user:
-> Generating embeddings for the first time may take several minutes depending on vault size. This runs locally — no data leaves your machine. Continue?
+Ask using AskUserQuestion:
+- question: "Generating embeddings for the first time may take several minutes depending on vault size. This runs locally — no data leaves your machine. Continue?"
+- header: "Generate Embeddings"
+- multiSelect: false
+- options:
+  - label: "Yes, generate embeddings", description: "Run qmd embed — may take a few minutes for large vaults"
+  - label: "Cancel", description: "Skip for now"
 
-Use AskUserQuestion with Yes / Cancel options.
+If Cancel, stop.
 
 ### Step 3: Run embed
 

--- a/.claude/plugins/onebrain/skills/update/SKILL.md
+++ b/.claude/plugins/onebrain/skills/update/SKILL.md
@@ -259,6 +259,8 @@ Run this procedure for each vault.yml key in the table below:
 | `import_inbox` | `[inbox]/imports` | v1.2.0 |
 | `attachments` | `attachments` | v1.2.0 |
 
+> **Note:** `qmd_collection` is a user-specific key set by `/qmd setup`. It is never included in the migration table above and must never be added or removed by `/update`. If `qmd_collection` is already present in vault.yml, leave it unchanged. If it is absent, leave it absent — the user may not have set up qmd.
+
 For each key:
 1. **Check if vault.yml exists.** If it does not exist: skip this key entirely (the user needs to run `/onboarding` first — do not create or modify vault.yml here).
 2. **Read vault.yml.** If it cannot be read or parsed: report the error, skip this key, continue.


### PR DESCRIPTION
## Summary

- Adds qmd as an optional local search engine for OneBrain vaults — BM25 + vector + re-ranking via built-in MCP server
- New `/qmd` skill manages setup, embedding, status, reindex, and uninstall with graceful opt-in/opt-out flow
- PostToolUse hook (`qmd-reindex.sh` + `.ps1`) auto-reindexes after every Write/Edit; agent falls back to Glob/Grep/Read when qmd is not installed
- Onboarding updated to offer qmd setup as an optional step after vault creation (Step 11b / Path B Step 12b)
- Collection name is `<vault-dirname>-<6-char-uuid>` stored in `vault.yml` as `qmd_collection` for multi-vault uniqueness
- Plugin bumped to v1.5.5

## Test Plan

- [ ] Install qmd (`npm install -g @tobilu/qmd`), start new session — verify `mcp__plugin_onebrain_qmd__query` tool appears
- [ ] Run `/qmd setup` — verify collection created, `vault.yml` updated with `qmd_collection` key
- [ ] Edit a vault note — verify `qmd update` runs via hook (`DEBUG=1` to check `/tmp/onebrain-qmd-debug.log`)
- [ ] Run `/qmd embed` — verify semantic search activates
- [ ] Run `/qmd status`, `/qmd reindex`, `/qmd uninstall` — verify each subcommand works
- [ ] Without qmd installed — verify agent uses Glob/Grep/Read normally, no errors
- [ ] Run `/onboarding` fresh — verify Step 11b qmd offer appears
- [ ] Run `/help` — verify `/qmd` row present
- [ ] Run `/update` — verify `qmd_collection` key preserved in vault.yml

🤖 Generated with [Claude Code](https://claude.ai/claude-code)