### PR TITLE
feat: add /recap cross-session synthesis skill (v1.5.7)

### DIFF
--- a/.claude/plugins/onebrain/.claude-plugin/plugin.json
+++ b/.claude/plugins/onebrain/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "onebrain",
-  "version": "1.5.6",
+  "version": "1.5.7",
   "description": "OneBrain — Where human and AI thinking become one. A powerful thinking partner powered by AI synergy.",
   "author": {
     "name": "OneBrain Contributors"

--- a/.claude/plugins/onebrain/INSTRUCTIONS.md
+++ b/.claude/plugins/onebrain/INSTRUCTIONS.md
@@ -83,6 +83,7 @@ These workflows are documented in `.claude/plugins/onebrain/skills/`:
 | `/import` | `import/SKILL.md` | Import local files (PDF, docs, images, scripts) → vault notes |
 | `/reading-notes` | `reading-notes/SKILL.md` | Book/article → structured notes |
 | `/weekly` | `weekly/SKILL.md` | Weekly reflection |
+| `/recap` | `recap/SKILL.md` | Cross-session synthesis → update MEMORY.md Key Learnings |
 | `/tasks` | `tasks/SKILL.md` | Create or update live task dashboard (TASKS.md) and open in Obsidian |
 | `/moc` | `moc/SKILL.md` | Create or update vault portal (MOC.md) and open in Obsidian |
 | `/wrapup` | `wrapup/SKILL.md` | Wrap up session → session log |

--- a/.claude/plugins/onebrain/skills/help/SKILL.md
+++ b/.claude/plugins/onebrain/skills/help/SKILL.md
@@ -39,6 +39,7 @@ Display a formatted table with all available commands:
 | `/tasks` | Open live task dashboard in Obsidian — creates/updates `TASKS.md` with live query sections | When you want an overview of what needs doing |
 | `/moc` | Create or refresh vault portal (MOC.md) — a Map of Content with live queries, AI summary, and your pinned links | When you want a bird's-eye view of your entire vault |
 | `/weekly` | Weekly reflection — review sessions, patterns, intentions | At the end of each week for review and planning |
+| `/recap` | Cross-session synthesis — reads 7 days of logs, surfaces patterns, updates MEMORY.md Key Learnings | Periodically, when you want to distill recent sessions into long-term memory |
 | `/wrapup` | Save a session summary to your session log | At the end of a work session to capture what you did |
 | `/learn` | Teach the agent something — facts about your world or behavioral preferences | When you want the agent to remember something across all future sessions |
 | `/clone` | Package your agent context (agent folder including MEMORY.md) for vault transfer | When moving to a new vault and want to preserve your agent's memory |

--- a/.claude/plugins/onebrain/skills/recap/SKILL.md
+++ b/.claude/plugins/onebrain/skills/recap/SKILL.md
@@ -14,8 +14,8 @@ Reads session logs from the past 7 days, surfaces patterns, decisions, and insig
 ## Before You Begin
 
 Read `vault.yml` and extract:
-- `folders.logs` as `logs_folder` (default: `07-logs`)
-- `folders.agent` as `agent_folder` (default: `05-agent`)
+- `folders.logs` as `[logs_folder]` (default: `07-logs`)
+- `folders.agent` as `[agent_folder]` (default: `05-agent`)
 
 ---
 
@@ -78,6 +78,8 @@ Compare every entry in "Insights worth keeping" against the existing `## Key Lea
 | Insight extends or refines an existing entry | Merge into the existing entry |
 | Insight is genuinely new | Keep for append |
 
+To merge: rewrite the existing bullet in-place to incorporate the new detail, keeping the original date.
+
 After dedup, if no new insights remain:
 > All insights are already captured in MEMORY.md — nothing new to add.
 
@@ -110,7 +112,7 @@ Do not modify `[agent_folder]/memory/` or `[agent_folder]/context/` — these ar
 ## Step 7: Confirm
 
 ```
-Recap complete. Added N insights to MEMORY.md.
+Recap complete. Added N new insights to MEMORY.md (M already captured — skipped).
 ```
 
 If overflow warning was triggered, append:
@@ -120,5 +122,5 @@ MEMORY.md is now N lines — consider /learn to trim.
 
 If nothing was written (all deduped):
 ```
-Recap complete. No new insights to add — MEMORY.md is already up to date.
+Recap complete. No new insights to add — all N insights already captured in MEMORY.md.
 ```

--- a/.claude/plugins/onebrain/skills/recap/SKILL.md
+++ b/.claude/plugins/onebrain/skills/recap/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: recap
+description: Cross-session synthesis — reads session logs from the past 7 days, surfaces patterns and insights, and updates MEMORY.md Key Learnings. Run periodically to keep long-term memory current.
+---
+
+# /recap — Cross-Session Synthesis
+
+Reads session logs from the past 7 days, surfaces patterns, decisions, and insights across sessions, then updates `MEMORY.md` Key Learnings with new, deduplicated entries.
+
+**Distinct from `/wrapup`:** `/wrapup` summarizes the current session just ended. `/recap` looks back across multiple sessions to surface long-term patterns.
+
+---
+
+## Before You Begin
+
+Read `vault.yml` and extract:
+- `folders.logs` as `logs_folder` (default: `07-logs`)
+- `folders.agent` as `agent_folder` (default: `05-agent`)
+
+---
+
+## Step 1: Find sessions from the past 7 days
+
+Glob `[logs_folder]/**/*.md`. Filter to files whose `date` frontmatter value is within the past 7 days (today inclusive).
+
+Report to the user:
+> Found N sessions (DD Mon – DD Mon)
+
+If no sessions found:
+> No sessions found in the past 7 days. Nothing to recap.
+
+Exit gracefully — do not proceed.
+
+---
+
+## Step 2: Read and extract from each log
+
+Read each session log. Extract:
+
+- **Key Decisions** — choices, directions, conclusions reached
+- **Insights & Learnings** — new understanding, patterns discovered
+- **Recurring topics** — project names or themes that appear in ≥ 2 sessions
+- **Open Questions** — questions listed in logs that have no follow-up answer in any later log
+
+---
+
+## Step 3: Synthesize and display
+
+Present the synthesis to the user before writing anything:
+
+```
+## Recap — DD Mon – DD Mon (N sessions)
+
+**Patterns noticed:**
+- [recurring theme across sessions, e.g. "5 of 7 sessions touched OneBrain infrastructure"]
+
+**Key decisions:**
+- [consolidated list of decisions made across sessions]
+
+**Insights worth keeping:**
+- [insight not already present in MEMORY.md Key Learnings]
+
+**Open threads:**
+- [question that appeared in logs but was never answered]
+```
+
+If a category has nothing to report, omit it.
+
+---
+
+## Step 4: Dedup check
+
+Compare every entry in "Insights worth keeping" against the existing `## Key Learnings & Patterns` section in `[agent_folder]/MEMORY.md`:
+
+| Case | Action |
+|------|--------|
+| Insight is identical or a subset of an existing entry | Drop — do not append |
+| Insight extends or refines an existing entry | Merge into the existing entry |
+| Insight is genuinely new | Keep for append |
+
+After dedup, if no new insights remain:
+> All insights are already captured in MEMORY.md — nothing new to add.
+
+Exit — do not write.
+
+---
+
+## Step 5: Update MEMORY.md
+
+Append each new post-dedup insight to the `## Key Learnings & Patterns` section of `[agent_folder]/MEMORY.md`:
+
+```
+- YYYY-MM-DD — [observation]
+```
+
+Also update the `updated:` field in the frontmatter to today's date.
+
+---
+
+## Step 6: Overflow check
+
+Count the total lines in `[agent_folder]/MEMORY.md`. If the count exceeds 180:
+
+> MEMORY.md is now N lines (recommended limit: 180). Consider running `/learn` to distill and condense older entries.
+
+Do not modify `[agent_folder]/memory/` or `[agent_folder]/context/` — these are managed by `/learn` only.
+
+---
+
+## Step 7: Confirm
+
+```
+Recap complete. Added N insights to MEMORY.md.
+```
+
+If overflow warning was triggered, append:
+```
+MEMORY.md is now N lines — consider /learn to trim.
+```
+
+If nothing was written (all deduped):
+```
+Recap complete. No new insights to add — MEMORY.md is already up to date.
+```

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Under the hood, OneBrain uses a **three-layer memory system**: your identity (al
 ---
 
 <details>
-<summary><strong>📋 All 20 Commands</strong></summary>
+<summary><strong>📋 All 21 Commands</strong></summary>
 <br>
 
 | Command | What it does |

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Under the hood, OneBrain uses a **three-layer memory system**: your identity (al
 | `/import [path]` | Import local files (PDF, Word, images, scripts) into vault notes |
 | `/reading-notes` | Turn a book or article into structured notes |
 | `/weekly` | Review the week, surface patterns, set intentions |
+| `/recap` | Cross-session synthesis — surface patterns across sessions and update long-term memory |
 | `/tasks` | Live task dashboard in Obsidian — creates/updates `TASKS.md` with always-current query sections |
 | `/moc` | Vault portal in Obsidian — creates/updates `MOC.md` with projects, areas, knowledge, tasks, and pinned links |
 | `/wrapup` | Wrap up session and save summary to session log |


### PR DESCRIPTION
## Summary

- Add `/recap` skill — reads session logs from the past 7 days, synthesizes patterns and insights across sessions, and updates `MEMORY.md` Key Learnings with new, deduplicated entries
- Update `INSTRUCTIONS.md`, `help/SKILL.md`, and `README.md` to include `/recap` in all command tables
- Bump plugin version to 1.5.7

## Design decisions

- **7-day window** — fixed look-back, no state required
- **Shows synthesis before writing** — user sees patterns before MEMORY.md is updated
- **Dedup against MEMORY.md only** — `context/` and `memory/` are `/learn` territory, never touched by `/recap`
- **Overflow warns, does not write** — if MEMORY.md > 180 lines, suggests `/learn` instead of auto-archiving

## Test Plan

- [ ] Run `/recap` in a vault with session logs — confirm synthesis is displayed before any write
- [ ] Confirm MEMORY.md Key Learnings updated with new entries only (no duplicates)
- [ ] Run `/recap` again immediately — confirm "No new insights to add" (dedup works)
- [ ] Run `/help` — confirm `/recap` appears after `/weekly`
- [ ] Confirm `context/` and `memory/` sub-folders were not modified