### PR TITLE
Remove confirmation prompts from capture, braindump, bookmark skills

### DIFF
--- a/.claude/plugins/onebrain/skills/bookmark/SKILL.md
+++ b/.claude/plugins/onebrain/skills/bookmark/SKILL.md
@@ -38,7 +38,7 @@ Use the user's answers and continue normally.
 
 ## Step 3: Pre-Save Checks
 
-**Duplicate check:** grep `[resources]/Bookmarks.md` for the URL. If already present, tell the user and stop (unless they confirm to save again).
+**Duplicate check:** grep `[resources]/Bookmarks.md` for the URL (`[resources]` from Step 2). If already present, tell the user and stop (unless they confirm to save again).
 
 **Existing summary note:** grep `[resources]/**/*.md` for `url: [URL]` in frontmatter. If found, record its title for use as a wikilink in the entry.
 
@@ -65,7 +65,7 @@ Build the entry:
 
 (Omit the wikilink if no summary note was found in Step 3.)
 
-File path: `[resources]/Bookmarks.md`.
+File path: `[resources]/Bookmarks.md` (`[resources]` from Step 2).
 
 **If the file does not exist**, create it:
 

--- a/.claude/plugins/onebrain/skills/bookmark/SKILL.md
+++ b/.claude/plugins/onebrain/skills/bookmark/SKILL.md
@@ -5,7 +5,7 @@ description: Quick URL bookmark capture — paste a link, AI generates name and 
 
 # Bookmark
 
-Save a URL to your `Bookmarks.md` file in one step. Paste the link — the AI fills in the name and description, suggests a category, and appends it to your curated list.
+Save a URL to your `Bookmarks.md` file in one step. Paste the link — the AI fills in the name and description, picks a category, and saves immediately.
 
 Usage: `/bookmark [url]`
 
@@ -22,7 +22,7 @@ If not, ask:
 
 ## Step 2: Fetch the Page
 
-**Resolve the resources folder first:** read `vault.yml` for `folders.resources`, defaulting to `04-resources`. Store as `[resources]` — used throughout the remaining steps.
+**Resolve the resources folder first:** read `vault.yml` for `folders.resources`, defaulting to `04-resources`. Store as `[resources]`.
 
 Fetch the page content. Extract:
 
@@ -32,69 +32,40 @@ Fetch the page content. Extract:
 **If fetch fails**, ask:
 > I couldn't fetch that URL. What should I call it, how would you describe it in one line, and what category fits best?
 
-Use the user's answers for all three fields and continue to Step 3 normally.
+Use the user's answers and continue normally.
 
 ---
 
 ## Step 3: Pre-Save Checks
 
-**Check for duplicate bookmark:** Grep `[resources]/Bookmarks.md` for the URL (using the `[resources]` path resolved in Step 2). If already present, tell the user:
-> This URL is already in your Bookmarks.md under `## [Category]`. Want to save it again, or skip?
+**Duplicate check:** grep `[resources]/Bookmarks.md` for the URL. If already present, tell the user and stop (unless they confirm to save again).
 
-Stop if they say skip.
-
-**Check for existing summarize note:** Grep `[resources]/**/*.md` for `url: [URL]` in frontmatter. If a matching note is found, record its title — it will be added as a wikilink in the bookmark entry (Step 5).
+**Existing summary note:** grep `[resources]/**/*.md` for `url: [URL]` in frontmatter. If found, record its title for use as a wikilink in the entry.
 
 ---
 
-## Step 4: Suggest Category and Subcategory
+## Step 4: Pick Category
 
-Bookmarks.md supports **2 levels maximum**, like a real awesome list:
+Infer the best category and optional subcategory from the content — do not ask. Use the structure:
 
-- **Level 1 — Category (`##`)**: broad domain, e.g., `AI Tools`, `Design`, `Dev Utilities`
-- **Level 2 — Subcategory (`###`)**: optional refinement within a category, e.g., `Writing`, `Code`, `Productivity`
+- **Level 1 (`##`)**: broad domain — `AI Tools`, `Design`, `Dev Utilities`, `Productivity`, `Reading`, `Learning`, `Finance`, `Health`, `Reference`
+- **Level 2 (`###`)**: optional refinement — only when it adds meaningful grouping
 
