### PR TITLE
feat: add /daily skill — daily briefing and intention setter

### DIFF
--- a/.claude/plugins/onebrain/.claude-plugin/plugin.json
+++ b/.claude/plugins/onebrain/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "onebrain",
-  "version": "1.5.7",
+  "version": "1.6.0",
   "description": "OneBrain — Where human and AI thinking become one. A powerful thinking partner powered by AI synergy.",
   "author": {
     "name": "OneBrain Contributors"

--- a/.claude/plugins/onebrain/INSTRUCTIONS.md
+++ b/.claude/plugins/onebrain/INSTRUCTIONS.md
@@ -83,6 +83,7 @@ These workflows are documented in `.claude/plugins/onebrain/skills/`:
 | `/import` | `import/SKILL.md` | Import local files (PDF, docs, images, scripts) → vault notes |
 | `/reading-notes` | `reading-notes/SKILL.md` | Book/article → structured notes |
 | `/weekly` | `weekly/SKILL.md` | Weekly reflection |
+| `/daily` | `daily/SKILL.md` | Daily briefing + intention setter → saves daily note to inbox |
 | `/recap` | `recap/SKILL.md` | Cross-session synthesis → update MEMORY.md Key Learnings |
 | `/tasks` | `tasks/SKILL.md` | Create or update live task dashboard (TASKS.md) and open in Obsidian |
 | `/moc` | `moc/SKILL.md` | Create or update vault portal (MOC.md) and open in Obsidian |

--- a/.claude/plugins/onebrain/skills/daily/SKILL.md
+++ b/.claude/plugins/onebrain/skills/daily/SKILL.md
@@ -84,7 +84,7 @@ Overwrite the `## Today's Focus` section only — preserve everything else. Do N
 ```markdown
 ---
 tags: [daily]
-date: YYYY-MM-DD
+created: YYYY-MM-DD
 ---
 
 # Daily — DD Mon YYYY

--- a/.claude/plugins/onebrain/skills/daily/SKILL.md
+++ b/.claude/plugins/onebrain/skills/daily/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: daily
+description: Two-phase daily briefing and intention-setting — surfaces tasks and session context, then saves today's focus as a daily note
+---
+
+# /daily — Daily Briefing & Intention
+
+Surfaces what needs attention today, then saves your stated focus as a daily note in the inbox.
+
+---
+
+## Before You Begin
+
+Read `vault.yml` and extract:
+- `folders.logs` as `[logs_folder]` (default: `07-logs`)
+- `folders.inbox` as `[inbox_folder]` (default: `00-inbox`)
+- `folders.projects` as `[projects_folder]` (default: `01-projects`)
+
+Determine today's date (`YYYY-MM-DD`) and current local time in Asia/Bangkok:
+- **Morning mode**: before 10:00
+- **Normal mode**: 10:00 and later
+
+---
+
+## Phase 1: Briefing
+
+### Previous Session Recap (Morning Mode Only)
+
+Glob `[logs_folder]/**/*.md`. Find the most recent session log whose `date` frontmatter is before today (not today). On Mondays this will typically be Friday's log. If no prior session exists, skip this section silently.
+
+Read that day's session log(s). Extract main topics and any unchecked action items.
+
+### Briefing Content
+
+Pull from two sources:
+
+**Source 1 — Tasks due today or overdue:**
+Grep `[projects_folder]/**/*.md` and `[inbox_folder]/*.md` for task lines matching `- [ ] .*📅 \d{4}-\d{2}-\d{2}`. Filter to dates ≤ today. Group: overdue first, then due today. Include the source note name.
+
+**Source 2 — Open action items from last session:**
+If morning mode: already loaded from recap step above — extract unchecked `- [ ]` items from the `## Action Items` section.
+If normal mode: load the most recent prior session logs now and extract unchecked `- [ ]` items from `## Action Items`.
+
+### Display the Briefing
+
+```
+## Daily Briefing — DD Mon YYYY [morning / afternoon / evening]
+
+**Last session (DD Mon):** [1–2 sentence recap of topics + open items]
+(morning mode only — skip if no prior session found)
+
+**Tasks due today:**
+- [ ] Task description 📅 YYYY-MM-DD (from [[Note Name]])
+- [ ] Overdue task 📅 YYYY-MM-DD (overdue — from [[Note Name]])
+
+**Open from last session:**
+- [ ] Action item text
+```
+
+If both sources are empty:
+> No tasks or open items for today.
+
+Then ask:
+> **วันนี้จะ focus อะไรครับ?**
+
+Wait for the user's response before proceeding to Phase 2.
+
+---
+
+## Phase 2: Intention → Daily Note
+
+### Check if today's daily note exists
+
+Check whether `[inbox_folder]/YYYY-MM-DD-daily.md` already exists.
+
+**If it does NOT exist (first run today):**
+Create the file with the full template below, then open in Obsidian.
+
+**If it already exists (run more than once today):**
+Overwrite the `## Today's Focus` section only — preserve everything else. Do NOT open in Obsidian again.
+
+### Daily Note Template (new file only)
+
+```markdown
+---
+tags: [daily]
+date: YYYY-MM-DD
+---
+
+# Daily — DD Mon YYYY
+
+## Briefing
+
+### Tasks due today
+- [ ] Task A 📅 YYYY-MM-DD
+- [ ] Task B 📅 YYYY-MM-DD (overdue)
+
+### Open from last session
+- [ ] Action item text
+
+## Today's Focus
+
+[User's stated intention]
+```
+
+If a section has no content (e.g. no tasks, no open items), write the heading with a single line: `(none)`
+
+### Open in Obsidian (new file only)
+
+Build the `obsidian://` URI:
+1. Take the absolute path of the daily note file
+2. URL-encode it — keep `/`, `:`, `@` as literal characters:
+   - Python3 (preferred): `python3 -c "import urllib.parse, sys; print(urllib.parse.quote(sys.argv[1], safe='/:@'))" "/absolute/path/to/file.md"`
+   - Node.js fallback: `node -e "const p=process.argv[1]; console.log(encodeURIComponent(p).replace(/%2F/gi,'/').replace(/%3A/gi,':').replace(/%40/gi,'@'))" "/absolute/path/to/file.md"`
+3. Run: `open "obsidian://open?path=[encoded_path]"`
+4. If the open command returns non-zero, show the URI for manual use:
+   > Could not open Obsidian automatically. Open manually: `obsidian://open?path=[encoded_path]`
+
+### Confirm
+
+- New file created: `Daily note saved and opened → [inbox_folder]/YYYY-MM-DD-daily.md`
+- Existing file updated: `Daily note updated → [inbox_folder]/YYYY-MM-DD-daily.md`

--- a/.claude/plugins/onebrain/skills/daily/SKILL.md
+++ b/.claude/plugins/onebrain/skills/daily/SKILL.md
@@ -39,7 +39,7 @@ Grep `[projects_folder]/**/*.md` and `[inbox_folder]/*.md` for task lines matchi
 
 **Source 2 — Open action items from last session:**
 If morning mode: already loaded from recap step above — extract unchecked `- [ ]` items from the `## Action Items` section.
-If normal mode: load the most recent prior session logs now and extract unchecked `- [ ]` items from `## Action Items`.
+If normal mode: Glob `[logs_folder]/**/*.md`. Find the most recent session log whose `date` frontmatter is before today. Read that log and extract unchecked `- [ ]` items from the `## Action Items` section.
 
 ### Display the Briefing
 
@@ -103,9 +103,11 @@ date: YYYY-MM-DD
 [User's stated intention]
 ```
 
-If a section has no content (e.g. no tasks, no open items), write the heading with a single line: `(none)`
+If a section has no content — including when `## Action Items` is absent from the session log or all its items are already checked — write the heading with a single line: `(none)`
 
 ### Open in Obsidian (new file only)
+
+**Only run this section if the daily note was newly created above. If you updated an existing file, skip to Confirm.**
 
 Build the `obsidian://` URI:
 1. Take the absolute path of the daily note file

--- a/.claude/plugins/onebrain/skills/help/SKILL.md
+++ b/.claude/plugins/onebrain/skills/help/SKILL.md
@@ -39,6 +39,7 @@ Display a formatted table with all available commands:
 | `/tasks` | Open live task dashboard in Obsidian — creates/updates `TASKS.md` with live query sections | When you want an overview of what needs doing |
 | `/moc` | Create or refresh vault portal (MOC.md) — a Map of Content with live queries, AI summary, and your pinned links | When you want a bird's-eye view of your entire vault |
 | `/weekly` | Weekly reflection — review sessions, patterns, intentions | At the end of each week for review and planning |
+| `/daily` | Two-phase daily briefing — surfaces tasks and last session context, then saves your stated focus as a daily note | Every morning (or any time you want to reset your focus for the day) |
 | `/recap` | Cross-session synthesis — reads 7 days of logs, surfaces patterns, updates MEMORY.md Key Learnings | Periodically, when you want to distill recent sessions into long-term memory |
 | `/wrapup` | Save a session summary to your session log | At the end of a work session to capture what you did |
 | `/learn` | Teach the agent something — facts about your world or behavioral preferences | When you want the agent to remember something across all future sessions |

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 **🧠 Memory across sessions** — Your AI remembers your name, goals, preferences, and past conversations. Every session picks up where the last one left off.
 
-**⚡ 20 slash commands and counting** — Braindump, capture, research, consolidate, connect, bookmark, import files, and more. More skills coming soon — capture an idea or deep-research a topic in seconds.
+**⚡ 22 slash commands and counting** — Braindump, capture, research, consolidate, connect, bookmark, import files, and more. More skills coming soon — capture an idea or deep-research a topic in seconds.
 
 **📂 Vault-native Markdown** — Every note is plain Markdown. No lock-in, no proprietary format. Your data stays in your vault, forever.
 
@@ -111,7 +111,7 @@ Under the hood, OneBrain uses a **three-layer memory system**: your identity (al
 ---
 
 <details>
-<summary><strong>📋 All 21 Commands</strong></summary>
+<summary><strong>📋 All 22 Commands</strong></summary>
 <br>
 
 | Command | What it does |
@@ -127,6 +127,7 @@ Under the hood, OneBrain uses a **three-layer memory system**: your identity (al
 | `/import [path]` | Import local files (PDF, Word, images, scripts) into vault notes |
 | `/reading-notes` | Turn a book or article into structured notes |
 | `/weekly` | Review the week, surface patterns, set intentions |
+| `/daily` | Daily briefing — surfaces tasks and last session context, then saves your focus as a daily note |
 | `/recap` | Cross-session synthesis — surface patterns across sessions and update long-term memory |
 | `/tasks` | Live task dashboard in Obsidian — creates/updates `TASKS.md` with always-current query sections |
 | `/moc` | Vault portal in Obsidian — creates/updates `MOC.md` with projects, areas, knowledge, tasks, and pinned links |


### PR DESCRIPTION
## Summary
- Add `/daily` skill: two-phase daily briefing + intention setter that saves a daily note to the inbox
- Register `/daily` in `INSTRUCTIONS.md` Available Workflows table
- Register `/daily` in `help/SKILL.md` command table

## What it does
Phase 1: surfaces overdue/due-today tasks + open action items from the last session log (with a previous-session recap in morning mode <10:00). Asks "วันนี้จะ focus อะไรครับ?" and waits for user input.

Phase 2: saves the stated intention to `00-inbox/YYYY-MM-DD-daily.md`. Opens in Obsidian on first run; updates focus section only on subsequent runs (no duplicate tabs).

## Test Plan
- [ ] Run `/daily` before 10:00 — verify morning mode shows last session recap
- [ ] Run `/daily` after 10:00 — verify no recap, briefing only
- [ ] Respond with a focus intention — verify daily note created and opened in Obsidian
- [ ] Run `/daily` again same day — verify only Today's Focus updated, Obsidian not reopened
- [ ] Run `/help` — verify `/daily` appears in the command table