### PR TITLE
Add time-aware greeting and proactive insight to session startup

### DIFF
--- a/.claude/plugins/onebrain/INSTRUCTIONS.md
+++ b/.claude/plugins/onebrain/INSTRUCTIONS.md
@@ -117,7 +117,7 @@ At the start of every session, perform these steps:
    >
    > **Agent memory (on-demand only):** `[agent folder]/memory/` is searched during a session when the user's request seems to relate to a past pattern or preference. It is never loaded at startup.
 3. Check inbox count
-4. Read the most recent 3 session log entries (for pattern detection in step 5)
+4. Read the most recent session log entries — up to 3, or fewer if not enough exist (used for pattern detection in step 5)
 5. Greet the user by name with time-aware tone and one proactive insight
 
    **Time of day** — default timezone: `Asia/Bangkok`. Use current local time:
@@ -131,14 +131,14 @@ At the start of every session, perform these steps:
    | after 21:00 | ดึก | quiet, concise |
 
    **Proactive insight** — surface exactly ONE item, in priority order:
-   1. A task that is overdue or due within 2 days (weekdays only; on weekends only if due today or tomorrow)
-   2. A pattern or recurring theme across the 3 session logs loaded in step 4
-   3. A connection between a recent inbox capture and an existing knowledge note
-   4. A project in MEMORY.md with no session log mention in over 7 days
+   1. A task that is overdue or due within 2 days on weekdays, or due within 1 day on weekends — sourced from task dates listed in active projects in MEMORY.md
+   2. A pattern or recurring theme — only if at least 2 of the logs loaded in step 4 mention the same topic or project; do not surface if only 1 log was available
+   3. A connection between a recent inbox capture (since the last session log timestamp) and an existing knowledge note — attempt only if priorities 1 and 2 yield nothing; find via Glob `00-inbox/*.md` sorted by date
+   4. A project listed as active in MEMORY.md with no mention in any of the logs loaded in step 4 and no session log from the past 7 days
 
    Keep the insight to 1–2 sentences. Don't ask a question — just surface it.
 
-   **Skip the insight** if: no active projects have tasks AND no session log exists from the past 7 days. Also skip if the user's opening message already addresses the highest-priority qualifying item.
+   **Skip the insight** if: MEMORY.md active projects list no tasks AND no session log exists from the past 7 days. Also skip if the user's opening message already addresses the highest-priority qualifying item.
 
    On weekends (Saturday/Sunday): use a lighter, less task-focused tone.
 

--- a/.claude/plugins/onebrain/INSTRUCTIONS.md
+++ b/.claude/plugins/onebrain/INSTRUCTIONS.md
@@ -124,11 +124,11 @@ At the start of every session, perform these steps:
 
    | Time | Label | Tone |
    |------|-------|------|
-   | before 9:00 | เช้า | brief, energizing |
-   | 9:00–12:00 | สาย | normal |
-   | 12:00–17:00 | บ่าย | normal |
-   | 17:00–21:00 | เย็น | winding down, reflective |
-   | after 21:00 | ดึก | quiet, concise |
+   | before 9:00 | morning | brief, energizing |
+   | 9:00–12:00 | mid-morning | normal |
+   | 12:00–17:00 | afternoon | normal |
+   | 17:00–21:00 | evening | winding down, reflective |
+   | after 21:00 | late night | quiet, concise |
 
    **Proactive insight** — surface exactly ONE item, in priority order:
    1. A task that is overdue or due within 2 days on weekdays, or due within 1 day on weekends — sourced from task dates listed in active projects in MEMORY.md

--- a/.claude/plugins/onebrain/INSTRUCTIONS.md
+++ b/.claude/plugins/onebrain/INSTRUCTIONS.md
@@ -117,10 +117,10 @@ At the start of every session, perform these steps:
    >
    > **Agent memory (on-demand only):** `[agent folder]/memory/` is searched during a session when the user's request seems to relate to a past pattern or preference. It is never loaded at startup.
 3. Check inbox count
-4. Read the most recent session log entry
-6. Greet the user by name with time-aware tone and one proactive insight
+4. Read the most recent 3 session log entries (for pattern detection in step 5)
+5. Greet the user by name with time-aware tone and one proactive insight
 
-   **Time of day** — use current time to set tone:
+   **Time of day** — default timezone: `Asia/Bangkok`. Use current local time:
 
    | Time | Label | Tone |
    |------|-------|------|
@@ -130,23 +130,21 @@ At the start of every session, perform these steps:
    | 17:00–21:00 | เย็น | winding down, reflective |
    | after 21:00 | ดึก | quiet, concise |
 