-Infer the best fit from the name, description, and URL domain. Suggest a subcategory only when it adds meaningful grouping — skip it for simple or uncrowded categories.
-
-Common top-level categories: `AI Tools`, `Dev Utilities`, `Design`, `Productivity`, `Reading`, `Learning`, `Finance`, `Health`, `Reference`
-
-New categories and subcategories can be created freely.
+Create new categories freely when none fit.
 
 ---
 
-## Step 5: Confirm and Save
+## Step 5: Save to Bookmarks.md
 
-Build the entry line. If a summarize note was found in Step 3, append a wikilink:
+Build the entry:
 
 ```markdown
 - **[Name](URL)** — Description. → [[Summary Note Title]]
 ```
 
-Otherwise:
+(Omit the wikilink if no summary note was found in Step 3.)
 
-```markdown
-- **[Name](URL)** — Description.
-```
-
-Show a preview. Include subcategory only if one was suggested:
-
-**With subcategory:**
-> Saving to **Bookmarks.md** under `## AI Tools` / `### Writing`:
-> `- **[Name](URL)** — Description. → [[Summary Note Title]]`
-> OK? (or type a different category or category/subcategory)
-
-**Without subcategory:**
-> Saving to **Bookmarks.md** under `## Design`:
-> `- **[Name](URL)** — Description.`
-> OK? (or type a different category)
-
-Save immediately on confirmation. Accept overrides in any form: `Design`, `Design / Icons`, `AI Tools > Code`.
-
----
-
-## Step 6: Append to Bookmarks.md
-
-File path: `[resources]/Bookmarks.md` (resolved in Step 2).
+File path: `[resources]/Bookmarks.md`.
 
 **If the file does not exist**, create it:
 
@@ -108,49 +79,24 @@ updated: YYYY-MM-DD
 # Bookmarks
 ```
 
-**Append the entry** under the correct section. Rules:
+Append under the correct `##` / `###` section (alphabetical order). Create missing sections in alphabetical position. Refresh `updated` in frontmatter.
 
-- `##` headers = top-level categories (Level 1)
-- `###` headers = subcategories (Level 2, optional) — nested under their parent `##`
-- Maximum depth is 2 levels — no `####` or deeper
-- `##` sections are kept in alphabetical order; `###` sections within a `##` are also alphabetical
-- Entries within a section are in append order
-- Create missing `##` or `###` sections in alphabetical position as needed
-- Refresh `updated` in frontmatter on every write
+---
 
-**Example structure:**
+## Step 6: Confirm
 
-```markdown
-## AI Tools
-
-### Code
-
-- **[GitHub Copilot](https://github.com/features/copilot)** — AI pair programmer that suggests code completions inline.
-
-### Writing
-
-- **[Notion AI](https://notion.so)** — AI writing assistant built into Notion pages. → [[Notion AI Summary]]
-
-## Design
-
-- **[Figma](https://figma.com)** — Collaborative interface design tool for teams.
-```
-
-Confirm after saving:
-> Saved to **Bookmarks.md** under `## [Category]` / `### [Subcategory]` (omit subcategory line if none).
+Say in one line:
+> Saved to **Bookmarks.md** under `## [Category]`[` / ### [Subcategory]`].
 
 ---
 
 ## Recategorize
 
-If the user asks to move or recategorize a bookmark (e.g., *"move Raycast to Productivity"*, *"recategorize my last bookmark"*):
+If the user asks to move or recategorize a bookmark:
 
-Resolve file path as in Step 2 (read `vault.yml` for `folders.resources`, default `04-resources`).
-
-1. Find the entry by name, or use the last bullet line in the file for "last bookmark"
-2. Remove from current section; append to bottom of target section (create `##` or `###` as needed)
-3. Refresh `updated` in frontmatter
-4. Confirm:
-   > Moved **[Name]** from `## [Old]` → `## [New Category]` / `### [New Subcategory]` (omit subcategory if none).
-
-> **Note:** "last bookmark" = last bullet line in the file. This heuristic may be unreliable if the file is edited manually.
+1. Resolve file path (read `vault.yml` for `folders.resources`, default `04-resources`)
+2. Find the entry by name, or use the last bullet for "last bookmark"
+3. Remove from current section; append to target section (create `##` / `###` as needed)
+4. Refresh `updated` in frontmatter
+5. Confirm in one line:
+   > Moved **[Name]** from `## [Old]` → `## [New]`[` / ### [Sub]`].

--- a/.claude/plugins/onebrain/skills/bookmark/SKILL.md
+++ b/.claude/plugins/onebrain/skills/bookmark/SKILL.md
@@ -86,7 +86,7 @@ Append under the correct `##` / `###` section (alphabetical order). Create missi
 ## Step 6: Confirm
 
 Say in one line:
