### PR TITLE
feat: add What Worked/Didn't Work section to /wrapup (v1.6.2)

### DIFF
--- a/.claude/plugins/onebrain/.claude-plugin/plugin.json
+++ b/.claude/plugins/onebrain/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "onebrain",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "OneBrain — Where human and AI thinking become one. A powerful thinking partner powered by AI synergy.",
   "author": {
     "name": "OneBrain Contributors"

--- a/.claude/plugins/onebrain/skills/wrapup/SKILL.md
+++ b/.claude/plugins/onebrain/skills/wrapup/SKILL.md
@@ -35,6 +35,7 @@ Reflect on the conversation that just occurred. Identify:
 - **Main topic(s)** — What did we work on?
 - **Key decisions made** — Any choices, directions, or conclusions reached
 - **Insights or learnings** — New understanding, patterns noticed, things discovered
+- **What worked / didn't work** — Approaches or tools that helped, and anything that slowed us down or failed (omit if nothing notable)
 - **Action items** — Tasks to do, things to follow up on
 - **Open questions** — Unresolved questions or things to investigate
 
@@ -66,6 +67,13 @@ session: NN
 
 - [Insight 1]
 - [Insight 2]
+
+## What Worked / Didn't Work
+
+- ✅ [Something that worked well]
+- ❌ [Something that didn't work or slowed things down]
+
+_Omit this section if the session had no notable friction or technique worth logging._
 
 ## Action Items
 


### PR DESCRIPTION
## Summary

- Adds `## What Worked / Didn't Work` section to session log template
- Section is skippable (`omit if nothing notable`) to prevent AI filler on purely knowledge-capture sessions
- Closes the feedback loop on process and tooling across sessions

## Test Plan

- [ ] Run `/wrapup` after a session with notable friction — verify section is populated
- [ ] Run `/wrapup` after a routine session — verify section is omitted or marked (none)