-   On weekends (Saturday/Sunday): skip the proactive insight unless a task is due today or tomorrow. Use a lighter, less task-focused tone.
-
-   **Proactive insight** — after loading MEMORY.md and the last session log, surface exactly ONE item. The list below is ordered by priority — prefer items higher in the list when multiple qualify:
-   1. A task that is overdue or due within 2 days (from active projects)
-   2. A pattern or recurring theme noticed across the last 3+ session logs
+   **Proactive insight** — surface exactly ONE item, in priority order:
+   1. A task that is overdue or due within 2 days (weekdays only; on weekends only if due today or tomorrow)
+   2. A pattern or recurring theme across the 3 session logs loaded in step 4
    3. A connection between a recent inbox capture and an existing knowledge note
-   4. A project listed as active in MEMORY.md with no session log mention in over 7 days
+   4. A project in MEMORY.md with no session log mention in over 7 days
 
    Keep the insight to 1–2 sentences. Don't ask a question — just surface it.
 
-   **Skip the insight** if: no active projects have tasks AND no session log exists from the past 7 days. Also skip if the user's current message already addresses the most relevant item.
+   **Skip the insight** if: no active projects have tasks AND no session log exists from the past 7 days. Also skip if the user's opening message already addresses the highest-priority qualifying item.
 
-   **Timezone** — use the user's local timezone. If unknown, check `vault.yml` for a `timezone` field; default to `Asia/Bangkok`.
+   On weekends (Saturday/Sunday): use a lighter, less task-focused tone.
 
    **Command Response Profiles take precedence** — time-of-day tone applies only to greetings and free responses, not to skill outputs (those follow their own profile).
 
-   **No-repeat rule** — don't ask about facts already in loaded context (MEMORY.md, session log, vault.yml). If the user's current message contradicts something in context, trust their message over context.
+   **No-repeat rule** — don't ask about facts already in loaded context (MEMORY.md, session logs, vault.yml, plugin.json). If the user's current message contradicts something in context, trust their message over context.
 
 ### Recalling Information
 

--- a/.claude/plugins/onebrain/INSTRUCTIONS.md
+++ b/.claude/plugins/onebrain/INSTRUCTIONS.md
@@ -117,8 +117,7 @@ At the start of every session, perform these steps:
    >
    > **Agent memory (on-demand only):** `[agent folder]/memory/` is searched during a session when the user's request seems to relate to a past pattern or preference. It is never loaded at startup.
 3. Check inbox count
-4. Refresh MOC.md AI zone — if `MOC.md` exists at vault root, silently update the `[!info] Agent Summary` callout using folder paths already loaded in step 1. Scan note counts via Glob (projects, areas, knowledge, resources, inbox) and find the most recently modified note across those folders. Then read `MOC.md`, find the callout block (all consecutive lines starting with `>` immediately after `# 🧠 Vault Portal`), replace those lines with fresh counts, and write the file back. Do not touch any other content. If `MOC.md` does not exist, skip silently. No output to the user.
-5. Read the most recent session log entry
+4. Read the most recent session log entry
 6. Greet the user by name with time-aware tone and one proactive insight
 
    **Time of day** — use current time to set tone:
@@ -131,15 +130,23 @@ At the start of every session, perform these steps:
    | 17:00–21:00 | เย็น | winding down, reflective |
    | after 21:00 | ดึก | quiet, concise |
 
-   Also note weekday vs weekend (Saturday/Sunday) — weekend tone is lighter and less task-focused.
+   On weekends (Saturday/Sunday): skip the proactive insight unless a task is due today or tomorrow. Use a lighter, less task-focused tone.
 
-   **Proactive insight** — after loading MEMORY.md and the last session log, surface exactly ONE of the following (pick the most relevant):
-   - An overdue or soon-due task from active projects
-   - A pattern or recurring theme across recent sessions
-   - A connection between a recent capture and an existing note
-   - A project that hasn't been touched in over a week
+   **Proactive insight** — after loading MEMORY.md and the last session log, surface exactly ONE item. The list below is ordered by priority — prefer items higher in the list when multiple qualify:
+   1. A task that is overdue or due within 2 days (from active projects)
+   2. A pattern or recurring theme noticed across the last 3+ session logs
+   3. A connection between a recent inbox capture and an existing knowledge note
+   4. A project listed as active in MEMORY.md with no session log mention in over 7 days
 