-> Saved to **Bookmarks.md** under `## [Category]`[` / ### [Subcategory]`].
+> Saved to **Bookmarks.md** under `## [Category]`. [If subcategory: `/ ### [Subcategory]`]
 
 ---
 
@@ -94,7 +94,7 @@ Say in one line:
 
 If the user asks to move or recategorize a bookmark:
 
-1. Resolve file path (read `vault.yml` for `folders.resources`, default `04-resources`)
+1. Resolve file path using `[resources]` from Step 2 if in the same session, otherwise read `vault.yml` for `folders.resources` (default `04-resources`)
 2. Find the entry by name, or use the last bullet for "last bookmark"
 3. Remove from current section; append to target section (create `##` / `###` as needed)
 4. Refresh `updated` in frontmatter

--- a/.claude/plugins/onebrain/skills/bookmark/SKILL.md
+++ b/.claude/plugins/onebrain/skills/bookmark/SKILL.md
@@ -99,4 +99,4 @@ If the user asks to move or recategorize a bookmark:
 3. Remove from current section; append to target section (create `##` / `###` as needed)
 4. Refresh `updated` in frontmatter
 5. Confirm in one line:
-   > Moved **[Name]** from `## [Old]` → `## [New]`[` / ### [Sub]`].
+   > Moved **[Name]** from `## [Old]` → `## [New]`. [If subcategory: `/ ### [Sub]`]

--- a/.claude/plugins/onebrain/skills/braindump/SKILL.md
+++ b/.claude/plugins/onebrain/skills/braindump/SKILL.md
@@ -71,6 +71,7 @@ created: YYYY-MM-DD
 ## Related Notes
 
 [[Link to relevant existing notes if any]]
+(Omit this section if no related notes are found)
 ```
 
 ---

--- a/.claude/plugins/onebrain/skills/braindump/SKILL.md
+++ b/.claude/plugins/onebrain/skills/braindump/SKILL.md
@@ -14,43 +14,30 @@ Capture everything on your mind right now. Don't filter — just say it.
 Say:
 > Go for it — what's on your mind? Dump everything. I'll sort it out.
 
-Wait for the user to share their thoughts. They might write a few sentences or several paragraphs. Don't interrupt.
+Wait for the user to share their thoughts. Don't interrupt.
 
 ---
 
 ## Step 2: Classify the Content
 
-After they've finished, silently analyze the content and classify each item into:
+Silently analyze and classify each item:
 
 | Type | Description | Destination |
 |------|-------------|-------------|
 | **Task** | Something to do | Extract as task with date |
 | **Idea** | Creative or speculative thought | File to inbox |
-| **Note** | Fact, reference, or information | File to inbox (process later via `/consolidate`) |
-| **Project** | Something that needs a dedicated note | Create/update in 01-projects/ |
+| **Note** | Fact, reference, or information | File to inbox |
+| **Project** | Something needing a dedicated note | Create/update in 01-projects/ |
 | **Question** | Open question or uncertainty | File to inbox with `?` tag |
 | **Feeling/Reflection** | Personal reflection or emotion | File to inbox |
 
 ---
 
-## Step 3: Show Classification
+## Step 3: Create Inbox File
 
-Present a quick summary before filing:
+File immediately — do not ask for confirmation first.
 
-> Here's what I heard:
-> - **2 tasks** — I'll extract these with due dates
-> - **1 idea** about [topic]
-> - **1 note** about [topic]
->
-> Shall I file these to your inbox? (or say "adjust" to change anything)
-
-Wait for confirmation or adjustments.
-
----
-
-## Step 4: Create Inbox File
-
-Create a file in `00-inbox/` named `YYYY-MM-DD-braindump.md` (use today's date; if a file with that name exists, append `-2`, `-3`, etc.).
+Create `00-inbox/YYYY-MM-DD-braindump.md` (append `-2`, `-3` if file exists):
 
 ```markdown
 ---
@@ -72,7 +59,6 @@ created: YYYY-MM-DD
 ## Ideas
 
 - [idea 1]
-- [idea 2]
 
 ## Notes & References
 
@@ -89,18 +75,13 @@ created: YYYY-MM-DD
 
 ---
 
-## Step 5: Check for Project Links
+## Step 4: Check for Project Links
 
