### PR TITLE
fix(checkpoint-hook): JSON injection + CLAUDE_PLUGIN_ROOT fallback (v1.8.1)

### DIFF
--- a/.claude/plugins/onebrain/.claude-plugin/plugin.json
+++ b/.claude/plugins/onebrain/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "onebrain",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "OneBrain — Where human and AI thinking become one. A powerful thinking partner powered by AI synergy.",
   "author": {
     "name": "OneBrain Contributors"

--- a/.claude/plugins/onebrain/hooks/checkpoint-hook.ps1
+++ b/.claude/plugins/onebrain/hooks/checkpoint-hook.ps1
@@ -2,7 +2,9 @@
 # Usage: checkpoint-hook.ps1 [-Mode stop|precompact]
 #
 # stop       — fires after every response; checkpoints on message/time threshold
+#              Uses JSON {"decision":"block","reason":"..."} to inject prompt back to Claude.
 # precompact — fires before context compression; checkpoints unless skip window or no activity
+#              Uses JSON {"systemMessage":"..."} — PreCompact does not support decision:block.
 #
 # Both modes share %TEMP%\onebrain-{ParentPid}.state (COUNT:LAST_TS).
 # 60s skip window prevents double-checkpoints when both fire close together.
@@ -40,22 +42,29 @@ if (Test-Path $StateFile) {
 }
 
 # --- PreCompact mode: checkpoint unless no activity since last one ---
+# PreCompact does not support decision:block — uses systemMessage instead.
 if ($Mode -eq "precompact") {
     if ($Count -lt $MinActivity) {
         # Not enough activity since last checkpoint — reset counter, skip creating file
         Set-Content -Path $StateFile -Value "0:$Now" -ErrorAction SilentlyContinue
         exit 0
     }
+    $Prompt = "Context compression is imminent. Before compacting, silently save a checkpoint to the vault logs. Steps: (1) Get today's date YYYY-MM-DD, extract YYYY and MM. (2) Count existing checkpoint-*.md files in [logs folder]/YYYY/MM/ to find the next checkpoint number NN (zero-padded, starts at 01). (3) Write [logs folder]/YYYY/MM/YYYY-MM-DD-checkpoint-NN.md with this exact frontmatter: tags: [checkpoint, session-log], date: YYYY-MM-DD, checkpoint: NN, trigger: precompact, merged: false. (4) Content sections: ## What We Worked On (2-3 sentences), ## Key Decisions (bullet list), ## Action Items (tasks with date YYYY-MM-DD), ## Open Questions (bullet list). Keep under 250 words total. No output to user."
+    # Build JSON before writing state — leave state unchanged on failure
+    $Json = try { ConvertTo-Json @{systemMessage = $Prompt} -Compress } catch { $null }
+    if (-not $Json) { exit 1 }
     try {
         Set-Content -Path $StateFile -Value "0:$Now" -ErrorAction Stop
     } catch {
-        exit 1
+        exit 2
     }
-    Write-Output "Context compression is imminent. Before compacting, silently save a checkpoint to the vault logs. Steps: (1) Get today's date YYYY-MM-DD, extract YYYY and MM. (2) Count existing checkpoint-*.md files in [logs folder]/YYYY/MM/ to find the next checkpoint number NN (zero-padded, starts at 01). (3) Write [logs folder]/YYYY/MM/YYYY-MM-DD-checkpoint-NN.md with this exact frontmatter: tags: [checkpoint, session-log], date: YYYY-MM-DD, checkpoint: NN, trigger: precompact, merged: false. (4) Content sections: '## What We Worked On' (2-3 sentences), '## Key Decisions' (bullet list), '## Action Items' (tasks with 📅 YYYY-MM-DD dates), '## Open Questions' (bullet list). Keep under 250 words total. No output to user."
+    Write-Output $Json
     exit 0
 }
 
 # --- Stop mode: check thresholds against vault.yml config ---
+# CLAUDE_PLUGIN_ROOT is set when called from plugin hooks.json; absent from settings.json.
+# hooks/ is one level deeper than plugin root, so fallback goes up 4 levels from script path.
 if ($env:CLAUDE_PLUGIN_ROOT) {
     try {
         $VaultRoot = (Resolve-Path (Join-Path $env:CLAUDE_PLUGIN_ROOT "../../..") -ErrorAction Stop).Path
@@ -65,8 +74,15 @@ if ($env:CLAUDE_PLUGIN_ROOT) {
         $VaultYml = $null
     }
 } else {
-    $VaultRoot = $null
-    $VaultYml = $null
+    # Fallback: derive from script path (used when called from settings.json)
+    try {
+        $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+        $VaultRoot = (Resolve-Path (Join-Path $ScriptDir "../../../..") -ErrorAction Stop).Path
+        $VaultYml = Join-Path $VaultRoot "vault.yml"
+    } catch {
+        $VaultRoot = $null
+        $VaultYml = $null
+    }
 }
 
 function Get-CheckpointValue($Key, $Default) {
@@ -93,12 +109,16 @@ if ($Count -ge $MsgThreshold -or $Elapsed -ge $TimeThreshold) {
         exit 0
     }
     $TriggerLabel = if ($Count -ge $MsgThreshold) { "auto ($Count messages)" } else { "auto ($([math]::Floor($Elapsed / 60))m elapsed)" }
+    $Prompt = "Auto-checkpoint triggered by $TriggerLabel. Silently save a checkpoint to the vault logs. Steps: (1) Get today's date YYYY-MM-DD, extract YYYY and MM. (2) Count existing checkpoint-*.md files in [logs folder]/YYYY/MM/ to find the next checkpoint number NN (zero-padded, starts at 01). (3) Write [logs folder]/YYYY/MM/YYYY-MM-DD-checkpoint-NN.md with this exact frontmatter: tags: [checkpoint, session-log], date: YYYY-MM-DD, checkpoint: NN, trigger: auto, merged: false. (4) Content sections: ## What We Worked On (2-3 sentences), ## Key Decisions (bullet list), ## Action Items (tasks with date YYYY-MM-DD), ## Open Questions (bullet list). Keep under 250 words total. No output to user."
+    # Build JSON before writing state — leave state unchanged on failure
+    $Json = try { ConvertTo-Json @{decision = 'block'; reason = $Prompt} -Compress } catch { $null }
+    if (-not $Json) { exit 1 }
     try {
         Set-Content -Path $StateFile -Value "0:$Now" -ErrorAction Stop
     } catch {
-        exit 1
+        exit 2
     }
-    Write-Output "Auto-checkpoint triggered by $TriggerLabel. Silently save a checkpoint to the vault logs. Steps: (1) Get today's date YYYY-MM-DD, extract YYYY and MM. (2) Count existing checkpoint-*.md files in [logs folder]/YYYY/MM/ to find the next checkpoint number NN (zero-padded, starts at 01). (3) Write [logs folder]/YYYY/MM/YYYY-MM-DD-checkpoint-NN.md with this exact frontmatter: tags: [checkpoint, session-log], date: YYYY-MM-DD, checkpoint: NN, trigger: auto, merged: false. (4) Content sections: '## What We Worked On' (2-3 sentences), '## Key Decisions' (bullet list), '## Action Items' (tasks with 📅 YYYY-MM-DD dates), '## Open Questions' (bullet list). Keep under 250 words total. No output to user."
+    Write-Output $Json
 } else {
     Set-Content -Path $StateFile -Value "${Count}:${LastTs}"
 }

--- a/.claude/plugins/onebrain/hooks/checkpoint-hook.ps1
+++ b/.claude/plugins/onebrain/hooks/checkpoint-hook.ps1
@@ -75,9 +75,9 @@ if ($env:CLAUDE_PLUGIN_ROOT) {
     }
 } else {
     # Fallback: derive from script path (used when called from settings.json)
+    # $PSScriptRoot is the reliable automatic variable for this — always set when running a .ps1 file
     try {
-        $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
-        $VaultRoot = (Resolve-Path (Join-Path $ScriptDir "../../../..") -ErrorAction Stop).Path
+        $VaultRoot = (Resolve-Path (Join-Path $PSScriptRoot "../../../..") -ErrorAction Stop).Path
         $VaultYml = Join-Path $VaultRoot "vault.yml"
     } catch {
         $VaultRoot = $null
@@ -122,3 +122,4 @@ if ($Count -ge $MsgThreshold -or $Elapsed -ge $TimeThreshold) {
 } else {
     Set-Content -Path $StateFile -Value "${Count}:${LastTs}"
 }
+exit 0

--- a/.claude/plugins/onebrain/hooks/checkpoint-hook.sh
+++ b/.claude/plugins/onebrain/hooks/checkpoint-hook.sh
@@ -42,7 +42,8 @@ if [ "$MODE" = "precompact" ]; then
   if ! echo "0:${NOW}" > "$STATE_FILE" 2>/dev/null; then
     exit 1
   fi
-  echo "Context compression is imminent. Before compacting, silently save a checkpoint to the vault logs. Steps: (1) Get today's date YYYY-MM-DD, extract YYYY and MM. (2) Count existing checkpoint-*.md files in [logs folder]/YYYY/MM/ to find the next checkpoint number NN (zero-padded, starts at 01). (3) Write [logs folder]/YYYY/MM/YYYY-MM-DD-checkpoint-NN.md with this exact frontmatter: tags: [checkpoint, session-log], date: YYYY-MM-DD, checkpoint: NN, trigger: precompact, merged: false. (4) Content sections: '## What We Worked On' (2-3 sentences), '## Key Decisions' (bullet list), '## Action Items' (tasks with 📅 YYYY-MM-DD dates), '## Open Questions' (bullet list). Keep under 250 words total. No output to user."
+  python3 -c "import json,sys; print(json.dumps({'decision':'block','reason':sys.argv[1]}))" \
+    "Context compression is imminent. Before compacting, silently save a checkpoint to the vault logs. Steps: (1) Get today's date YYYY-MM-DD, extract YYYY and MM. (2) Count existing checkpoint-*.md files in [logs folder]/YYYY/MM/ to find the next checkpoint number NN (zero-padded, starts at 01). (3) Write [logs folder]/YYYY/MM/YYYY-MM-DD-checkpoint-NN.md with this exact frontmatter: tags: [checkpoint, session-log], date: YYYY-MM-DD, checkpoint: NN, trigger: precompact, merged: false. (4) Content sections: ## What We Worked On (2-3 sentences), ## Key Decisions (bullet list), ## Action Items (tasks with date YYYY-MM-DD), ## Open Questions (bullet list). Keep under 250 words total. No output to user."
   exit 0
 fi
 
@@ -50,7 +51,9 @@ fi
 if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ]; then
   VAULT_ROOT="$(cd "${CLAUDE_PLUGIN_ROOT}/../../.." 2>/dev/null && pwd)" || VAULT_ROOT=""
 else
-  VAULT_ROOT=""
+  # Fallback: derive from script path (used when called from settings.json)
+  SCRIPT_DIR="$(cd "$(dirname "$0")" 2>/dev/null && pwd)"
+  VAULT_ROOT="$(cd "${SCRIPT_DIR}/../../../.." 2>/dev/null && pwd)" || VAULT_ROOT=""
 fi
 VAULT_YML="${VAULT_ROOT:+${VAULT_ROOT}/vault.yml}"
 
@@ -91,7 +94,8 @@ if [ "$COUNT" -ge "$MSG_THRESHOLD" ] || [ "$ELAPSED" -ge "$TIME_THRESHOLD" ]; th
   if ! echo "0:${NOW}" > "$STATE_FILE" 2>/dev/null; then
     exit 1
   fi
-  echo "Auto-checkpoint triggered by ${TRIGGER_LABEL}. Silently save a checkpoint to the vault logs. Steps: (1) Get today's date YYYY-MM-DD, extract YYYY and MM. (2) Count existing checkpoint-*.md files in [logs folder]/YYYY/MM/ to find the next checkpoint number NN (zero-padded, starts at 01). (3) Write [logs folder]/YYYY/MM/YYYY-MM-DD-checkpoint-NN.md with this exact frontmatter: tags: [checkpoint, session-log], date: YYYY-MM-DD, checkpoint: NN, trigger: auto, merged: false. (4) Content sections: '## What We Worked On' (2-3 sentences), '## Key Decisions' (bullet list), '## Action Items' (tasks with 📅 YYYY-MM-DD dates), '## Open Questions' (bullet list). Keep under 250 words total. No output to user."
+  python3 -c "import json,sys; print(json.dumps({'decision':'block','reason':sys.argv[1]}))" \
+    "Auto-checkpoint triggered by ${TRIGGER_LABEL}. Silently save a checkpoint to the vault logs. Steps: (1) Get today's date YYYY-MM-DD, extract YYYY and MM. (2) Count existing checkpoint-*.md files in [logs folder]/YYYY/MM/ to find the next checkpoint number NN (zero-padded, starts at 01). (3) Write [logs folder]/YYYY/MM/YYYY-MM-DD-checkpoint-NN.md with this exact frontmatter: tags: [checkpoint, session-log], date: YYYY-MM-DD, checkpoint: NN, trigger: auto, merged: false. (4) Content sections: ## What We Worked On (2-3 sentences), ## Key Decisions (bullet list), ## Action Items (tasks with date YYYY-MM-DD), ## Open Questions (bullet list). Keep under 250 words total. No output to user."
 else
   echo "${COUNT}:${LAST_TS}" > "$STATE_FILE"
 fi

--- a/.claude/plugins/onebrain/hooks/checkpoint-hook.sh
+++ b/.claude/plugins/onebrain/hooks/checkpoint-hook.sh
@@ -3,7 +3,9 @@
 # Usage: checkpoint-hook.sh stop|precompact
 #
 # stop       — fires after every response; checkpoints on message/time threshold
+#              Uses JSON {"decision":"block","reason":"..."} to inject prompt back to Claude.
 # precompact — fires before context compression; checkpoints unless skip window or no activity
+#              Uses JSON {"systemMessage":"..."} — PreCompact does not support decision:block.
 #
 # Both modes share /tmp/onebrain-{PPID}.state (COUNT:LAST_TS).
 # 60s skip window prevents double-checkpoints when both fire close together.
@@ -33,27 +35,36 @@ else
 fi
 
 # --- PreCompact mode: checkpoint unless no activity since last one ---
+# PreCompact does not support decision:block — uses systemMessage instead.
 if [ "$MODE" = "precompact" ]; then
   if [ "$COUNT" -lt $MIN_ACTIVITY ]; then
     # Not enough activity since last checkpoint — reset counter, skip creating file
     echo "0:${NOW}" > "$STATE_FILE" 2>/dev/null
     exit 0
   fi
-  if ! echo "0:${NOW}" > "$STATE_FILE" 2>/dev/null; then
+  # Build JSON first — restore state on python3 failure so future triggers still work
+  PROMPT="Context compression is imminent. Before compacting, silently save a checkpoint to the vault logs. Steps: (1) Get today's date YYYY-MM-DD, extract YYYY and MM. (2) Count existing checkpoint-*.md files in [logs folder]/YYYY/MM/ to find the next checkpoint number NN (zero-padded, starts at 01). (3) Write [logs folder]/YYYY/MM/YYYY-MM-DD-checkpoint-NN.md with this exact frontmatter: tags: [checkpoint, session-log], date: YYYY-MM-DD, checkpoint: NN, trigger: precompact, merged: false. (4) Content sections: ## What We Worked On (2-3 sentences), ## Key Decisions (bullet list), ## Action Items (tasks with date YYYY-MM-DD), ## Open Questions (bullet list). Keep under 250 words total. No output to user."
+  JSON=$(python3 -c "import json,sys; print(json.dumps({'systemMessage':sys.argv[1]}))" "$PROMPT" 2>/dev/null)
+  if [ -z "$JSON" ]; then
+    # python3 unavailable or failed — leave state unchanged so future triggers still work
     exit 1
   fi
-  python3 -c "import json,sys; print(json.dumps({'decision':'block','reason':sys.argv[1]}))" \
-    "Context compression is imminent. Before compacting, silently save a checkpoint to the vault logs. Steps: (1) Get today's date YYYY-MM-DD, extract YYYY and MM. (2) Count existing checkpoint-*.md files in [logs folder]/YYYY/MM/ to find the next checkpoint number NN (zero-padded, starts at 01). (3) Write [logs folder]/YYYY/MM/YYYY-MM-DD-checkpoint-NN.md with this exact frontmatter: tags: [checkpoint, session-log], date: YYYY-MM-DD, checkpoint: NN, trigger: precompact, merged: false. (4) Content sections: ## What We Worked On (2-3 sentences), ## Key Decisions (bullet list), ## Action Items (tasks with date YYYY-MM-DD), ## Open Questions (bullet list). Keep under 250 words total. No output to user."
+  if ! echo "0:${NOW}" > "$STATE_FILE" 2>/dev/null; then
+    exit 2
+  fi
+  printf '%s\n' "$JSON"
   exit 0
 fi
 
 # --- Stop mode: check thresholds against vault.yml config ---
+# CLAUDE_PLUGIN_ROOT is set when called from plugin hooks.json; absent from settings.json.
+# hooks/ is one level deeper than plugin root, so fallback goes up 4 levels from script dir.
 if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ]; then
-  VAULT_ROOT="$(cd "${CLAUDE_PLUGIN_ROOT}/../../.." 2>/dev/null && pwd)" || VAULT_ROOT=""
+  VAULT_ROOT=$(cd "${CLAUDE_PLUGIN_ROOT}/../../.." 2>/dev/null && pwd)
 else
   # Fallback: derive from script path (used when called from settings.json)
-  SCRIPT_DIR="$(cd "$(dirname "$0")" 2>/dev/null && pwd)"
-  VAULT_ROOT="$(cd "${SCRIPT_DIR}/../../../.." 2>/dev/null && pwd)" || VAULT_ROOT=""
+  SCRIPT_DIR=$(cd "$(dirname "$0")" 2>/dev/null && pwd)
+  VAULT_ROOT=$(cd "${SCRIPT_DIR}/../../../.." 2>/dev/null && pwd)
 fi
 VAULT_YML="${VAULT_ROOT:+${VAULT_ROOT}/vault.yml}"
 
@@ -91,11 +102,17 @@ if [ "$COUNT" -ge "$MSG_THRESHOLD" ] || [ "$ELAPSED" -ge "$TIME_THRESHOLD" ]; th
   else
     TRIGGER_LABEL="auto ($(( ELAPSED / 60 ))m elapsed)"
   fi
-  if ! echo "0:${NOW}" > "$STATE_FILE" 2>/dev/null; then
+  # Build JSON first — restore state on python3 failure so future triggers still work
+  PROMPT="Auto-checkpoint triggered by ${TRIGGER_LABEL}. Silently save a checkpoint to the vault logs. Steps: (1) Get today's date YYYY-MM-DD, extract YYYY and MM. (2) Count existing checkpoint-*.md files in [logs folder]/YYYY/MM/ to find the next checkpoint number NN (zero-padded, starts at 01). (3) Write [logs folder]/YYYY/MM/YYYY-MM-DD-checkpoint-NN.md with this exact frontmatter: tags: [checkpoint, session-log], date: YYYY-MM-DD, checkpoint: NN, trigger: auto, merged: false. (4) Content sections: ## What We Worked On (2-3 sentences), ## Key Decisions (bullet list), ## Action Items (tasks with date YYYY-MM-DD), ## Open Questions (bullet list). Keep under 250 words total. No output to user."
+  JSON=$(python3 -c "import json,sys; print(json.dumps({'decision':'block','reason':sys.argv[1]}))" "$PROMPT" 2>/dev/null)
+  if [ -z "$JSON" ]; then
+    # python3 unavailable or failed — leave state unchanged so future triggers still work
     exit 1
   fi
-  python3 -c "import json,sys; print(json.dumps({'decision':'block','reason':sys.argv[1]}))" \
-    "Auto-checkpoint triggered by ${TRIGGER_LABEL}. Silently save a checkpoint to the vault logs. Steps: (1) Get today's date YYYY-MM-DD, extract YYYY and MM. (2) Count existing checkpoint-*.md files in [logs folder]/YYYY/MM/ to find the next checkpoint number NN (zero-padded, starts at 01). (3) Write [logs folder]/YYYY/MM/YYYY-MM-DD-checkpoint-NN.md with this exact frontmatter: tags: [checkpoint, session-log], date: YYYY-MM-DD, checkpoint: NN, trigger: auto, merged: false. (4) Content sections: ## What We Worked On (2-3 sentences), ## Key Decisions (bullet list), ## Action Items (tasks with date YYYY-MM-DD), ## Open Questions (bullet list). Keep under 250 words total. No output to user."
+  if ! echo "0:${NOW}" > "$STATE_FILE" 2>/dev/null; then
+    exit 2
+  fi
+  printf '%s\n' "$JSON"
 else
   echo "${COUNT}:${LAST_TS}" > "$STATE_FILE"
 fi

--- a/.claude/plugins/onebrain/hooks/hooks.json
+++ b/.claude/plugins/onebrain/hooks/hooks.json
@@ -11,28 +11,6 @@
           }
         ]
       }
