### PR TITLE
Refactor /update: shell script for fetch/apply + version display in greeting

### DIFF
--- a/.claude/plugins/onebrain/INSTRUCTIONS.md
+++ b/.claude/plugins/onebrain/INSTRUCTIONS.md
@@ -111,7 +111,7 @@ Without embeddings, `mcp__plugin_onebrain_qmd__query` uses BM25 keyword search o
 
 At the start of every session, perform these steps:
 
-1. Read vault.yml for folder names and configuration — sets `[agent folder]` from `folders.agent` (default: `05-agent`) and `[logs folder]` from `folders.logs` (default: `07-logs`)
+1. Read vault.yml for folder names and configuration — sets `[agent folder]` from `folders.agent` (default: `05-agent`) and `[logs folder]` from `folders.logs` (default: `07-logs`). Also read `.claude/plugins/onebrain/.claude-plugin/plugin.json` and note the `version` field — include it in your greeting (e.g. "OneBrain v1.5.6").
 2. Read `[agent folder]/MEMORY.md` to load identity, personality, and active projects
    > **Agent context (lazy load):** If the session involves a domain-specific topic (e.g., research, writing, technical work), grep `[agent folder]/context/` for notes relevant to that topic and use them as background context. Do not load all context files every session — only when relevant.
    >

--- a/.claude/plugins/onebrain/INSTRUCTIONS.md
+++ b/.claude/plugins/onebrain/INSTRUCTIONS.md
@@ -111,7 +111,7 @@ Without embeddings, `mcp__plugin_onebrain_qmd__query` uses BM25 keyword search o
 
 At the start of every session, perform these steps:
 
-1. Read vault.yml for folder names and configuration — sets `[agent folder]` from `folders.agent` (default: `05-agent`) and `[logs folder]` from `folders.logs` (default: `07-logs`). Also read `.claude/plugins/onebrain/.claude-plugin/plugin.json` and note the `version` field — include it in your greeting (e.g. "OneBrain v1.5.6").
+1. Read vault.yml for folder names and configuration — sets `[agent folder]` from `folders.agent` (default: `05-agent`) and `[logs folder]` from `folders.logs` (default: `07-logs`). Also read `.claude/plugins/onebrain/.claude-plugin/plugin.json` and note the `version` field — include it in your greeting (e.g. "OneBrain v1.5.6"). If the file doesn't exist, skip the version.
 2. Read `[agent folder]/MEMORY.md` to load identity, personality, and active projects
    > **Agent context (lazy load):** If the session involves a domain-specific topic (e.g., research, writing, technical work), grep `[agent folder]/context/` for notes relevant to that topic and use them as background context. Do not load all context files every session — only when relevant.
    >

--- a/.claude/plugins/onebrain/skills/update/SKILL.md
+++ b/.claude/plugins/onebrain/skills/update/SKILL.md
@@ -5,20 +5,13 @@ description: Update OneBrain skills, config, and plugins from GitHub — never t
 
 ## Install Path Detection
 
-Before doing anything else, check whether OneBrain is installed at the project level or globally:
-
 Check if `.claude/plugins/onebrain/` exists in the current vault directory.
 
-**If it does NOT exist** (global plugin install — /onboarding has not been run yet):
-
-Stop and tell the user:
+**If it does NOT exist:**
 > OneBrain is installed as a global plugin but hasn't been adopted into this vault yet.
->
 > Run `/onboarding` first to bundle OneBrain into your vault — after that, `/update` will work normally.
 
 Do not proceed further.
-
-**If it DOES exist** (vault install — Path A or adopted Path B): continue with the steps below.
 
 ---
 
@@ -38,111 +31,49 @@ Tell the user what will and won't be updated:
 - `.claude/plugins/onebrain/` — all plugin files (skills, hooks, agents, INSTRUCTIONS.md)
 - `.claude-plugin/` — local plugin marketplace registry
 
-> **Note:** `CLAUDE.md`, `GEMINI.md`, and `AGENTS.md` are not in the fetch allowlist. Instead, Step 4e ensures they contain the `@import` pointer to `INSTRUCTIONS.md` (migrating old inline instructions if needed).
-
 **WILL NOT touch (your data and preferences):**
-- All your note folders (00-inbox, 01-projects, 02-areas, 03-knowledge, 04-resources, 05-agent, 06-archive, 07-logs) — all your notes
-- `[agent_folder]/MEMORY.md` — your identity and session context (inside your agent folder)
+- All your note folders (00-inbox through 07-logs) — all your notes
+- `[agent_folder]/MEMORY.md` — your identity and session context
 - `vault.yml` — your vault configuration
-- `.obsidian/` — all Obsidian settings and plugins are yours to manage after onboarding
+- `.obsidian/` — all Obsidian settings
 - `.claude/settings.local.json` — your local Claude settings
-- `.claude/onebrain.local.md` — your local plugin config
-- `install.sh`, `install.ps1` — only used for fresh installs
-- `README.md`, `CONTRIBUTING.md`, `LICENSE`, `assets/` — repo-only files, not part of the vault
 
 Ask: **"Proceed with update?"** and wait for confirmation before continuing.
 
 ---
 
-## Step 2: Fetch Upstream File List
+## Step 2: Compare (Dry-Run)
 
-Use WebFetch to retrieve the full file tree from the OneBrain repository:
+Run the update script in dry-run mode:
 
-`https://api.github.com/repos/kengio/onebrain/git/trees/main?recursive=1`
+```bash
+bash .claude/plugins/onebrain/skills/update/update.sh
+```
 
-Parse the JSON response. The `tree` array contains every file (`type: "blob"`) and directory (`type: "tree"`) in the repo, each with a `path` field.
+Parse the output and present a summary to the user:
 