-If any item mentions an active project from `[agent folder]/MEMORY.md` (already loaded in context):
-- Mention it: "This looks related to [Project] — want me to also add a note there?"
-- If yes, find the project file by searching `01-projects/**/*.md` and append a brief note to it (the subfolder is wherever the project file already lives)
+If any item clearly relates to an active project in MEMORY.md, append a brief note to that project file automatically. Mention it in the confirmation.
 
 ---
 
-## Step 6: Confirm and Suggest Next
+## Step 5: Confirm
 
-Say:
-> Filed to `00-inbox/YYYY-MM-DD-braindump.md`.
-> [If tasks were extracted]: I extracted N tasks — they'll show up in your Tasks view.
->
-> Anything else on your mind, or shall we dive into something from this dump?
+Say in one line:
+> Filed to `00-inbox/YYYY-MM-DD-braindump.md`. [If tasks: Extracted N tasks.] [If project link: Added note to [[Project]].]

--- a/.claude/plugins/onebrain/skills/braindump/SKILL.md
+++ b/.claude/plugins/onebrain/skills/braindump/SKILL.md
@@ -77,7 +77,7 @@ created: YYYY-MM-DD
 
 ## Step 4: Check for Project Links
 
-If any item clearly relates to an active project in MEMORY.md, append a brief note to that project file automatically. Mention it in the confirmation.
+If any item is a direct update, task, or decision for an active project in MEMORY.md (not a passing mention), append a brief note to that project file automatically. Mention it in the confirmation.
 
 ---
 

--- a/.claude/plugins/onebrain/skills/capture/SKILL.md
+++ b/.claude/plugins/onebrain/skills/capture/SKILL.md
@@ -36,7 +36,7 @@ Classify the content — do not ask, infer from context:
 
 ## Step 3: Find and Link Related Notes
 
-Scan `03-knowledge/**/*.md`, `04-resources/**/*.md`, `02-areas/**/*.md`, and `01-projects/**/*.md` for related notes. Include the top 1–3 most relevant as wikilinks in the note. Do not ask — add them automatically.
+Scan `03-knowledge/**/*.md`, `04-resources/**/*.md`, `02-areas/**/*.md`, and `01-projects/**/*.md` for related notes. Exclude the destination file itself. Include the top 1–3 most relevant as wikilinks in the note. Do not ask — add them automatically.
 
 ---
 
@@ -59,6 +59,7 @@ created: YYYY-MM-DD
 ## Related
 
 [[Link 1]]
+[[Link 2]]
 ```
 
 **For knowledge / reference / area note:**

--- a/.claude/plugins/onebrain/skills/capture/SKILL.md
+++ b/.claude/plugins/onebrain/skills/capture/SKILL.md
@@ -18,50 +18,29 @@ If they provided content after `/capture [content]`, use that directly.
 
 ---
 
-## Step 2: Determine Note Type
+## Step 2: Determine Note Type and Location
 
-Classify the content:
-- **Fleeting note** → file to `00-inbox/` (unprocessed idea, rough thought)
-- **Knowledge note** → file to `03-knowledge/` (personal synthesis, insight, processed idea)
-- **Reference note** → file to `04-resources/` (external source, fact, quote, reference material)
-- **Area note** → file to `02-areas/` (ongoing responsibility — health, finances, career...)
-- **Project note** → append to relevant `01-projects/` file
+Classify the content — do not ask, infer from context:
 
-Ask if unclear:
-> Is this a rough idea to process later, your own synthesized insight, reference material from an external source, something related to an ongoing area of responsibility, or a project update?
+| Type | Destination |
+|------|-------------|
+| Fleeting note / rough idea | `00-inbox/YYYY-MM-DD-[slug].md` |
+| Personal insight / synthesis | `03-knowledge/[best-subfolder]/[Topic Name].md` |
+| External reference / source | `04-resources/[best-subfolder]/[Topic Name].md` |
+| Ongoing responsibility | `02-areas/[best-subfolder]/[Topic Name].md` |
+| Project update | append to `01-projects/[subfolder]/[Project Name].md` |
 
----
-
-## Step 3: Choose Subfolder
-
-**Skip this step for fleeting notes going to `00-inbox/`.**
-
-For knowledge notes (`03-knowledge/`), reference notes (`04-resources/`), area notes (`02-areas/`), or project notes (`01-projects/`):
-
-1. Glob existing subfolders in the target folder (e.g. `03-knowledge/*/`, `04-resources/*/`, or `02-areas/*/`)
-2. Analyze the content to determine the best category
-3. Suggest a subfolder path (kebab-case, max 2 levels, e.g. `programming/python`):
-   - If an existing subfolder fits well → suggest it
-   - If none match → suggest a new name (1-2 short words, hyphenated)
-4. Present to user:
-   > I'd file this under `[target-folder]/[suggested-path]/`. Sound good?
-   > Existing folders: [list]
-5. Use the confirmed path. Subfolder naming rules: all lowercase, hyphens not spaces, max 2 levels.
+**For subfolders:** glob existing subfolders in the target folder and pick the best fit. If none match, create a new kebab-case name (1–2 words). Do not ask — decide and proceed.
 
 ---
 
-## Step 4: Find Related Notes
+## Step 3: Find and Link Related Notes
 
-Scan `03-knowledge/**/*.md`, `04-resources/**/*.md`, `02-areas/**/*.md`, and `01-projects/**/*.md` for notes related to the content (by topic/tags/title).
-
-List up to 3 relevant matches and ask:
-> I found these related notes — should I link to any of them?
-> - [[Note A]] — [why it's related]
-> - [[Note B]] — [why it's related]
+Scan `03-knowledge/**/*.md`, `04-resources/**/*.md`, `02-areas/**/*.md`, and `01-projects/**/*.md` for related notes. Include the top 1–3 most relevant as wikilinks in the note. Do not ask — add them automatically.
 
 ---
 
-## Step 5: Create the Note
+## Step 4: Create the Note
 
 **For inbox (fleeting note):**
 
@@ -80,12 +59,11 @@ created: YYYY-MM-DD
 ## Related
 
 [[Link 1]]
-[[Link 2]]
 ```
 