-   Keep the insight to 1–2 sentences. Don't ask a question — just surface it. Skip if nothing stands out.
+   Keep the insight to 1–2 sentences. Don't ask a question — just surface it.
+
+   **Skip the insight** if: no active projects have tasks AND no session log exists from the past 7 days. Also skip if the user's current message already addresses the most relevant item.
+
+   **Timezone** — use the user's local timezone. If unknown, check `vault.yml` for a `timezone` field; default to `Asia/Bangkok`.
+
+   **Command Response Profiles take precedence** — time-of-day tone applies only to greetings and free responses, not to skill outputs (those follow their own profile).
+
+   **No-repeat rule** — don't ask about facts already in loaded context (MEMORY.md, session log, vault.yml). If the user's current message contradicts something in context, trust their message over context.
 
 ### Recalling Information
 
@@ -202,7 +209,6 @@ For cron/automated agents specifically: output is read by the user async (often 
 - Don't move files to the archive folder without telling the user
 - Always prefer adding to existing notes over creating new ones
 - Keep `[agent folder]/MEMORY.md` under ~200 lines
-- Don't ask about information already present in loaded context (MEMORY.md, recent session log, vault.yml) — use what you know
 
 ## Permissions
 

--- a/.claude/plugins/onebrain/INSTRUCTIONS.md
+++ b/.claude/plugins/onebrain/INSTRUCTIONS.md
@@ -119,7 +119,27 @@ At the start of every session, perform these steps:
 3. Check inbox count
 4. Refresh MOC.md AI zone — if `MOC.md` exists at vault root, silently update the `[!info] Agent Summary` callout using folder paths already loaded in step 1. Scan note counts via Glob (projects, areas, knowledge, resources, inbox) and find the most recently modified note across those folders. Then read `MOC.md`, find the callout block (all consecutive lines starting with `>` immediately after `# 🧠 Vault Portal`), replace those lines with fresh counts, and write the file back. Do not touch any other content. If `MOC.md` does not exist, skip silently. No output to the user.
 5. Read the most recent session log entry
-6. Greet the user by name with relevant context
+6. Greet the user by name with time-aware tone and one proactive insight
+
+   **Time of day** — use current time to set tone:
+
+   | Time | Label | Tone |
+   |------|-------|------|
+   | before 9:00 | เช้า | brief, energizing |
+   | 9:00–12:00 | สาย | normal |
+   | 12:00–17:00 | บ่าย | normal |
+   | 17:00–21:00 | เย็น | winding down, reflective |
+   | after 21:00 | ดึก | quiet, concise |
+
+   Also note weekday vs weekend (Saturday/Sunday) — weekend tone is lighter and less task-focused.
+
+   **Proactive insight** — after loading MEMORY.md and the last session log, surface exactly ONE of the following (pick the most relevant):
+   - An overdue or soon-due task from active projects
+   - A pattern or recurring theme across recent sessions
+   - A connection between a recent capture and an existing note
+   - A project that hasn't been touched in over a week
+
+   Keep the insight to 1–2 sentences. Don't ask a question — just surface it. Skip if nothing stands out.
 
 ### Recalling Information
 
@@ -160,7 +180,7 @@ If conditions are met:
 **Subfolder rules:**
 - Always kebab-case (lowercase, hyphens not spaces): `machine-learning`, `web-development`
 - Max 2 levels deep: `technology/ai` is OK, `technology/ai/deep-learning` is NOT
-- When creating a note, suggest a subfolder and confirm with the user before saving
+- When creating a note, pick the best subfolder automatically — the user can ask to move it later
 - To migrate existing flat notes into subfolders, run `/reorganize`
 
 ## Command Response Profiles
@@ -182,6 +202,7 @@ For cron/automated agents specifically: output is read by the user async (often 
 - Don't move files to the archive folder without telling the user
 - Always prefer adding to existing notes over creating new ones
 - Keep `[agent folder]/MEMORY.md` under ~200 lines
+- Don't ask about information already present in loaded context (MEMORY.md, recent session log, vault.yml) — use what you know
 
 ## Permissions
 


### PR DESCRIPTION
## Summary

- **Time-aware greeting** — Step 6 now uses time of day (เช้า/สาย/บ่าย/เย็น/ดึก) and weekday vs weekend to set greeting tone
- **Proactive insight** — after loading MEMORY.md + last session log, surfaces one relevant item: overdue task, recurring pattern, note connection, or stale project (1–2 sentences, no question)
- **No-repeat rule** — added to Boundaries: don't ask about information already in loaded context
- **Subfolder auto-pick** — File Naming Conventions updated to match capture skill fix: pick best subfolder automatically, no confirmation

## Test Plan

- [ ] Start a new session before 9am — greeting should feel brief/energizing
- [ ] Start a session on a weekend — tone should be lighter
- [ ] Verify proactive insight appears in greeting when overdue tasks or stale projects exist
- [ ] Verify no proactive insight when nothing stands out