-    ],
-    "Stop": [
-      {
-        "matcher": "",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/checkpoint-hook.sh\" stop || powershell.exe -ExecutionPolicy Bypass -File \"${CLAUDE_PLUGIN_ROOT}/hooks/checkpoint-hook.ps1\" -Mode stop"
-          }
-        ]
-      }
-    ],
-    "PreCompact": [
-      {
-        "matcher": "",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/checkpoint-hook.sh\" precompact || powershell.exe -ExecutionPolicy Bypass -File \"${CLAUDE_PLUGIN_ROOT}/hooks/checkpoint-hook.ps1\" -Mode precompact"
-          }
-        ]
-      }
     ]
   }
 }

--- a/.claude/plugins/onebrain/skills/update/SKILL.md
+++ b/.claude/plugins/onebrain/skills/update/SKILL.md
@@ -234,7 +234,7 @@ Stop and PreCompact hooks must be registered in the vault's `.claude/settings.js
    }
    ```
 8. Write the updated JSON back to `.claude/settings.json`
-9. Report: "Registered Stop + PreCompact checkpoint hooks in `.claude/settings.json`."
+9. Report: "Registered Stop + PreCompact checkpoint hooks in `.claude/settings.json`. Note: paths are absolute — re-run `/update` if you move this vault."
 10. If both were already present: skip silently (no output)
 
 ---

--- a/.claude/plugins/onebrain/skills/update/SKILL.md
+++ b/.claude/plugins/onebrain/skills/update/SKILL.md
@@ -210,6 +210,35 @@ Rules:
 
 ---
 
+## Step 4g: Register Checkpoint Hooks in Project settings.json (If Missing)
+
+Stop and PreCompact hooks must be registered in the vault's `.claude/settings.json` — they are not picked up from plugin `hooks.json` automatically. This step ensures they are present.
+
+1. Derive the vault root (directory containing `vault.yml`)
+2. Set hook path: `[vault_root]/.claude/plugins/onebrain/hooks/checkpoint-hook.sh`
+3. Read `.claude/settings.json`. If it cannot be parsed as JSON: report error and skip.
+4. Check if `hooks.Stop` already contains a command referencing `checkpoint-hook.sh stop`
+5. If **absent**: add the Stop hook entry under `hooks.Stop` (create `hooks` key if missing):
+   ```json
+   {
+     "matcher": "",
+     "hooks": [{ "type": "command", "command": "bash \"[hook_path]\" stop" }]
+   }
+   ```
+6. Check if `hooks.PreCompact` already contains a command referencing `checkpoint-hook.sh precompact`
+7. If **absent**: add the PreCompact hook entry under `hooks.PreCompact`:
+   ```json
+   {
+     "matcher": "",
+     "hooks": [{ "type": "command", "command": "bash \"[hook_path]\" precompact" }]
+   }
+   ```
+8. Write the updated JSON back to `.claude/settings.json`
+9. Report: "Registered Stop + PreCompact checkpoint hooks in `.claude/settings.json`."
+10. If both were already present: skip silently (no output)
+
+---
+
 ## Step 5: Report
 
 Show a final summary of everything updated and migrated. Then suggest:

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Unlike chat-based AI tools, OneBrain lives in plain Markdown files you own forev
 | 📂 | **Vault-native Markdown** | Plain Markdown, no lock-in. Your data stays yours forever |
 | 🤖 | **Multi-agent** | Works with Claude Code, Gemini CLI, or any agent that reads Markdown |
 | 🔌 | **Zero Config** | Clone, open in Obsidian, run `/onboarding`. Ready in under 2 minutes |
-| 📓 | **Session Logs & Checkpoints** | Every conversation saved with summaries and action items. Auto-checkpoints fire every 15 messages or 30 min so nothing is lost mid-session |
+| 📓 | **Session Logs & Checkpoints** | Every conversation saved with summaries and action items. Auto-checkpoints fire every 15 messages or 30 min so nothing is lost mid-session *(auto-checkpoint requires Claude Code)* |
 | 🔗 | **Knowledge Synthesis** | `/consolidate` turns inbox captures into permanent connected knowledge |
 | 🎓 | **Teachable AI** | `/learn` permanently shapes how your agent thinks and responds |
 | 📱 | **Mobile Access** | Send instructions and receive briefings from anywhere via Telegram |


### PR DESCRIPTION
## Summary

- **Stop hook prompt injection was broken**: plain `echo` stdout from Stop/PreCompact hooks goes to debug log only — Claude never sees it. Fix: output JSON `{"decision":"block","reason":"..."}` for Stop mode; `{"systemMessage":"..."}` for PreCompact (which doesn't support blocking).
- **vault.yml threshold not read when called from settings.json**: `CLAUDE_PLUGIN_ROOT` is only set when hooks run from plugin `hooks.json`, not from project `settings.json`. Fix: derive vault root from `$0` script path as fallback.
- **python3 failure could freeze checkpointing for entire session**: state file was written to `0:NOW` before python3 ran — if python3 failed, counter stuck at 0 forever. Fix: build JSON first, only write state after success.
- **/update Step 4g**: registers Stop+PreCompact hooks in vault `.claude/settings.json` with warning about absolute paths.
- **Version bump**: 1.8.0 → 1.8.1

## Test plan

- [x] Verified Stop hook fires and checkpoint file is written (tested in vault session)
- [x] Verified `$0`-based vault root resolves correctly to vault root
- [x] Verified JSON output is valid for both modes
- [x] 3 rounds of code review — all critical/important issues resolved
- [ ] PreCompact `systemMessage` behavior pending live context compression test

## Review notes

Round 1 caught: PreCompact doesn't support `decision:block`. Round 2 caught: python3-after-state-write failure mode. Round 3: clean, no new critical issues.