-**For knowledge note (`03-knowledge/`), reference note (`04-resources/`), or area note (`02-areas/`):**
+**For knowledge / reference / area note:**
 
-File: `[target-folder]/[subfolder]/[Topic Name].md` (target folder and subfolder confirmed in Steps 2–3)
+File: `[target-folder]/[subfolder]/[Topic Name].md`
 
 If the file already exists, append a new section. If not, create it:
 
@@ -106,7 +84,7 @@ created: YYYY-MM-DD
 
 **For project note:**
 
-Append to `01-projects/[subfolder]/[Project Name].md` (subfolder confirmed in Step 3):
+Append to the existing project file:
 
 ```markdown
 
@@ -119,10 +97,7 @@ Related: [[Link 1]]
 
 ---
 
-## Step 6: Confirm
+## Step 5: Confirm
 
-Say:
-> Captured to `[file path]`.
-> [If links added]: Linked to [[Note A]] and [[Note B]].
->
-> Anything else to add?
+Say in one line:
+> Captured to `[file path]`. [If links added: Linked to [[Note A]], [[Note B]].]

--- a/.claude/plugins/onebrain/skills/capture/SKILL.md
+++ b/.claude/plugins/onebrain/skills/capture/SKILL.md
@@ -36,7 +36,7 @@ Classify the content — do not ask, infer from context:
 
 ## Step 3: Find and Link Related Notes
 
-Scan `03-knowledge/**/*.md`, `04-resources/**/*.md`, `02-areas/**/*.md`, and `01-projects/**/*.md` for related notes. Exclude the destination file itself. Include the top 1–3 most relevant as wikilinks in the note. Do not ask — add them automatically.
+Scan `03-knowledge/**/*.md`, `04-resources/**/*.md`, `02-areas/**/*.md`, and `01-projects/**/*.md` for related notes. Exclude the destination file itself. Include the top 1–3 most relevant as wikilinks in the note. Do not ask — add them automatically. If no related notes are found, omit the `## Related` section entirely.
 
 ---
 


### PR DESCRIPTION
## Summary

All three capture-profile skills now follow the rule: **write the note, confirm done in one line. No elaboration.**

- **capture** — auto-classifies note type, auto-picks subfolder (no "Sound good?" step), auto-links related notes (no "Should I link?" step), single-line confirm
- **braindump** — files immediately without "Shall I file these?" confirmation step, auto-appends to project notes when clearly related
- **bookmark** — saves immediately without preview + "OK?" step, single-line confirm

## Test Plan

- [ ] `/capture [idea]` — files without asking subfolder or link confirmation
- [ ] `/braindump` — files to inbox without confirmation step after classification
- [ ] `/bookmark [url]` — saves immediately, confirms in one line