### PR TITLE
feat: add /moc vault portal command

### DIFF
--- a/.claude/plugins/onebrain/.claude-plugin/plugin.json
+++ b/.claude/plugins/onebrain/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "onebrain",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "description": "OneBrain — Where human and AI thinking become one. A powerful thinking partner powered by AI synergy.",
   "author": {
     "name": "OneBrain Contributors"

--- a/.claude/plugins/onebrain/INSTRUCTIONS.md
+++ b/.claude/plugins/onebrain/INSTRUCTIONS.md
@@ -84,6 +84,7 @@ These workflows are documented in `.claude/plugins/onebrain/skills/`:
 | `/reading-notes` | `reading-notes/SKILL.md` | Book/article → structured notes |
 | `/weekly` | `weekly/SKILL.md` | Weekly reflection |
 | `/tasks` | `tasks/SKILL.md` | Create or update live task dashboard (TASKS.md) and open in Obsidian |
+| `/moc` | `moc/SKILL.md` | Create or update vault portal (MOC.md) and open in Obsidian |
 | `/wrapup` | `wrapup/SKILL.md` | Wrap up session → session log |
 | `/learn` | `learn/SKILL.md` | Teach the agent — facts or behavioral preferences |
 | `/clone` | `clone/SKILL.md` | Package agent context for vault transfer |
@@ -116,6 +117,7 @@ At the start of every session, perform these steps:
    >
    > **Agent memory (on-demand only):** `[agent folder]/memory/` is searched during a session when the user's request seems to relate to a past pattern or preference. It is never loaded at startup.
 3. Check inbox count
+3b. Refresh MOC.md AI zone — if `MOC.md` exists at vault root, silently rewrite only the `[!info] Agent Summary` callout with fresh counts (steps 1–2 from the `/moc` skill). The AI zone boundary is all content between the `# 🧠 Vault Portal` heading and the first `## ` section heading — replace only that block. Do not rewrite Dataview sections or the Pinned section. If `MOC.md` does not exist, skip silently. No output to the user.
 4. Read the most recent session log entry
 5. Greet the user by name with relevant context
 

--- a/.claude/plugins/onebrain/INSTRUCTIONS.md
+++ b/.claude/plugins/onebrain/INSTRUCTIONS.md
@@ -117,7 +117,7 @@ At the start of every session, perform these steps:
    >
    > **Agent memory (on-demand only):** `[agent folder]/memory/` is searched during a session when the user's request seems to relate to a past pattern or preference. It is never loaded at startup.
 3. Check inbox count
-4. Refresh MOC.md AI zone — if `MOC.md` exists at vault root, silently rewrite only the `[!info] Agent Summary` callout with fresh counts (steps 1–2 from the `/moc` skill). The AI zone boundary is all content between the `# 🧠 Vault Portal` heading and the first `## ` section heading — replace only that block. Do not rewrite Dataview sections or the Pinned section. If `MOC.md` does not exist, skip silently. No output to the user.
+4. Refresh MOC.md AI zone — if `MOC.md` exists at vault root, silently update the `[!info] Agent Summary` callout using folder paths already loaded in step 1. Scan note counts via Glob (projects, areas, knowledge, resources, inbox) and find the most recently modified note across those folders. Then read `MOC.md`, find the callout block (all consecutive lines starting with `>` immediately after `# 🧠 Vault Portal`), replace those lines with fresh counts, and write the file back. Do not touch any other content. If `MOC.md` does not exist, skip silently. No output to the user.
 5. Read the most recent session log entry
 6. Greet the user by name with relevant context
 

--- a/.claude/plugins/onebrain/INSTRUCTIONS.md
+++ b/.claude/plugins/onebrain/INSTRUCTIONS.md
@@ -117,9 +117,9 @@ At the start of every session, perform these steps:
    >
    > **Agent memory (on-demand only):** `[agent folder]/memory/` is searched during a session when the user's request seems to relate to a past pattern or preference. It is never loaded at startup.
 3. Check inbox count
-3b. Refresh MOC.md AI zone — if `MOC.md` exists at vault root, silently rewrite only the `[!info] Agent Summary` callout with fresh counts (steps 1–2 from the `/moc` skill). The AI zone boundary is all content between the `# 🧠 Vault Portal` heading and the first `## ` section heading — replace only that block. Do not rewrite Dataview sections or the Pinned section. If `MOC.md` does not exist, skip silently. No output to the user.
-4. Read the most recent session log entry
-5. Greet the user by name with relevant context
+4. Refresh MOC.md AI zone — if `MOC.md` exists at vault root, silently rewrite only the `[!info] Agent Summary` callout with fresh counts (steps 1–2 from the `/moc` skill). The AI zone boundary is all content between the `# 🧠 Vault Portal` heading and the first `## ` section heading — replace only that block. Do not rewrite Dataview sections or the Pinned section. If `MOC.md` does not exist, skip silently. No output to the user.
+5. Read the most recent session log entry
+6. Greet the user by name with relevant context
 
 ### Recalling Information
 

--- a/.claude/plugins/onebrain/skills/help/SKILL.md
+++ b/.claude/plugins/onebrain/skills/help/SKILL.md
@@ -37,6 +37,7 @@ Display a formatted table with all available commands:
 | `/import` | Import local files (PDF, Word, Excel, images, video, scripts) into vault notes | When you have files on disk you want distilled into your knowledge base |
 | `/reading-notes` | Book or article → structured progressive summary | When finishing a book or long article and want to capture it |
 | `/tasks` | Open live task dashboard in Obsidian — creates/updates `TASKS.md` with live query sections | When you want an overview of what needs doing |
+| `/moc` | Create or refresh vault portal (MOC.md) — a Map of Content with live queries, AI summary, and your pinned links | When you want a bird's-eye view of your entire vault |
 | `/weekly` | Weekly reflection — review sessions, patterns, intentions | At the end of each week for review and planning |
 | `/wrapup` | Save a session summary to your session log | At the end of a work session to capture what you did |
 | `/learn` | Teach the agent something — facts about your world or behavioral preferences | When you want the agent to remember something across all future sessions |

--- a/.claude/plugins/onebrain/skills/moc/SKILL.md
+++ b/.claude/plugins/onebrain/skills/moc/SKILL.md
@@ -33,6 +33,9 @@ Read `vault.yml` from the current working directory. Extract folder paths with t
 If `vault.yml` does not exist, use all defaults and warn the user:
 > "vault.yml not found — using default folder paths. Run `/onboarding` to set up your vault configuration."
 
+If `vault.yml` exists but cannot be read or parsed, stop immediately and tell the user:
+> "vault.yml exists but could not be parsed — aborting. Check vault.yml for syntax errors and try again. Error: [error]."
+
 Store `moc_path = {vault_root}/MOC.md`.
 
 ---
@@ -48,19 +51,27 @@ Collect the following using Glob to count `.md` files:
 - **inbox_count** — `.md` files directly in `[folders.inbox]/` (non-recursive, direct children only)
 - **focus_note** — the single most recently modified `.md` file across projects, areas, knowledge, and resources folders. Store its display name (filename without `.md` extension) and its vault-relative path for use as a wikilink.
 
-If any folder does not exist, use count 0 for that folder.
+If a folder does not exist on disk, use count 0 for that folder — this is expected for new vaults.
+
+If the Glob tool returns an error or cannot enumerate a folder that appears to exist, stop immediately and tell the user:
+> "Could not scan [folder] — MOC.md was not written. Error: [error]. Resolve the issue and try again."
+
+Do not write MOC.md with potentially incorrect counts.
 
 ---
 
 ## Step 3: Preserve existing Pinned section
 
 **If `MOC.md` exists:**
-- Read the file
+- Read the file. If the read fails, stop immediately and tell the user:
+  > "Could not read existing MOC.md at [moc_path] — aborting to protect your Pinned section. Error: [error]. Resolve the file access issue and try again."
 - Extract `created:` from the frontmatter — store as `created_date` (fall back to today if absent)
 - Set `is_new_file = false`
 - Find the line that starts with `## 📌 Pinned`
 - Store everything from that line to the end of file as `pinned_content`
-- If `## 📌 Pinned` is not found, use the default pinned block (defined in Step 4)
+- If `## 📌 Pinned` is not found in the existing file, warn the user before continuing:
+  > "Warning: Pinned section (`## 📌 Pinned`) not found in existing MOC.md — the default placeholder will be used instead. Any content you added below the last recognized section header may not be preserved."
+  Then use the default pinned block.
 
 **If `MOC.md` does not exist:**
 - Set `created_date` to today
@@ -127,7 +138,7 @@ sort by due
 ```dataview
 TABLE file.mtime AS "Modified"
 FROM ""
-WHERE !startswith(file.folder, "LOGS_FOLDER") AND !startswith(file.folder, "AGENT_FOLDER") AND file.name != "MOC" AND file.name != "TASKS"
+WHERE !startswith(file.folder, "LOGS_FOLDER") AND !startswith(file.folder, "AGENT_FOLDER") AND !startswith(file.folder, "ARCHIVE_FOLDER") AND file.name != "MOC" AND file.name != "TASKS"
 SORT file.mtime DESC
 LIMIT 10
 ```
@@ -201,6 +212,7 @@ Open via Bash based on platform (detect from `$OSTYPE`). Capture exit code:
 - Linux (non-WSL): `xdg-open "<uri>"`
 - Linux (WSL): `cmd.exe /c start "" "<uri>"`
 - Windows (msys/cygwin): `cmd.exe /c start "" "<uri>"`
+- Unrecognized platform: skip the open attempt and go to the encoding-failure branch, replacing the reason with "platform not recognized".
 
 ---
 

--- a/.claude/plugins/onebrain/skills/moc/SKILL.md
+++ b/.claude/plugins/onebrain/skills/moc/SKILL.md
@@ -57,6 +57,7 @@ If any folder does not exist, use count 0 for that folder.
 **If `MOC.md` exists:**
 - Read the file
 - Extract `created:` from the frontmatter — store as `created_date` (fall back to today if absent)
+- Set `is_new_file = false`
 - Find the line that starts with `## 📌 Pinned`
 - Store everything from that line to the end of file as `pinned_content`
 - If `## 📌 Pinned` is not found, use the default pinned block (defined in Step 4)
@@ -91,7 +92,7 @@ Write the complete file. Replace every placeholder in the template with actual v
 | `RESOURCES_COUNT` | resources_count |
 | `INBOX_COUNT` | inbox_count |
 | `FOCUS_LINK` | `[[vault-relative-path\|display-name]]` of focus_note — e.g. `[[01-projects/alpha/Project Alpha\|Project Alpha]]`. Use `—` if no notes found. |
-| `FIRST_RUN_LINE` | If `is_new_file` is true: `> 💡 Install the [Dataview plugin](https://github.com/blacksmithgu/obsidian-dataview) to activate live query sections.` — otherwise omit this line entirely (do not leave a blank line in its place) |
+| `FIRST_RUN_LINE` | If `is_new_file` is true: `> 💡 Install the [Dataview plugin](https://github.com/blacksmithgu/obsidian-dataview) to activate live query sections.` — otherwise remove this line entirely from the output; do not insert a blank line where it was. |
 | `PINNED_CONTENT` | preserved pinned section (or default below) |
 
 **Template:**
@@ -126,7 +127,7 @@ sort by due
 ```dataview
 TABLE file.mtime AS "Modified"
 FROM ""
-WHERE file.folder != "AGENT_FOLDER" AND file.folder != "LOGS_FOLDER" AND file.name != "MOC" AND file.name != "TASKS"
+WHERE !contains(file.folder, "LOGS_FOLDER") AND !contains(file.folder, "AGENT_FOLDER") AND file.name != "MOC" AND file.name != "TASKS"
 SORT file.mtime DESC
 LIMIT 10
 ```

--- a/.claude/plugins/onebrain/skills/moc/SKILL.md
+++ b/.claude/plugins/onebrain/skills/moc/SKILL.md
@@ -1,0 +1,220 @@
+---
+name: moc
+description: Create or update the vault portal (MOC.md) at the vault root — a Map of Content with live Dataview queries, AI summary, and user Pinned section. Opens MOC.md in Obsidian.
+---
+
+# Vault Portal
+
+Creates or updates `MOC.md` at the vault root — a hybrid Map of Content with:
+- **AI zone:** agent-written summary callout (note counts, focus note)
+- **Dataview zone:** live queries for Tasks, Recently Modified, Projects, Areas, Knowledge, Resources, Bookmarks
+- **Static zone:** user-maintained Pinned section (never overwritten by the agent)
+
+Usage:
+- `/moc` — create or refresh MOC.md and open it in Obsidian
+
+---
+
+## Step 1: Read vault configuration
+
+Read `vault.yml` from the current working directory. Extract folder paths with these defaults if keys are absent:
+
+| Key | Default |
+|-----|---------|
+| `folders.inbox` | `00-inbox` |
+| `folders.projects` | `01-projects` |
+| `folders.areas` | `02-areas` |
+| `folders.knowledge` | `03-knowledge` |
+| `folders.resources` | `04-resources` |
+| `folders.agent` | `05-agent` |
+| `folders.archive` | `06-archive` |
+| `folders.logs` | `07-logs` |
+
+If `vault.yml` does not exist, use all defaults and warn the user:
+> "vault.yml not found — using default folder paths. Run `/onboarding` to set up your vault configuration."
+
+Store `moc_path = {vault_root}/MOC.md`.
+
+---
+
+## Step 2: Scan vault for summary data
+
+Collect the following using Glob to count `.md` files:
+
+- **projects_count** — `.md` files under `[folders.projects]/` (recursive)
+- **areas_count** — `.md` files under `[folders.areas]/` (recursive)
+- **knowledge_count** — `.md` files under `[folders.knowledge]/` (recursive)
+- **resources_count** — `.md` files under `[folders.resources]/` (recursive)
+- **inbox_count** — `.md` files directly in `[folders.inbox]/` (non-recursive, direct children only)
+- **focus_note** — the single most recently modified `.md` file across projects, areas, knowledge, and resources folders. Store its display name (filename without `.md` extension) and its vault-relative path for use as a wikilink.
+
+If any folder does not exist, use count 0 for that folder.
+
+---
+
+## Step 3: Preserve existing Pinned section
+
+**If `MOC.md` exists:**
+- Read the file
+- Extract `created:` from the frontmatter — store as `created_date` (fall back to today if absent)
+- Find the line that starts with `## 📌 Pinned`
+- Store everything from that line to the end of file as `pinned_content`
+- If `## 📌 Pinned` is not found, use the default pinned block (defined in Step 4)
+
+**If `MOC.md` does not exist:**
+- Set `created_date` to today
+- Set `is_new_file = true`
+- Use the default pinned block
+
+---
+
+## Step 4: Write MOC.md
+
+Write the complete file. Replace every placeholder in the template with actual values before writing.
+
+**Placeholder reference:**
+
+| Placeholder | Value |
+|------------|-------|
+| `CREATED_DATE` | preserved `created:` date or today |
+| `TODAY` | today's date (YYYY-MM-DD) |
+| `PROJECTS_FOLDER` | `folders.projects` value |
+| `AREAS_FOLDER` | `folders.areas` value |
+| `KNOWLEDGE_FOLDER` | `folders.knowledge` value |
+| `RESOURCES_FOLDER` | `folders.resources` value |
+| `AGENT_FOLDER` | `folders.agent` value |
+| `LOGS_FOLDER` | `folders.logs` value |
+| `ARCHIVE_FOLDER` | `folders.archive` value |
+| `PROJECTS_COUNT` | projects_count |
+| `AREAS_COUNT` | areas_count |
+| `KNOWLEDGE_COUNT` | knowledge_count |
+| `RESOURCES_COUNT` | resources_count |
+| `INBOX_COUNT` | inbox_count |
+| `FOCUS_LINK` | `[[vault-relative-path\|display-name]]` of focus_note — e.g. `[[01-projects/alpha/Project Alpha\|Project Alpha]]`. Use `—` if no notes found. |
+| `FIRST_RUN_LINE` | If `is_new_file` is true: `> 💡 Install the [Dataview plugin](https://github.com/blacksmithgu/obsidian-dataview) to activate live query sections.` — otherwise omit this line entirely (do not leave a blank line in its place) |
+| `PINNED_CONTENT` | preserved pinned section (or default below) |
+
+**Template:**
+
+`````markdown
+---
+tags: [dashboard, moc]
+created: CREATED_DATE
+updated: TODAY
+---
+
+# 🧠 Vault Portal
+
+> [!info] Agent Summary — updated TODAY
+> **PROJECTS_COUNT** projects · **AREAS_COUNT** areas · **KNOWLEDGE_COUNT** knowledge notes · **RESOURCES_COUNT** resources · **INBOX_COUNT** inbox items
+> 🔺 Focus: FOCUS_LINK
+FIRST_RUN_LINE
+
+## ⚡ Tasks
+
+```tasks
+not done
+path does not include LOGS_FOLDER
+path does not include ARCHIVE_FOLDER
+due before in 8 days
+sort by priority
+sort by due
+```
+
+## 🕐 Recently Modified
+
+```dataview
+TABLE file.mtime AS "Modified"
+FROM ""
+WHERE file.folder != "AGENT_FOLDER" AND file.folder != "LOGS_FOLDER" AND file.name != "MOC" AND file.name != "TASKS"
+SORT file.mtime DESC
+LIMIT 10
+```
+
+## 🚀 Projects
+
+```dataview
+LIST
+FROM "PROJECTS_FOLDER"
+SORT file.mtime DESC
+```
+
+## 🗂 Areas
+
+```dataview
+LIST
+FROM "AREAS_FOLDER"
+SORT file.name ASC
+```
+
+## 🧠 Knowledge
+
+```dataview
+TABLE length(rows) AS "Notes"
+FROM "KNOWLEDGE_FOLDER"
+GROUP BY file.folder
+SORT file.folder ASC
+```
+
+## 📚 Resources
+
+```dataview
+LIST
+FROM "RESOURCES_FOLDER"
+SORT file.mtime DESC
+```
+
+## 🔖 Bookmarks
+
+[[Bookmarks]] — saved URLs and references.
+
+PINNED_CONTENT
+`````
+
+**Default `PINNED_CONTENT`** (used when no existing Pinned section is found):
+
+```markdown
+## 📌 Pinned
+
+<!-- Add your own permanent links and notes here. The agent will never overwrite this section. -->
+```
+
+**If the write fails**, stop immediately and tell the user:
+> "Could not write MOC.md at [moc_path]. Error: [error]. Vault root used: [vault_root]"
+
+---
+
+## Step 5: Open in Obsidian
+
+Build the `obsidian://` URI using path-based addressing:
+
+1. Take the absolute path to `MOC.md`
+2. URL-encode it, keeping `/`, `:`, and `@` as literal characters:
+   - Python3 first: `urllib.parse.quote(path, safe='/:@')`
+   - Node.js fallback: `encodeURIComponent(path).replace(/%2F/gi, '/').replace(/%3A/gi, ':').replace(/%40/gi, '@')`
+   - If neither available: go to encoding-failure branch
+3. Build: `uri = "obsidian://open?path=" + encoded_path`
+
+Open via Bash based on platform (detect from `$OSTYPE`). Capture exit code:
+- macOS (`darwin`): `open "<uri>"`
+- Linux (non-WSL): `xdg-open "<uri>"`
+- Linux (WSL): `cmd.exe /c start "" "<uri>"`
+- Windows (msys/cygwin): `cmd.exe /c start "" "<uri>"`
+
+---
+
+## Step 6: Confirm
+
+**Exit code 0 (success):** `MOC.md opened in Obsidian.`
+
+**Non-zero exit code (open failed):**
+> "MOC.md was updated but could not be opened automatically in Obsidian.
+>
+> Open it manually:
+> - In Obsidian: navigate to `MOC.md` in your vault
+> - Via URI: `obsidian://open?path=[encoded_path]`
+>
+> If Obsidian is not installed, visit https://obsidian.md"
+
+**Encoding-failure (no Python3 or Node.js):**
+> "MOC.md was updated but could not be opened automatically — URL encoding is unavailable (Python3 and Node.js both missing). Open it manually in Obsidian by navigating to `MOC.md`."

--- a/.claude/plugins/onebrain/skills/moc/SKILL.md
+++ b/.claude/plugins/onebrain/skills/moc/SKILL.md
@@ -127,7 +127,7 @@ sort by due
 ```dataview
 TABLE file.mtime AS "Modified"
 FROM ""
-WHERE !contains(file.folder, "LOGS_FOLDER") AND !contains(file.folder, "AGENT_FOLDER") AND file.name != "MOC" AND file.name != "TASKS"
+WHERE !startswith(file.folder, "LOGS_FOLDER") AND !startswith(file.folder, "AGENT_FOLDER") AND file.name != "MOC" AND file.name != "TASKS"
 SORT file.mtime DESC
 LIMIT 10
 ```
@@ -154,7 +154,7 @@ SORT file.name ASC
 TABLE length(rows) AS "Notes"
 FROM "KNOWLEDGE_FOLDER"
 GROUP BY file.folder
-SORT file.folder ASC
+SORT key ASC
 ```
 
 ## 📚 Resources

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 **🧠 Memory across sessions** — Your AI remembers your name, goals, preferences, and past conversations. Every session picks up where the last one left off.
 
-**⚡ 18 slash commands and counting** — Braindump, capture, research, consolidate, connect, bookmark, import files, and more. More skills coming soon — capture an idea or deep-research a topic in seconds.
+**⚡ 20 slash commands and counting** — Braindump, capture, research, consolidate, connect, bookmark, import files, and more. More skills coming soon — capture an idea or deep-research a topic in seconds.
 
 **📂 Vault-native Markdown** — Every note is plain Markdown. No lock-in, no proprietary format. Your data stays in your vault, forever.
 
@@ -111,7 +111,7 @@ Under the hood, OneBrain uses a **three-layer memory system**: your identity (al
 ---
 
 <details>
-<summary><strong>📋 All 18 Commands</strong></summary>
+<summary><strong>📋 All 20 Commands</strong></summary>
 <br>
 
 | Command | What it does |
@@ -128,10 +128,12 @@ Under the hood, OneBrain uses a **three-layer memory system**: your identity (al
 | `/reading-notes` | Turn a book or article into structured notes |
 | `/weekly` | Review the week, surface patterns, set intentions |
 | `/tasks` | Live task dashboard in Obsidian — creates/updates `TASKS.md` with always-current query sections |
+| `/moc` | Vault portal in Obsidian — creates/updates `MOC.md` with projects, areas, knowledge, tasks, and pinned links |
 | `/wrapup` | Wrap up session and save summary to session log |
 | `/learn` | Teach the agent something — facts about your world or behavioral preferences |
 | `/clone` | Package your agent context for transfer to a new vault |
 | `/reorganize` | Migrate flat notes into organized subfolders |
+| `/qmd` | Set up fast vault search index — enables semantic search across all notes |
 | `/update` | Update skills, config, and plugins from GitHub |
 | `/help` | List all available commands with descriptions |
 
@@ -162,6 +164,7 @@ onebrain/
 │   ├── images/
 │   └── video/
 ├── TASKS.md           Live task dashboard (created by /tasks, opened in Obsidian)
+├── MOC.md             Vault portal — Map of Content (created by /moc)
 ├── CLAUDE.md          Instructions for Claude Code
 ├── GEMINI.md          Instructions for Gemini CLI
 ├── AGENTS.md          Universal agent instructions


### PR DESCRIPTION
## Summary

- Adds `/moc` slash command that creates and maintains `MOC.md` at the vault root — a hybrid Map of Content for navigating the entire vault from one place
- `MOC.md` has three zones: AI-written summary callout (note counts + focus note), Dataview live query sections (Tasks, Recently Modified, Projects, Areas, Knowledge, Resources, Bookmarks), and a user-owned Pinned section the agent never overwrites
- Session start silently refreshes the AI summary callout on every session; `/moc` does a full rebuild on demand

## Changes

- **New:** `.claude/plugins/onebrain/skills/moc/SKILL.md` — full `/moc` skill
- **Modified:** `INSTRUCTIONS.md` — adds `/moc` to workflow table and step 4 to session start behavior
- **Modified:** `skills/help/SKILL.md` — adds `/moc` to the command table
- **Modified:** `.claude-plugin/plugin.json` — version bump 1.5.5 → 1.5.6

## Test plan

- [ ] Run `/moc` in a vault session — verify `MOC.md` is created at vault root with correct sections
- [ ] Open `MOC.md` in Obsidian — verify Dataview sections render (requires Dataview plugin) and Tasks section renders
- [ ] Edit `## 📌 Pinned` manually, then run `/moc` again — verify Pinned content is preserved
- [ ] Start a new session — verify AI summary callout is silently refreshed (check `updated:` date)
- [ ] Run `/help` — verify `/moc` appears in the command table

🤖 Generated with [Claude Code](https://claude.com/claude-code)