### PR TITLE
feat: run qmd update after any vault file change

### DIFF
--- a/.claude/plugins/onebrain/.claude-plugin/plugin.json
+++ b/.claude/plugins/onebrain/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "onebrain",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "OneBrain — Where human and AI thinking become one. A powerful thinking partner powered by AI synergy.",
   "author": {
     "name": "OneBrain Contributors"

--- a/.claude/plugins/onebrain/INSTRUCTIONS.md
+++ b/.claude/plugins/onebrain/INSTRUCTIONS.md
@@ -111,7 +111,7 @@ Without embeddings, `mcp__plugin_onebrain_qmd__query` uses BM25 keyword search o
 
 ## qmd Index Maintenance
 
-Whenever you add, edit, or delete any file in the vault, check first whether qmd is available by looking for `mcp__plugin_onebrain_qmd__status` in your tool list. If it is available, immediately run:
+Whenever you add, edit, or delete any file in the vault, check first whether qmd is available by looking for `mcp__plugin_onebrain_qmd__query` in your tool list. If it is available, immediately run:
 
 ```bash
 qmd update -c <collection>
@@ -119,7 +119,7 @@ qmd update -c <collection>
 
 where `<collection>` is the collection name from `vault.yml` (`qmd_collection` field, e.g. `ob-1-441565`). This keeps the search index in sync and prevents stale entries from appearing in results.
 
-If qmd tools are not available, skip this step entirely.
+If qmd tools are not available, or if `qmd_collection` is not present in `vault.yml`, skip this step entirely.
 
 ## Session Behavior
 

--- a/.claude/plugins/onebrain/INSTRUCTIONS.md
+++ b/.claude/plugins/onebrain/INSTRUCTIONS.md
@@ -109,6 +109,18 @@ When qmd tools are NOT available (not installed or not set up), use Glob/Grep/Re
 
 Without embeddings, `mcp__plugin_onebrain_qmd__query` uses BM25 keyword search only. To enable semantic/similarity search (finding conceptually related notes, not just keyword matches), the user must run `/qmd embed` at least once. Suggest this if the user asks for similarity-based or "related notes" queries and qmd is available but embeddings haven't been run.
 
+## qmd Index Maintenance
+
+Whenever you add, edit, or delete any file in the vault, check first whether qmd is available by looking for `mcp__plugin_onebrain_qmd__status` in your tool list. If it is available, immediately run:
+
+```bash
+qmd update -c <collection>
+```
+
+where `<collection>` is the collection name from `vault.yml` (`qmd_collection` field, e.g. `ob-1-441565`). This keeps the search index in sync and prevents stale entries from appearing in results.
+
+If qmd tools are not available, skip this step entirely.
+
 ## Session Behavior
 
 At the start of every session, perform these steps:


### PR DESCRIPTION
## Summary

- Adds `## qmd Index Maintenance` section to `INSTRUCTIONS.md`
- After any add/edit/delete in the vault, checks for `mcp__plugin_onebrain_qmd__status` in tool list before running `qmd update`
- Skips entirely if qmd is not set up — no false errors for users who don't use qmd

## Test Plan

- [ ] Make a file change in vault — verify `qmd update -c <collection>` runs automatically
- [ ] Confirm no `qmd update` call when qmd MCP tools are not in session tool list