### PR TITLE
fix: enforce TLS 1.2 and use Invoke-WebRequest for GitHub download

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -1,6 +1,9 @@
 #Requires -Version 5.0
 $ErrorActionPreference = 'Stop'
 
+# Ensure TLS 1.2 is enabled — required by GitHub (PS 5 defaults to TLS 1.0 which GitHub dropped)
+[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+
 # ─── Colors ───────────────────────────────────────────────────────────────────
 if ($Host.UI.SupportsVirtualTerminal) {
   $script:Bold      = [char]0x1b + "[1m"
@@ -307,7 +310,7 @@ function Main {
     $zipPath = Join-Path $tmpDir "onebrain.zip"
 
     try {
-      Invoke-RestMethod -Uri $repoUrl -OutFile $zipPath
+      Invoke-WebRequest -Uri $repoUrl -OutFile $zipPath -UseBasicParsing
     } catch {
       Print-Error "Download failed. Check your internet connection and try again."
       Print-Error $_.Exception.Message


### PR DESCRIPTION
## Summary

- Adds TLS 1.2 enforcement at script startup — PowerShell 5 on Windows defaults to TLS 1.0 which GitHub dropped, causing silent download failures
- Switches zip download from `Invoke-RestMethod` to `Invoke-WebRequest -UseBasicParsing` — more appropriate for binary file downloads and avoids IE rendering engine dependency (required on Server Core / CI / unattended installs)

## Test Plan

- [ ] Run `install.ps1` on Windows with PowerShell 5 — verify vault downloads and extracts successfully
- [ ] Confirm no regression on PowerShell 7 (`-UseBasicParsing` is silently ignored on PS 6+)