-If this request fails (network error, API rate limit), tell the user and stop.
-
----
-
-## Step 3: Compare & Report
-
-For each path in the allowlist, compare the upstream version against the local version. Collect results into three buckets: **modified**, **new**, **unchanged**.
-
-**Allowlist — paths to check and potentially update:**
-
-| Path | Type |
-|------|------|
-| `.gitignore` | file |
-| `.claude/plugins/onebrain/` | directory |
-| `.claude-plugin/` | directory |
-
-**For individual files:** Fetch the upstream content using WebFetch:
-`https://raw.githubusercontent.com/kengio/onebrain/main/[path]`
-Read the local file with the Read tool and compare. Mark as `unchanged`, `modified`, or `new` (if the local file doesn't exist yet). If the fetch fails, mark as `fetch-failed` — do NOT treat as unchanged.
-
-**For directories:** Filter the upstream file tree (from Step 2) to all blobs whose path starts with the directory prefix. For each upstream file:
-- Fetch its content from `https://raw.githubusercontent.com/kengio/onebrain/main/[path]`
-- Read the local file with the Read tool and compare
-- Mark as `unchanged`, `modified`, `new`, or `fetch-failed` (if the fetch fails)
-
-Also identify **local files that no longer exist upstream** (present locally but absent from the upstream tree for that directory prefix). These will be deleted in Step 4 to keep the directory in sync.
-
-If any files are `fetch-failed`, include them in the summary and do not proceed to Step 4. Tell the user:
-> Could not fetch N file(s) from GitHub. This may be a transient network issue. Re-run `/update` to retry.
-
-Present the summary before asking to apply. Example:
-> Found: 2 modified, 1 new, 7 unchanged.
-> Modified: `.claude/plugins/onebrain/`
-> New: `.claude/plugins/onebrain/skills/new-skill/SKILL.md`
+> Found: N modified, N new, N deleted, N unchanged.
+> Modified: [list files marked with ~]
+> New: [list files marked with +]
+> Deleted: [list files marked with -]
 >
 > Apply these updates?
 
-Wait for confirmation.
+If the output contains `status: partial_failure` or any lines starting with `!`, stop and report which files failed to fetch. Tell the user to re-run `/update` to retry.
+
+Wait for confirmation before continuing.
 
 ---
 
-## Step 3b: Clear Plugin Cache (If Version Unchanged)
+## Step 3: Apply
 
-Before applying updates, check whether the upstream plugin version matches the local plugin version:
-
-1. Read `[vault root]/.claude/plugins/onebrain/.claude-plugin/plugin.json` and note `version` as **local_version**.
-2. The upstream `plugin.json` was already fetched in Step 3 — note its `version` as **upstream_version**.
-
-**If upstream_version == local_version (no version bump):**
-
-The plugin cache directory for this version must be removed so the plugin manager picks up the updated source files on next load. Run:
-
-Run the following, skipping silently any path that does not exist (this is expected when only one cache variant was used):
+Run the update script in apply mode:
 
 ```bash
-rm -rf ~/.claude/plugins/cache/onebrain/onebrain/[local_version]
-rm -rf ~/.claude/plugins/cache/onebrain-local/onebrain/[local_version]
+bash .claude/plugins/onebrain/skills/update/update.sh --apply
 ```
 
-Only report an error if a path exists but deletion fails. If deletion fails, tell the user: "Could not clear plugin cache at [path]. You can delete it manually, or start a new session — the plugin manager should detect the updated source files automatically." Continue with the update regardless.
-
-On success, report: "Cleared plugin cache for v[local_version] — run /reload-plugins or start a new session to apply changes."
-
-**If upstream_version != local_version:**
-No cache action needed — the plugin manager will create a new cache directory for the new version automatically.
-
----
-
-## Step 4: Apply Updates
-
-After user confirms, apply each changed or new item from the allowlist using the Write tool:
-
-**For individual files:** Write the upstream content (fetched in Step 3) to the local path. If the write fails, record it as `write-failed` and continue to the next file — do not stop.
-
-**For directories:**
-- Write each upstream file that is `modified` or `new` to its local path. If any write fails, record it as `write-failed` and continue.
-- Delete any local files identified as no longer existing upstream (removed from the repo). If a delete fails, record it as `delete-failed` and continue. This keeps plugin and skill directories clean when files are renamed or removed.
-
-Only modify files that are in the allowlist. Never touch note folders, `[agent_folder]/MEMORY.md`, `vault.yml`, or any user preference files.
-
-After all writes and deletes are attempted: if any `write-failed` or `delete-failed` files exist, include them in the Step 5 report with instructions to manually replace or remove them, and advise re-running `/update`.
+If the output contains `status: partial_failure`, report which files failed and advise re-running `/update`.
 
 ---
 
@@ -155,32 +86,26 @@ After applying updates, check for the old MEMORY.md location:
 3. Check if `[agent_folder]/MEMORY.md` exists
 
 **Case A — Root MEMORY.md exists, agent folder MEMORY.md does not:**
-Copy the file and ask before deleting:
-- If `[agent_folder]/` does not exist, create the folder along with `context/` and `memory/` subfolders (each with a `.gitkeep`)
+- If `[agent_folder]/` does not exist, create it along with `context/` and `memory/` subfolders (each with a `.gitkeep`)
 - Copy the content of `MEMORY.md` to `[agent_folder]/MEMORY.md`
-- **If the copy fails:** report the error and stop. Do not offer to delete the root copy — it is the only remaining copy. Tell the user: "Could not copy MEMORY.md to `[agent_folder]/MEMORY.md`. Ensure `[agent_folder]/` is writable, then re-run `/update`."
-- **If the copy succeeds:** verify `[agent_folder]/MEMORY.md` now exists and is non-empty, then ask the user: "Copied MEMORY.md to `[agent_folder]/MEMORY.md` (new location in this version). Can I delete the root copy?"
-- Delete the root `MEMORY.md` only after confirmation
+- If copy fails: report the error and stop — do not offer to delete the root copy
+- If copy succeeds: verify the new file is non-empty, then ask: "Copied MEMORY.md to `[agent_folder]/MEMORY.md`. Can I delete the root copy?"
+- Delete root `MEMORY.md` only after confirmation
 
 **Case B — Both exist:**
-Do not move. Tell the user:
-> Found `MEMORY.md` at the vault root AND at `[agent_folder]/MEMORY.md`. The agent will use `[agent_folder]/MEMORY.md`. Please review and delete the root copy manually when you're ready: `MEMORY.md`.
+> Found `MEMORY.md` at the vault root AND at `[agent_folder]/MEMORY.md`. The agent will use `[agent_folder]/MEMORY.md`. Please review and delete the root copy manually: `MEMORY.md`.
 
-**Case C — Only agent folder MEMORY.md exists (already migrated):**
-No action needed.
+**Case C — Only agent folder MEMORY.md exists:** No action.
 
-**Case D — Neither exists:**
-No action needed. User will need to run `/onboarding`.
-
-After running whichever case above applies, proceed to Step 4b-ii.
+**Case D — Neither exists:** No action. User will need to run `/onboarding`.
 
 ---
 
 ## Step 4b-ii: Patch MEMORY.md Frontmatter (If Needed)
 
-After the location migration above, ensure `[agent_folder]/MEMORY.md` has correct frontmatter.
+Ensure `[agent_folder]/MEMORY.md` has correct frontmatter (skip if file doesn't exist):
 
-**Required frontmatter fields** (as defined by the onboarding skill):
+**Required fields:**
 ```yaml
 ---
 tags: [agent-memory]
@@ -189,193 +114,67 @@ updated: YYYY-MM-DD
 ---
 ```
 
-**Procedure:**
-
-1. If `[agent_folder]/MEMORY.md` does not exist (Case D above): skip this step entirely.
-2. Read `[agent_folder]/MEMORY.md`.
-3. Check whether the file begins with a frontmatter block (first line is exactly `---`).
-
-**If frontmatter is malformed** (file begins with `---` but no second `---` line exists before end of file):
-- Do NOT write anything. Report: "MEMORY.md has a malformed frontmatter block (opening `---` with no closing `---`). Skipping frontmatter patch — please fix it manually before re-running `/update`."
-- Skip to Step 4c.
-
-**If frontmatter is entirely missing:**
-- Prepend the following block before the existing file content (read-modify-write — the new content is the frontmatter block + a blank line + the entire original file content unchanged, do not truncate anything):
-  ```yaml
-  ---
-  tags: [agent-memory]
-  created: YYYY-MM-DD
-  updated: YYYY-MM-DD
-  ---
-  ```
-  Use today's date for both `created` and `updated`.
-- If the write fails: report the error and the exact change attempted (so the user can apply it manually). Do not retry.
-- Report: "Added missing frontmatter to `[agent_folder]/MEMORY.md`."
-
-**If frontmatter is present but incomplete** (the `---` block exists, but one or more required keys are missing):
-- Parse the existing frontmatter block (content between the first and second `---`).
-- For each missing key, insert it into the frontmatter block:
-  - `tags` missing → add `tags: [agent-memory]`
-  - `created` missing → add `created: YYYY-MM-DD` (today's date)
-  - `updated` missing → add `updated: YYYY-MM-DD` (today's date)
-- Write back the full file: the patched frontmatter followed by the entire original body content unchanged (read-modify-write — do not truncate any part of the body).
-- If the write fails: report the error and the exact keys that needed to be added. Do not retry.
-- Report: "Patched frontmatter in `[agent_folder]/MEMORY.md` — added: [list of added keys]."
-
-**If frontmatter is present and complete:** Skip silently.
+- If frontmatter is malformed (opening `---` with no closing `---`): report and skip
+- If frontmatter is missing: prepend the block above (use today's date for both fields)
+- If frontmatter is present but incomplete: insert only the missing keys
+- If frontmatter is complete: skip silently
 
 ---
 
-## Step 4c: Create Missing Vault Folders (Migration)
+## Step 4c: Create Missing Vault Folders
 
-After applying updates, ensure any folders introduced in newer versions exist. Check and create if missing — do not report unchanged folders, only new ones.
+Ensure these folders exist (create with `.gitkeep` if missing, report only new ones):
 
-**Folders to ensure exist:**
+| Folder | Introduced |
+|--------|-----------|
+| `[inbox]/imports/` | v1.2.0 |
+| `[attachments]/` | v1.2.0 |
+| `[attachments]/pdf/` | v1.2.0 |
+| `[attachments]/images/` | v1.2.0 |
+| `[attachments]/video/` | v1.2.0 |
 
-| Folder | Purpose | Introduced |
-|--------|---------|-----------|
-| `[inbox]/imports/` | Staging area for `/import` skill | v1.2.0 |
-| `[attachments]/` | Copied attachments root (`--attach` flag) | v1.2.0 |
-| `[attachments]/pdf/` | PDF attachments subfolder | v1.2.0 |
-| `[attachments]/images/` | Image attachments subfolder | v1.2.0 |
-| `[attachments]/video/` | Video attachments subfolder | v1.2.0 |
-
-Where `[attachments]` is resolved from `vault.yml` `folders.attachments` (default: `attachments`).
-
-Where `[inbox]` is resolved from `vault.yml` `folders.inbox` (default: `00-inbox`).
-
-**For each folder in the table:**
-1. Check if it exists (glob or ls). If it exists: skip silently.
-2. If it does not exist: write an empty `.gitkeep` file inside it (this creates the folder).
-   - If the write fails: report the error and tell the user to create the folder manually before using `/import`. Continue to the next folder — do not stop.
-3. Report: "Created `[folder]/` — new in this version."
-
-**vault.yml key migration — explicit procedure:**
-
-Run this procedure for each vault.yml key in the table below:
+Also ensure `vault.yml` has these keys under `folders:` (add if missing, never touch `qmd_collection`):
 
 | Key | Value | Introduced |
 |-----|-------|-----------|
 | `import_inbox` | `[inbox]/imports` | v1.2.0 |
 | `attachments` | `attachments` | v1.2.0 |
 
-> **Note:** `qmd_collection` is a user-specific key set by `/qmd setup`. It is never included in the migration table above and must never be added or removed by `/update`. If `qmd_collection` is already present in vault.yml, leave it unchanged. If it is absent, leave it absent — the user may not have set up qmd.
-
-For each key:
-1. **Check if vault.yml exists.** If it does not exist: skip this key entirely (the user needs to run `/onboarding` first — do not create or modify vault.yml here).
-2. **Read vault.yml.** If it cannot be read or parsed: report the error, skip this key, continue.
-3. **Check if `folders:` block is present** in the parsed content. If the `folders:` block is absent: report "vault.yml exists but has no `folders:` block — cannot safely add `[key]`. Please check vault.yml manually." Skip this key.
-4. **Search for the key** (grep for `[key]:` within the `folders:` block). If it is already present: skip silently.
-5. **Insert the key** as a new line within the `folders:` mapping — after the last existing folder entry, inside the `folders:` block. If `folders:` is present but has no entries (the value is null or the block is empty), insert the key as the first and only entry under `folders:`. Do NOT append to the end of the file. Use the Write tool to write the entire updated vault.yml content (read → modify in memory → write back), never a partial append.
-6. Report: "Added `[key]` to vault.yml."
-
 ---
 
 ## Step 4d: Migrate Plugin Key (onebrain-local → onebrain)
 
-The OneBrain marketplace was renamed from `onebrain-local` to `onebrain` in v1.3.0. Existing installations may still have stale keys in their Claude Code settings. This step migrates both affected keys.
-
-Check the following settings files:
-- `.claude/settings.json` (project-level)
-- `.claude/settings.local.json` (project-level local)
-
-For each file that exists:
-1. Read the file. **If read fails:** Report the error and tell the user to manually rename the keys in `[file]`. Continue to the next file.
-2. Parse as JSON. **If the file is not valid JSON:** Report the parse error and skip this file. Continue to the next file.
-3. Check for either stale key.
-4. **If neither found:** Skip silently.
-5. **If either found:** Apply both changes to the parsed JSON structure (read → modify → write back):
-
-**Change 1 — `enabledPlugins`:**
-- If `"onebrain@onebrain-local"` exists as a key and `"onebrain@onebrain"` does NOT exist: rename the key.
-- If both keys exist: remove `"onebrain@onebrain-local"` (keep the new key, avoid duplicates).
-- If only `"onebrain@onebrain"` exists: skip (already migrated).
-
-**Change 2 — `extraKnownMarketplaces`:**
-- If `"onebrain-local"` exists as a key and `"onebrain"` does NOT exist: rename the key.
-- If both keys exist: remove `"onebrain-local"` (keep the new key, avoid duplicates).
-- If only `"onebrain"` exists: skip (already migrated).
-
-6. Write the full modified file back. **If write fails:** Report the error and tell the user to manually rename the keys in `[file]`. Continue to the next file.
-7. **On success:** Report: "Migrated stale marketplace keys in `[file]`."
+Check `.claude/settings.json` and `.claude/settings.local.json`. For each that exists:
+- Rename `"onebrain@onebrain-local"` → `"onebrain@onebrain"` in `enabledPlugins`
+- Rename `"onebrain-local"` → `"onebrain"` in `extraKnownMarketplaces`
+- If both old and new keys exist: remove the old one
+- Report: "Migrated stale marketplace keys in `[file]`."
 
 ---
 
 ## Step 4e: Migrate Instruction Files to @import (If Needed)
 
-Old installations may have `CLAUDE.md`, `GEMINI.md`, and/or `AGENTS.md` with ~160 lines of inline OneBrain instructions instead of the single `@import` pointer. This step ensures all three files use the `@import` pattern so the agent always reads the current `INSTRUCTIONS.md`.
+The @import line: `@.claude/plugins/onebrain/INSTRUCTIONS.md`
 
-**The @import line:** `@.claude/plugins/onebrain/INSTRUCTIONS.md`
+**CLAUDE.md:**
+- Does not exist → create with just the @import line
+- Already has @import line → skip
+- Has `# OneBrain` heading → replace the OneBrain block with @import line (preserve any user content above it)
+- Other content, no @import → append @import line at the end
 
-**Detection — "already has the @import line":** any non-blank line in the file equals `@.claude/plugins/onebrain/INSTRUCTIONS.md` after stripping leading/trailing whitespace.
-
-**Detection — "old inline instructions":** the file contains a line that starts with `# OneBrain` (the first heading of all old inline instruction blocks).
-
----
-
-### CLAUDE.md
-
-Read `CLAUDE.md` at the vault root.
-- **If read fails:** report the error and tell the user to manually inspect `CLAUDE.md` and ensure it contains the single line `@.claude/plugins/onebrain/INSTRUCTIONS.md` — until resolved, the agent will continue using whatever is currently in that file. Continue to GEMINI.md.
-
-Apply the matching case:
-
-**Case 1 — File does not exist:**
-Create `CLAUDE.md` with content: `@.claude/plugins/onebrain/INSTRUCTIONS.md`
-- If write fails: report the error and tell the user to create `CLAUDE.md` manually with the single line `@.claude/plugins/onebrain/INSTRUCTIONS.md`. Continue to GEMINI.md.
-- On success: report "Created `CLAUDE.md` with @import pointer." Continue to GEMINI.md.
-
-**Case 2 — File exists and already has the @import line:**
-Skip silently. Continue to GEMINI.md.
-
-**Case 3 — File exists, no @import line, contains old OneBrain instructions (`# OneBrain` heading present):**
-1. Find the line index of the first line starting with `# OneBrain`.
-2. Extract **user content**: everything before that line (may be empty).
-3. Build new file content:
-   - If user content is non-empty (non-blank lines exist before `# OneBrain`): keep that content, then append a blank line followed by `@.claude/plugins/onebrain/INSTRUCTIONS.md`
-   - If no user content exists (the file starts with `# OneBrain`): replace the entire file with just `@.claude/plugins/onebrain/INSTRUCTIONS.md`
-4. Write back (read-modify-write).
-   - If write fails: report the error and tell the user to manually replace the OneBrain block in `CLAUDE.md` with the single line `@.claude/plugins/onebrain/INSTRUCTIONS.md`. Continue to GEMINI.md.
-5. On success: report "Migrated `CLAUDE.md` — replaced inline OneBrain instructions with @import pointer." If user content was preserved, add: "Your custom content above the OneBrain block was preserved." Continue to GEMINI.md.
-
-**Case 4 — File exists, no @import line, no `# OneBrain` heading (unrecognized content):**
-Do not replace. Append the @import line after a blank line at the end of the file.
-- If write fails: report the error and tell the user to manually add `@.claude/plugins/onebrain/INSTRUCTIONS.md` as a new line at the end of `CLAUDE.md`. Continue to GEMINI.md.
-- On success: report "Appended @import pointer to `CLAUDE.md` — existing content preserved." Continue to GEMINI.md.
-
----
-
-### GEMINI.md and AGENTS.md
-
-For each of `GEMINI.md` and `AGENTS.md`:
-
-Read the file.
-- **If read fails:** report the error and tell the user to manually inspect `[filename]` and ensure it contains the single line `@.claude/plugins/onebrain/INSTRUCTIONS.md`. Continue to the next file.
-
-Apply the matching case:
-
-**Case 1 — File does not exist:**
-Create the file with content: `@.claude/plugins/onebrain/INSTRUCTIONS.md`
-- If write fails: report the error and tell the user to create `[filename]` manually with the single line `@.claude/plugins/onebrain/INSTRUCTIONS.md`. Continue to the next file.
-- On success: report "Created `[filename]` with @import pointer."
-
-**Case 2 — File exists and already has the @import line:**
-Skip silently.
-
-**Case 3 — File exists, no @import line:**
-Replace the entire file content with: `@.claude/plugins/onebrain/INSTRUCTIONS.md`
-(These files were never intended for user content — no preservation needed.)
-- If write fails: report the error and tell the user to manually replace the contents of `[filename]` with the single line `@.claude/plugins/onebrain/INSTRUCTIONS.md`. Continue to the next file.
-- On success: report "Migrated `[filename]` — replaced with @import pointer."
+**GEMINI.md and AGENTS.md:**
+- Does not exist → create with just the @import line
+- Already has @import line → skip
+- Any other content → replace entire file with @import line
 
 ---
 
 ## Step 5: Report
 
-Show a final summary of what was updated. Then suggest:
+Show a final summary of everything updated and migrated. Then suggest:
 
 > **Done.** OneBrain has been updated.
 >
 > Next steps:
-> - Run `/reload-plugins` to apply changes immediately in this session (no restart needed)
+> - Run `/reload-plugins` to apply changes immediately in this session
 > - Or start a new Claude Code session — changes are picked up automatically

--- a/.claude/plugins/onebrain/skills/update/SKILL.md
+++ b/.claude/plugins/onebrain/skills/update/SKILL.md
@@ -44,11 +44,16 @@ Ask: **"Proceed with update?"** and wait for confirmation before continuing.
 
 ## Step 2: Compare (Dry-Run)
 
-Run the update script in dry-run mode:
+Detect the platform and run the appropriate script in dry-run mode:
 
-```bash
-bash .claude/plugins/onebrain/skills/update/update.sh
-```
+- **Unix/macOS** — check if `bash` is available (e.g. `which bash` succeeds or `$OSTYPE` is set):
+  ```bash
+  bash .claude/plugins/onebrain/skills/update/update.sh
+  ```
+- **Windows** — check if running in PowerShell or `$env:OS` contains "Windows":
+  ```powershell
+  powershell -File .claude/plugins/onebrain/skills/update/update.ps1
+  ```
 
 Parse the output and present a summary to the user:
 
@@ -67,11 +72,16 @@ Wait for confirmation before continuing.
 
 ## Step 3: Apply
 
-Run the update script in apply mode:
+Run the update script in apply mode (same platform detection as Step 2):
 
-```bash
-bash .claude/plugins/onebrain/skills/update/update.sh --apply
-```
+- **Unix/macOS:**
+  ```bash
+  bash .claude/plugins/onebrain/skills/update/update.sh --apply
+  ```
+- **Windows:**
+  ```powershell
+  powershell -File .claude/plugins/onebrain/skills/update/update.ps1 -Apply
+  ```
 
 If the output contains `status: partial_failure`, report which files failed and advise re-running `/update`.
 

--- a/.claude/plugins/onebrain/skills/update/SKILL.md
+++ b/.claude/plugins/onebrain/skills/update/SKILL.md
@@ -50,7 +50,7 @@ Detect the platform and run the appropriate script in dry-run mode:
   ```bash
   bash .claude/plugins/onebrain/skills/update/update.sh
   ```
-- **Windows** — check if running in PowerShell or `$env:OS` contains "Windows":
+- **Windows** — if the platform reported in your session context is Windows, or `$PSVersionTable` is defined in the current shell:
   ```powershell
   powershell -File .claude/plugins/onebrain/skills/update/update.ps1
   ```
@@ -78,7 +78,7 @@ Run the update script in apply mode (same platform detection as Step 2):
   ```bash
   bash .claude/plugins/onebrain/skills/update/update.sh --apply
   ```
-- **Windows:**
+- **Windows** (same detection as Step 2):
   ```powershell
   powershell -File .claude/plugins/onebrain/skills/update/update.ps1 -Apply
   ```

--- a/.claude/plugins/onebrain/skills/update/SKILL.md
+++ b/.claude/plugins/onebrain/skills/update/SKILL.md
@@ -123,6 +123,8 @@ updated: YYYY-MM-DD
 
 ## Step 4c: Create Missing Vault Folders
 
+Resolve `[inbox]` from `vault.yml` `folders.inbox` (default: `00-inbox`) and `[attachments]` from `vault.yml` `folders.attachments` (default: `attachments`) — both were already read in Step 4b.
+
 Ensure these folders exist (create with `.gitkeep` if missing, report only new ones):
 
 | Folder | Introduced |

--- a/.claude/plugins/onebrain/skills/update/SKILL.md
+++ b/.claude/plugins/onebrain/skills/update/SKILL.md
@@ -159,11 +159,14 @@ Also ensure `vault.yml` has these keys under `folders:` (add if missing, never t
 | `import_inbox` | `[inbox]/imports` | v1.2.0 |
 | `attachments` | `attachments` | v1.2.0 |
 
+When inserting missing keys: read the file, insert within the existing `folders:` block (not at end of file), write back the full file. If the `folders:` block is absent, report and skip.
+
 ---
 
 ## Step 4d: Migrate Plugin Key (onebrain-local → onebrain)
 
 Check `.claude/settings.json` and `.claude/settings.local.json`. For each that exists:
+- If the file cannot be read or parsed as JSON: report the error and skip it
 - Rename `"onebrain@onebrain-local"` → `"onebrain@onebrain"` in `enabledPlugins`
 - Rename `"onebrain-local"` → `"onebrain"` in `extraKnownMarketplaces`
 - If both old and new keys exist: remove the old one

--- a/.claude/plugins/onebrain/skills/update/SKILL.md
+++ b/.claude/plugins/onebrain/skills/update/SKILL.md
@@ -37,6 +37,9 @@ Tell the user what will and won't be updated:
 - `vault.yml` — your vault configuration
 - `.obsidian/` — all Obsidian settings
 - `.claude/settings.local.json` — your local Claude settings
+- `.claude/onebrain.local.md` — your local plugin config
+- `install.sh`, `install.ps1` — fresh-install only, not part of the vault
+- `README.md`, `CONTRIBUTING.md`, `LICENSE`, `assets/` — repo-only files
 
 Ask: **"Proceed with update?"** and wait for confirmation before continuing.
 
@@ -46,14 +49,18 @@ Ask: **"Proceed with update?"** and wait for confirmation before continuing.
 
 Detect the platform and run the appropriate script in dry-run mode:
 
-- **Unix/macOS** — check if `bash` is available (e.g. `which bash` succeeds or `$OSTYPE` is set):
+Use the platform reported in your session context (e.g. `Platform: darwin` or `Platform: win32`) to choose the right script. If the platform is Windows, use PowerShell; otherwise use bash.
+
+- **Unix/macOS:**
   ```bash
   bash .claude/plugins/onebrain/skills/update/update.sh
   ```
-- **Windows** — if the platform reported in your session context is Windows, or `$PSVersionTable` is defined in the current shell:
+- **Windows:**
   ```powershell
   powershell -File .claude/plugins/onebrain/skills/update/update.ps1
   ```
+
+> **Note:** The dry-run and apply passes each fetch files independently from GitHub. This is intentional — scripts are stateless and require no temp storage between runs. The window between passes is small enough that mid-run upstream changes are not a practical concern for a personal tool.
 
 Parse the output and present a summary to the user:
 
@@ -78,7 +85,7 @@ Run the update script in apply mode (same platform detection as Step 2):
   ```bash
   bash .claude/plugins/onebrain/skills/update/update.sh --apply
   ```
-- **Windows** (same detection as Step 2):
+- **Windows** (same platform detection as Step 2):
   ```powershell
   powershell -File .claude/plugins/onebrain/skills/update/update.ps1 -Apply
   ```

--- a/.claude/plugins/onebrain/skills/update/update.ps1
+++ b/.claude/plugins/onebrain/skills/update/update.ps1
@@ -85,8 +85,8 @@ function Compare-AndApply {
             $Added.Add($Path)
         }
     } else {
-        $UpstreamHash = (Get-FileHash $TmpFile    -Algorithm MD5).Hash
-        $LocalHash    = (Get-FileHash $LocalPath  -Algorithm MD5).Hash
+        $UpstreamHash = (Get-FileHash $TmpFile    -Algorithm SHA256).Hash
+        $LocalHash    = (Get-FileHash $LocalPath  -Algorithm SHA256).Hash
 
         if ($UpstreamHash -eq $LocalHash) {
             $Unchanged.Add($Path)
@@ -115,8 +115,9 @@ foreach ($Dir in $AllowDirs) {
     foreach ($Path in $DirPaths) { Compare-AndApply $Path }
 
     # Find local files absent from upstream (deleted in repo)
+    # Guard: skip deletion scan if $DirPaths is empty — avoids marking all local files as deleted.
     $LocalDir = Join-Path $VaultRoot $Dir
-    if (Test-Path $LocalDir) {
+    if ($DirPaths.Count -gt 0 -and (Test-Path $LocalDir)) {
         Get-ChildItem $LocalDir -Recurse -File | Where-Object { $_.Name -ne ".gitkeep" } | ForEach-Object {
             $Rel = $_.FullName.Substring($VaultRoot.Length + 1).Replace("\", "/")
             if ($DirPaths -notcontains $Rel) {

--- a/.claude/plugins/onebrain/skills/update/update.ps1
+++ b/.claude/plugins/onebrain/skills/update/update.ps1
@@ -117,7 +117,7 @@ foreach ($Dir in $AllowDirs) {
     # Find local files absent from upstream (deleted in repo)
     $LocalDir = Join-Path $VaultRoot $Dir
     if (Test-Path $LocalDir) {
-        Get-ChildItem $LocalDir -Recurse -File | ForEach-Object {
+        Get-ChildItem $LocalDir -Recurse -File | Where-Object { $_.Name -ne ".gitkeep" } | ForEach-Object {
             $Rel = $_.FullName.Substring($VaultRoot.Length + 1).Replace("\", "/")
             if ($DirPaths -notcontains $Rel) {
                 $Deleted.Add($Rel)

--- a/.claude/plugins/onebrain/skills/update/update.ps1
+++ b/.claude/plugins/onebrain/skills/update/update.ps1
@@ -1,0 +1,169 @@
+# OneBrain update script (PowerShell) — fetch, compare, and apply system files from GitHub.
+# Run from vault root.
+#
+# Usage:
+#   powershell -File .claude/plugins/onebrain/skills/update/update.ps1           # dry-run
+#   powershell -File .claude/plugins/onebrain/skills/update/update.ps1 -Apply    # apply updates
+
+param(
+    [switch]$Apply
+)
+
+$ErrorActionPreference = "Stop"
+
+$VaultRoot  = (Get-Location).Path
+$PluginDir  = Join-Path $VaultRoot ".claude/plugins/onebrain"
+$Repo       = "kengio/onebrain"
+$Branch     = "main"
+$ApiTree    = "https://api.github.com/repos/$Repo/git/trees/${Branch}?recursive=1"
+$RawBase    = "https://raw.githubusercontent.com/$Repo/$Branch"
+
+# Verify vault install
+if (-not (Test-Path $PluginDir)) {
+    Write-Host "ERROR: OneBrain plugin not found at .claude/plugins/onebrain/ — run /onboarding first."
+    exit 1
+}
+
+# Snapshot local version before any files are overwritten (used for cache logic later)
+$LocalVer = ""
+$PluginJsonPath = Join-Path $PluginDir ".claude-plugin/plugin.json"
+if (Test-Path $PluginJsonPath) {
+    try { $LocalVer = (Get-Content $PluginJsonPath -Raw | ConvertFrom-Json).version } catch {}
+}
+
+# Fetch upstream file tree
+try {
+    $TreeJson = Invoke-RestMethod -Uri $ApiTree -UseBasicParsing
+} catch {
+    Write-Host "ERROR: Could not fetch file list from GitHub (network error or rate limit)."
+    exit 1
+}
+
+# Extract all blob paths
+$AllPaths = $TreeJson.tree | Where-Object { $_.type -eq "blob" } | Select-Object -ExpandProperty path
+if ($null -eq $AllPaths) {
+    Write-Host "ERROR: Could not parse file list from GitHub (unexpected response format)."
+    exit 1
+}
+
+# Allowlist
+$AllowFiles = @(".gitignore")
+$AllowDirs  = @(".claude/plugins/onebrain", ".claude-plugin")
+
+# Tracking
+$Modified  = [System.Collections.Generic.List[string]]::new()
+$Added     = [System.Collections.Generic.List[string]]::new()
+$Unchanged = [System.Collections.Generic.List[string]]::new()
+$Failed    = [System.Collections.Generic.List[string]]::new()
+$Deleted   = [System.Collections.Generic.List[string]]::new()
+
+function Compare-AndApply {
+    param([string]$Path)
+
+    $LocalPath = Join-Path $VaultRoot $Path
+    $TmpFile   = [System.IO.Path]::GetTempFileName()
+
+    try {
+        Invoke-WebRequest -Uri "$RawBase/$Path" -OutFile $TmpFile -UseBasicParsing -ErrorAction Stop
+    } catch {
+        $Failed.Add($Path)
+        Remove-Item $TmpFile -Force -ErrorAction SilentlyContinue
+        return
+    }
+
+    if (-not (Test-Path $LocalPath)) {
+        if ($Apply) {
+            $ParentDir = Split-Path $LocalPath -Parent
+            if (-not (Test-Path $ParentDir)) { New-Item -ItemType Directory -Path $ParentDir -Force | Out-Null }
+            try {
+                Copy-Item $TmpFile $LocalPath -Force -ErrorAction Stop
+                $Added.Add($Path)
+            } catch {
+                $Failed.Add($Path)
+            }
+        } else {
+            $Added.Add($Path)
+        }
+    } else {
+        $UpstreamHash = (Get-FileHash $TmpFile    -Algorithm MD5).Hash
+        $LocalHash    = (Get-FileHash $LocalPath  -Algorithm MD5).Hash
+
+        if ($UpstreamHash -eq $LocalHash) {
+            $Unchanged.Add($Path)
+        } elseif ($Apply) {
+            try {
+                Copy-Item $TmpFile $LocalPath -Force -ErrorAction Stop
+                $Modified.Add($Path)
+            } catch {
+                $Failed.Add($Path)
+            }
+        } else {
+            $Modified.Add($Path)
+        }
+    }
+
+    Remove-Item $TmpFile -Force -ErrorAction SilentlyContinue
+}
+
+# Process individual allowlisted files
+foreach ($f in $AllowFiles) { Compare-AndApply $f }
+
+# Process allowlisted directories
+foreach ($Dir in $AllowDirs) {
+    $DirPaths = @($AllPaths | Where-Object { $_ -like "$Dir/*" })
+
+    foreach ($Path in $DirPaths) { Compare-AndApply $Path }
+
+    # Find local files absent from upstream (deleted in repo)
+    $LocalDir = Join-Path $VaultRoot $Dir
+    if (Test-Path $LocalDir) {
+        Get-ChildItem $LocalDir -Recurse -File | ForEach-Object {
+            $Rel = $_.FullName.Substring($VaultRoot.Length + 1).Replace("\", "/")
+            if ($DirPaths -notcontains $Rel) {
+                $Deleted.Add($Rel)
+                if ($Apply) { Remove-Item $_.FullName -Force -ErrorAction SilentlyContinue }
+            }
+        }
+    }
+}
+
+# Clear plugin cache when version is unchanged (apply mode only)
+$CacheNote = ""
+if ($Apply) {
+    $UpstreamVer = ""
+    try {
+        $UpstreamVer = (Invoke-RestMethod -Uri "$RawBase/.claude/plugins/onebrain/.claude-plugin/plugin.json" -UseBasicParsing).version
+    } catch {}
+
+    if ($LocalVer -and $LocalVer -eq $UpstreamVer) {
+        @(
+            "$env:USERPROFILE\.claude\plugins\cache\onebrain\onebrain\$LocalVer",
+            "$env:USERPROFILE\.claude\plugins\cache\onebrain-local\onebrain\$LocalVer"
+        ) | ForEach-Object {
+            if (Test-Path $_) { Remove-Item $_ -Recurse -Force -ErrorAction SilentlyContinue }
+        }
+        $CacheNote = "  cache: cleared plugin cache for v$LocalVer"
+    }
+}
+
+# Output report
+Write-Host "=== OneBrain Update Report ==="
+Write-Host "mode: $(if ($Apply) { 'applied' } else { 'dry-run' })"
+Write-Host "modified: $($Modified.Count)"
+Write-Host "added: $($Added.Count)"
+Write-Host "deleted: $($Deleted.Count)"
+Write-Host "unchanged: $($Unchanged.Count)"
+Write-Host "failed: $($Failed.Count)"
+
+foreach ($f in $Modified) { Write-Host "  ~ $f" }
+foreach ($f in $Added)    { Write-Host "  + $f" }
+foreach ($f in $Deleted)  { Write-Host "  - $f" }
+foreach ($f in $Failed)   { Write-Host "  ! $f" }
+
+if ($CacheNote) { Write-Host $CacheNote }
+
+if ($Failed.Count -gt 0) {
+    Write-Host "status: partial_failure"
+    exit 1
+}
+Write-Host "status: ok"

--- a/.claude/plugins/onebrain/skills/update/update.ps1
+++ b/.claude/plugins/onebrain/skills/update/update.ps1
@@ -33,7 +33,7 @@ if (Test-Path $PluginJsonPath) {
 
 # Fetch upstream file tree
 try {
-    $TreeJson = Invoke-RestMethod -Uri $ApiTree -UseBasicParsing
+    $TreeJson = Invoke-RestMethod -Uri $ApiTree
 } catch {
     Write-Host "ERROR: Could not fetch file list from GitHub (network error or rate limit)."
     exit 1
@@ -130,12 +130,17 @@ foreach ($Dir in $AllowDirs) {
 # Clear plugin cache when version is unchanged (apply mode only)
 $CacheNote = ""
 if ($Apply) {
+    # Use Invoke-WebRequest + ConvertFrom-Json because raw GitHub content returns text/plain,
+    # which Invoke-RestMethod returns as a string rather than a parsed object.
     $UpstreamVer = ""
     try {
-        $UpstreamVer = (Invoke-RestMethod -Uri "$RawBase/.claude/plugins/onebrain/.claude-plugin/plugin.json" -UseBasicParsing).version
+        $UpstreamVer = (Invoke-WebRequest -Uri "$RawBase/.claude/plugins/onebrain/.claude-plugin/plugin.json" -UseBasicParsing -ErrorAction Stop).Content |
+            ConvertFrom-Json |
+            Select-Object -ExpandProperty version
     } catch {}
 
     if ($LocalVer -and $LocalVer -eq $UpstreamVer) {
+        # Claude Code on Windows stores cache under %USERPROFILE%\.claude\ (mirrors Unix ~/.claude/)
         @(
             "$env:USERPROFILE\.claude\plugins\cache\onebrain\onebrain\$LocalVer",
             "$env:USERPROFILE\.claude\plugins\cache\onebrain-local\onebrain\$LocalVer"

--- a/.claude/plugins/onebrain/skills/update/update.sh
+++ b/.claude/plugins/onebrain/skills/update/update.sh
@@ -36,11 +36,23 @@ import json, sys
 for item in json.load(sys.stdin).get('tree', []):
     if item['type'] == 'blob':
         print(item['path'])
-")
+" 2>/dev/null) || {
+  echo "ERROR: Could not parse file list from GitHub (unexpected response format)."
+  exit 1
+}
 
 # Allowlist
 ALLOW_FILES=(".gitignore")
 ALLOW_DIRS=(".claude/plugins/onebrain" ".claude-plugin")
+
+# Snapshot local version before any files are overwritten (used for cache logic later)
+LOCAL_VER=$(python3 -c "
+import json
+try:
+    print(json.load(open('${PLUGIN_DIR}/.claude-plugin/plugin.json'))['version'])
+except:
+    print('')
+" 2>/dev/null || echo "")
 
 # Tracking arrays
 MODIFIED=() ADDED=() UNCHANGED=() FAILED=() DELETED=()
@@ -58,17 +70,27 @@ compare_and_apply() {
   fi
 
   if [[ ! -f "${local_path}" ]]; then
-    ADDED+=("${path}")
     if [[ "${APPLY}" == true ]]; then
       mkdir -p "$(dirname "${local_path}")"
-      cp "${tmp_file}" "${local_path}"
+      if cp "${tmp_file}" "${local_path}" 2>/dev/null; then
+        ADDED+=("${path}")
+      else
+        FAILED+=("${path}")
+      fi
+    else
+      ADDED+=("${path}")
     fi
   elif diff -q "${tmp_file}" "${local_path}" > /dev/null 2>&1; then
     UNCHANGED+=("${path}")
   else
-    MODIFIED+=("${path}")
     if [[ "${APPLY}" == true ]]; then
-      cp "${tmp_file}" "${local_path}"
+      if cp "${tmp_file}" "${local_path}" 2>/dev/null; then
+        MODIFIED+=("${path}")
+      else
+        FAILED+=("${path}")
+      fi
+    else
+      MODIFIED+=("${path}")
     fi
   fi
 
@@ -105,15 +127,9 @@ for dir in "${ALLOW_DIRS[@]}"; do
 done
 
 # Clear plugin cache when version is unchanged (apply mode only)
+# LOCAL_VER was snapshotted before the apply loop to avoid reading the already-overwritten file.
 CACHE_NOTE=""
 if [[ "${APPLY}" == true ]]; then
-  LOCAL_VER=$(python3 -c "
-import json
-try:
-    print(json.load(open('${PLUGIN_DIR}/.claude-plugin/plugin.json'))['version'])
-except:
-    print('')
-" 2>/dev/null || echo "")
   UPSTREAM_VER=$(curl -sf "${RAW_BASE}/.claude/plugins/onebrain/.claude-plugin/plugin.json" 2>/dev/null | \
     python3 -c "import json,sys; print(json.load(sys.stdin)['version'])" 2>/dev/null || echo "")
 

--- a/.claude/plugins/onebrain/skills/update/update.sh
+++ b/.claude/plugins/onebrain/skills/update/update.sh
@@ -112,11 +112,12 @@ for dir in "${ALLOW_DIRS[@]}"; do
   done <<< "${dir_paths}"
 
   # Find local files absent from upstream (deleted in repo)
+  # Guard: skip deletion scan if dir_paths is empty — avoids marking all local files as deleted.
   local_dir="${VAULT_ROOT}/${dir}"
-  if [[ -d "${local_dir}" ]]; then
+  if [[ -n "${dir_paths}" ]] && [[ -d "${local_dir}" ]]; then
     while IFS= read -r local_abs; do
       rel="${local_abs#${VAULT_ROOT}/}"
-      if ! echo "${dir_paths}" | grep -qF "${rel}"; then
+      if ! echo "${dir_paths}" | grep -qxF "${rel}"; then
         DELETED+=("${rel}")
         if [[ "${APPLY}" == true ]]; then
           rm -f "${local_abs}"

--- a/.claude/plugins/onebrain/skills/update/update.sh
+++ b/.claude/plugins/onebrain/skills/update/update.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# OneBrain update script — fetch, compare, and apply system files from GitHub.
+# Run from vault root.
+#
+# Usage:
+#   bash .claude/plugins/onebrain/skills/update/update.sh           # dry-run (compare only)
+#   bash .claude/plugins/onebrain/skills/update/update.sh --apply   # apply updates
+
+set -uo pipefail
+
+APPLY=false
+[[ "${1:-}" == "--apply" ]] && APPLY=true
+
+VAULT_ROOT="$(pwd)"
+PLUGIN_DIR="${VAULT_ROOT}/.claude/plugins/onebrain"
+REPO="kengio/onebrain"
+BRANCH="main"
+API_TREE="https://api.github.com/repos/${REPO}/git/trees/${BRANCH}?recursive=1"
+RAW_BASE="https://raw.githubusercontent.com/${REPO}/${BRANCH}"
+
+# Verify vault install
+if [[ ! -d "${PLUGIN_DIR}" ]]; then
+  echo "ERROR: OneBrain plugin not found at .claude/plugins/onebrain/ — run /onboarding first."
+  exit 1
+fi
+
+# Fetch upstream file tree
+TREE_JSON=$(curl -sf "${API_TREE}" 2>/dev/null) || {
+  echo "ERROR: Could not fetch file list from GitHub (network error or rate limit)."
+  exit 1
+}
+
+# Extract all blob paths
+ALL_PATHS=$(echo "${TREE_JSON}" | python3 -c "
+import json, sys
+for item in json.load(sys.stdin).get('tree', []):
+    if item['type'] == 'blob':
+        print(item['path'])
+")
+
+# Allowlist
+ALLOW_FILES=(".gitignore")
+ALLOW_DIRS=(".claude/plugins/onebrain" ".claude-plugin")
+
+# Tracking arrays
+MODIFIED=() ADDED=() UNCHANGED=() FAILED=() DELETED=()
+
+compare_and_apply() {
+  local path="$1"
+  local local_path="${VAULT_ROOT}/${path}"
+  local tmp_file
+  tmp_file=$(mktemp)
+
+  if ! curl -sf "${RAW_BASE}/${path}" > "${tmp_file}" 2>/dev/null; then
+    FAILED+=("${path}")
+    rm -f "${tmp_file}"
+    return
+  fi
+
+  if [[ ! -f "${local_path}" ]]; then
+    ADDED+=("${path}")
+    if [[ "${APPLY}" == true ]]; then
+      mkdir -p "$(dirname "${local_path}")"
+      cp "${tmp_file}" "${local_path}"
+    fi
+  elif diff -q "${tmp_file}" "${local_path}" > /dev/null 2>&1; then
+    UNCHANGED+=("${path}")
+  else
+    MODIFIED+=("${path}")
+    if [[ "${APPLY}" == true ]]; then
+      cp "${tmp_file}" "${local_path}"
+    fi
+  fi
+
+  rm -f "${tmp_file}"
+}
+
+# Process individual allowlisted files
+for f in "${ALLOW_FILES[@]}"; do
+  compare_and_apply "${f}"
+done
+
+# Process allowlisted directories
+for dir in "${ALLOW_DIRS[@]}"; do
+  dir_paths=$(echo "${ALL_PATHS}" | grep "^${dir}/") || true
+
+  while IFS= read -r path; do
+    [[ -z "${path}" ]] && continue
+    compare_and_apply "${path}"
+  done <<< "${dir_paths}"
+
+  # Find local files absent from upstream (deleted in repo)
+  local_dir="${VAULT_ROOT}/${dir}"
+  if [[ -d "${local_dir}" ]]; then
+    while IFS= read -r local_abs; do
+      rel="${local_abs#${VAULT_ROOT}/}"
+      if ! echo "${dir_paths}" | grep -qF "${rel}"; then
+        DELETED+=("${rel}")
+        if [[ "${APPLY}" == true ]]; then
+          rm -f "${local_abs}"
+        fi
+      fi
+    done < <(find "${local_dir}" -type f)
+  fi
+done
+
+# Clear plugin cache when version is unchanged (apply mode only)
+CACHE_NOTE=""
+if [[ "${APPLY}" == true ]]; then
+  LOCAL_VER=$(python3 -c "
+import json
+try:
+    print(json.load(open('${PLUGIN_DIR}/.claude-plugin/plugin.json'))['version'])
+except:
+    print('')
+" 2>/dev/null || echo "")
+  UPSTREAM_VER=$(curl -sf "${RAW_BASE}/.claude/plugins/onebrain/.claude-plugin/plugin.json" 2>/dev/null | \
+    python3 -c "import json,sys; print(json.load(sys.stdin)['version'])" 2>/dev/null || echo "")
+
+  if [[ -n "${LOCAL_VER}" && "${LOCAL_VER}" == "${UPSTREAM_VER}" ]]; then
+    rm -rf "${HOME}/.claude/plugins/cache/onebrain/onebrain/${LOCAL_VER}" 2>/dev/null || true
+    rm -rf "${HOME}/.claude/plugins/cache/onebrain-local/onebrain/${LOCAL_VER}" 2>/dev/null || true
+    CACHE_NOTE="  cache: cleared plugin cache for v${LOCAL_VER}"
+  fi
+fi
+
+# Output report
+echo "=== OneBrain Update Report ==="
+echo "mode: $([[ "${APPLY}" == true ]] && echo "applied" || echo "dry-run")"
+echo "modified: ${#MODIFIED[@]}"
+echo "added: ${#ADDED[@]}"
+echo "deleted: ${#DELETED[@]}"
+echo "unchanged: ${#UNCHANGED[@]}"
+echo "failed: ${#FAILED[@]}"
+
+for f in "${MODIFIED[@]+"${MODIFIED[@]}"}"; do echo "  ~ ${f}"; done
+for f in "${ADDED[@]+"${ADDED[@]}"}";    do echo "  + ${f}"; done
+for f in "${DELETED[@]+"${DELETED[@]}"}"; do echo "  - ${f}"; done
+for f in "${FAILED[@]+"${FAILED[@]}"}";  do echo "  ! ${f}"; done
+
+[[ -n "${CACHE_NOTE}" ]] && echo "${CACHE_NOTE}"
+
+if [[ ${#FAILED[@]} -gt 0 ]]; then
+  echo "status: partial_failure"
+  exit 1
+fi
+echo "status: ok"

--- a/.claude/plugins/onebrain/skills/update/update.sh
+++ b/.claude/plugins/onebrain/skills/update/update.sh
@@ -122,7 +122,7 @@ for dir in "${ALLOW_DIRS[@]}"; do
           rm -f "${local_abs}"
         fi
       fi
-    done < <(find "${local_dir}" -type f)
+    done < <(find "${local_dir}" -type f -not -name ".gitkeep")
   fi
 done
 


### PR DESCRIPTION
## Summary

- **New `skills/update/update.sh`** — shell script handles the deterministic Steps 2–4 (fetch upstream tree, compare files via `diff`, apply with `cp`). Uses `curl` in a loop, outputs a structured text report the Agent reads and presents.
- **Simplified `SKILL.md`** — Agent now runs the script for mechanical work; retains only judgment-required steps (4b–4e: MEMORY.md migration, folder creation, @import patching). SKILL.md reduced from ~270 lines to ~130.
- **`INSTRUCTIONS.md`** — Session startup step 1 now reads `plugin.json` and includes version in the greeting (e.g. "OneBrain v1.5.6").

## Test Plan

- [ ] Run `bash .claude/plugins/onebrain/skills/update/update.sh` from a vault root — verify structured report output (dry-run)
- [ ] Run with `--apply` — verify files are written and cache is cleared
- [ ] Run `/update` via Agent — verify SKILL.md flow is shorter and script output is parsed correctly
- [ ] Start a new session — verify version appears in greeting