### PR TITLE
fix: clear plugin cache on apply + remove open-in-obsidian from skills

### DIFF
--- a/.claude/plugins/onebrain/.claude-plugin/plugin.json
+++ b/.claude/plugins/onebrain/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "onebrain",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "OneBrain — Where human and AI thinking become one. A powerful thinking partner powered by AI synergy.",
   "author": {
     "name": "OneBrain Contributors"

--- a/.claude/plugins/onebrain/skills/daily/SKILL.md
+++ b/.claude/plugins/onebrain/skills/daily/SKILL.md
@@ -105,19 +105,6 @@ created: YYYY-MM-DD
 
 If a section has no content — including when `## Action Items` is absent from the session log or all its items are already checked — write the heading with a single line: `(none)`
 
-### Open in Obsidian (new file only)
-
-**Only run this section if the daily note was newly created above. If you updated an existing file, skip to Confirm.**
-
-Build the `obsidian://` URI:
-1. Take the absolute path of the daily note file
-2. URL-encode it — keep `/`, `:`, `@` as literal characters:
-   - Python3 (preferred): `python3 -c "import urllib.parse, sys; print(urllib.parse.quote(sys.argv[1], safe='/:@'))" "/absolute/path/to/file.md"`
-   - Node.js fallback: `node -e "const p=process.argv[1]; console.log(encodeURIComponent(p).replace(/%2F/gi,'/').replace(/%3A/gi,':').replace(/%40/gi,'@'))" "/absolute/path/to/file.md"`
-3. Run: `open "obsidian://open?path=[encoded_path]"`
-4. If the open command returns non-zero, show the URI for manual use:
-   > Could not open Obsidian automatically. Open manually: `obsidian://open?path=[encoded_path]`
-
 ### Confirm
 
 - New file created: `Daily note saved and opened → [inbox_folder]/YYYY-MM-DD-daily.md`

--- a/.claude/plugins/onebrain/skills/daily/SKILL.md
+++ b/.claude/plugins/onebrain/skills/daily/SKILL.md
@@ -74,10 +74,10 @@ Wait for the user's response before proceeding to Phase 2.
 Check whether `[inbox_folder]/YYYY-MM-DD-daily.md` already exists.
 
 **If it does NOT exist (first run today):**
-Create the file with the full template below, then open in Obsidian.
+Create the file with the full template below.
 
 **If it already exists (run more than once today):**
-Overwrite the `## Today's Focus` section only — preserve everything else. Do NOT open in Obsidian again.
+Overwrite the `## Today's Focus` section only — preserve everything else.
 
 ### Daily Note Template (new file only)
 
@@ -107,5 +107,5 @@ If a section has no content — including when `## Action Items` is absent from 
 
 ### Confirm
 
-- New file created: `Daily note saved and opened → [inbox_folder]/YYYY-MM-DD-daily.md`
+- New file created: `Daily note saved → [inbox_folder]/YYYY-MM-DD-daily.md`
 - Existing file updated: `Daily note updated → [inbox_folder]/YYYY-MM-DD-daily.md`

--- a/.claude/plugins/onebrain/skills/moc/SKILL.md
+++ b/.claude/plugins/onebrain/skills/moc/SKILL.md
@@ -196,38 +196,6 @@ PINNED_CONTENT
 
 ---
 
-## Step 5: Open in Obsidian
+## Step 5: Confirm
 
-Build the `obsidian://` URI using path-based addressing:
-
-1. Take the absolute path to `MOC.md`
-2. URL-encode it, keeping `/`, `:`, and `@` as literal characters:
-   - Python3 first: `urllib.parse.quote(path, safe='/:@')`
-   - Node.js fallback: `encodeURIComponent(path).replace(/%2F/gi, '/').replace(/%3A/gi, ':').replace(/%40/gi, '@')`
-   - If neither available: go to encoding-failure branch
-3. Build: `uri = "obsidian://open?path=" + encoded_path`
-
-Open via Bash based on platform (detect from `$OSTYPE`). Capture exit code:
-- macOS (`darwin`): `open "<uri>"`
-- Linux (non-WSL): `xdg-open "<uri>"`
-- Linux (WSL): `cmd.exe /c start "" "<uri>"`
-- Windows (msys/cygwin): `cmd.exe /c start "" "<uri>"`
-- Unrecognized platform: skip the open attempt and go to the encoding-failure branch, replacing the reason with "platform not recognized".
-
----
-
-## Step 6: Confirm
-
-**Exit code 0 (success):** `MOC.md opened in Obsidian.`
-
-**Non-zero exit code (open failed):**
-> "MOC.md was updated but could not be opened automatically in Obsidian.
->
-> Open it manually:
-> - In Obsidian: navigate to `MOC.md` in your vault
-> - Via URI: `obsidian://open?path=[encoded_path]`
->
-> If Obsidian is not installed, visit https://obsidian.md"
-
-**Encoding-failure (no Python3 or Node.js):**
-> "MOC.md was updated but could not be opened automatically — URL encoding is unavailable (Python3 and Node.js both missing). Open it manually in Obsidian by navigating to `MOC.md`."
+`MOC.md updated.`

--- a/.claude/plugins/onebrain/skills/moc/SKILL.md
+++ b/.claude/plugins/onebrain/skills/moc/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: moc
-description: Create or update the vault portal (MOC.md) at the vault root — a Map of Content with live Dataview queries, AI summary, and user Pinned section. Opens MOC.md in Obsidian.
+description: Create or update the vault portal (MOC.md) at the vault root — a Map of Content with live Dataview queries, AI summary, and user Pinned section.
 ---
 
 # Vault Portal

--- a/.claude/plugins/onebrain/skills/tasks/SKILL.md
+++ b/.claude/plugins/onebrain/skills/tasks/SKILL.md
@@ -122,43 +122,6 @@ Do not proceed to Steps 3 or 4 if the write failed.
 
 ---
 
-## Step 3: Open in Obsidian
+## Step 3: Print confirmation
 
-Build the `obsidian://` URI using path-based addressing:
-
-1. Take the absolute path to `TASKS.md`
-2. URL-encode it, keeping `/`, `:`, and `@` as literal characters:
-   - Priority order: Python3 first, then Node.js
-   - Python3: `urllib.parse.quote(path, safe='/:@')`
-   - Node.js: `encodeURIComponent(path).replace(/%2F/gi, '/').replace(/%3A/gi, ':').replace(/%40/gi, '@')`
-   - If neither runtime is available: go to Step 4 encoding-failure branch
-3. `uri = "obsidian://open?path=" + encoded_path`
-
-Open via Bash based on platform (detect from `$OSTYPE`). Capture the exit code:
-- macOS: `open "<uri>"`
-- Linux (non-WSL): `xdg-open "<uri>"`
-- Linux (WSL): `cmd.exe /c start "" "<uri>"`
-- Windows (msys/cygwin): `cmd.exe /c start "" "<uri>"`
-
-**If exit code 0:** proceed to Step 4 success branch.
-**If non-zero exit code:** proceed to Step 4 open-failure branch.
-
----
-
-## Step 4: Print confirmation
-
-**Success:** `TASKS.md opened in Obsidian.`
-
-**Open-failure (open command returned non-zero, encoding succeeded):**
-
-> "TASKS.md was updated but could not be opened automatically in Obsidian.
->
-> Open it manually:
-> - In Obsidian: navigate to `TASKS.md` in your vault
-> - Via URI: `obsidian://open?path=[encoded_path]`
->
-> If Obsidian is not installed, visit https://obsidian.md"
-
-**Encoding-failure (no Python3 or Node.js available):**
-
-> "TASKS.md was updated but could not be opened automatically — URL encoding is unavailable (Python3 and Node.js both missing). Open it manually in Obsidian by navigating to `[tasks_path]`."
+`TASKS.md updated.`

--- a/.claude/plugins/onebrain/skills/tasks/SKILL.md
+++ b/.claude/plugins/onebrain/skills/tasks/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: tasks
-description: Create or update the live task dashboard (TASKS.md) in Obsidian and open it.
+description: Create or update the live task dashboard (TASKS.md) in Obsidian.
 ---
 
 # Task Dashboard
 
-Creates or updates a permanent `TASKS.md` at the vault root using Obsidian Tasks plugin live query blocks, then opens it in Obsidian. The file is always current — no vault scanning needed. Mark tasks complete directly in Obsidian by clicking the checkboxes.
+Creates or updates a permanent `TASKS.md` at the vault root using Obsidian Tasks plugin live query blocks. The file is always current — no vault scanning needed. Mark tasks complete directly in Obsidian by clicking the checkboxes.
 
 Usage:
 - `/tasks` — open the full dashboard
@@ -102,7 +102,7 @@ If the write fails, stop immediately and tell the user:
 
 > "Could not create TASKS.md at [tasks_path]. Error: [error]. Check that the vault path is correct and that you have write permission. Vault root used: [vault_root]"
 
-Do not proceed to Steps 3 or 4 if the write failed.
+Do not proceed to Step 3 if the write failed.
 
 **If TASKS.md already exists:**
 
@@ -118,7 +118,7 @@ If the write fails, stop immediately and tell the user:
 
 > "Could not update TASKS.md at [tasks_path]. Error: [error]. Check that the vault path is correct and that you have write permission. Vault root used: [vault_root]"
 
-Do not proceed to Steps 3 or 4 if the write failed.
+Do not proceed to Step 3 if the write failed.
 
 ---
 

--- a/.claude/plugins/onebrain/skills/update/update.ps1
+++ b/.claude/plugins/onebrain/skills/update/update.ps1
@@ -24,13 +24,6 @@ if (-not (Test-Path $PluginDir)) {
     exit 1
 }
 
-# Snapshot local version before any files are overwritten (used for cache logic later)
-$LocalVer = ""
-$PluginJsonPath = Join-Path $PluginDir ".claude-plugin/plugin.json"
-if (Test-Path $PluginJsonPath) {
-    try { $LocalVer = (Get-Content $PluginJsonPath -Raw | ConvertFrom-Json).version } catch {}
-}
-
 # Fetch upstream file tree
 try {
     $TreeJson = Invoke-RestMethod -Uri $ApiTree

--- a/.claude/plugins/onebrain/skills/update/update.ps1
+++ b/.claude/plugins/onebrain/skills/update/update.ps1
@@ -128,27 +128,28 @@ foreach ($Dir in $AllowDirs) {
     }
 }
 
-# Clear plugin cache when version is unchanged (apply mode only)
+# Clear stale plugin cache entries (apply mode only)
+# Removes all cached versions except the current one to prevent stale hooks/skills from loading.
+# Note: deleting a version loaded by the current session causes PostToolUse hook errors until
+# the session is restarted — this is expected and resolves on next session start.
 $CacheNote = ""
-if ($Apply) {
-    # Use Invoke-WebRequest + ConvertFrom-Json because raw GitHub content returns text/plain,
-    # which Invoke-RestMethod returns as a string rather than a parsed object.
-    $UpstreamVer = ""
-    try {
-        $UpstreamVer = (Invoke-WebRequest -Uri "$RawBase/.claude/plugins/onebrain/.claude-plugin/plugin.json" -UseBasicParsing -ErrorAction Stop).Content |
-            ConvertFrom-Json |
-            Select-Object -ExpandProperty version
-    } catch {}
-
-    if ($LocalVer -and $LocalVer -eq $UpstreamVer) {
-        # Claude Code on Windows stores cache under %USERPROFILE%\.claude\ (mirrors Unix ~/.claude/)
-        @(
-            "$env:USERPROFILE\.claude\plugins\cache\onebrain\onebrain\$LocalVer",
-            "$env:USERPROFILE\.claude\plugins\cache\onebrain-local\onebrain\$LocalVer"
-        ) | ForEach-Object {
-            if (Test-Path $_) { Remove-Item $_ -Recurse -Force -ErrorAction SilentlyContinue }
+if ($Apply -and $LocalVer) {
+    # Claude Code on Windows stores cache under %USERPROFILE%\.claude\ (mirrors Unix ~/.claude/)
+    $ClearedSet = [System.Collections.Generic.HashSet[string]]::new()
+    @(
+        "$env:USERPROFILE\.claude\plugins\cache\onebrain\onebrain",
+        "$env:USERPROFILE\.claude\plugins\cache\onebrain-local\onebrain"
+    ) | ForEach-Object {
+        if (Test-Path $_) {
+            Get-ChildItem -Path $_ -Directory | Where-Object { $_.Name -ne $LocalVer } | ForEach-Object {
+                Remove-Item $_.FullName -Recurse -Force -ErrorAction SilentlyContinue
+                $null = $ClearedSet.Add($_.Name)
+            }
         }
-        $CacheNote = "  cache: cleared plugin cache for v$LocalVer"
+    }
+    if ($ClearedSet.Count -gt 0) {
+        $ClearedList = ($ClearedSet | Sort-Object) -join ', '
+        $CacheNote = "  cache: cleared stale versions ($ClearedList), kept v$LocalVer — start a new Claude Code session to reload the plugin"
     }
 }
 

--- a/.claude/plugins/onebrain/skills/update/update.ps1
+++ b/.claude/plugins/onebrain/skills/update/update.ps1
@@ -128,12 +128,13 @@ foreach ($Dir in $AllowDirs) {
     }
 }
 
-# Clear stale plugin cache entries (apply mode only)
-# Removes all cached versions except the current one to prevent stale hooks/skills from loading.
-# Note: deleting a version loaded by the current session causes PostToolUse hook errors until
-# the session is restarted — this is expected and resolves on next session start.
+# Clear plugin cache on apply — removes all cached versions so Claude Code re-reads from vault
+# on the next session start, guaranteeing the latest plugin version is always loaded.
+# Confirmed safe: Claude Code re-loads from source (directory) when cache is absent.
+# Note: PostToolUse hook errors may appear for the remainder of the current session —
+# this is expected and resolves on next session start.
 $CacheNote = ""
-if ($Apply -and $LocalVer) {
+if ($Apply) {
     # Claude Code on Windows stores cache under %USERPROFILE%\.claude\ (mirrors Unix ~/.claude/)
     $ClearedSet = [System.Collections.Generic.HashSet[string]]::new()
     @(
@@ -141,7 +142,7 @@ if ($Apply -and $LocalVer) {
         "$env:USERPROFILE\.claude\plugins\cache\onebrain-local\onebrain"
     ) | ForEach-Object {
         if (Test-Path $_) {
-            Get-ChildItem -Path $_ -Directory | Where-Object { $_.Name -ne $LocalVer } | ForEach-Object {
+            Get-ChildItem -Path $_ -Directory | ForEach-Object {
                 Remove-Item $_.FullName -Recurse -Force -ErrorAction SilentlyContinue
                 $null = $ClearedSet.Add($_.Name)
             }
@@ -149,7 +150,7 @@ if ($Apply -and $LocalVer) {
     }
     if ($ClearedSet.Count -gt 0) {
         $ClearedList = ($ClearedSet | Sort-Object) -join ', '
-        $CacheNote = "  cache: cleared stale versions ($ClearedList), kept v$LocalVer — start a new Claude Code session to reload the plugin"
+        $CacheNote = "  cache: cleared all cached versions ($ClearedList) — start a new Claude Code session to reload the plugin"
     }
 }
 

--- a/.claude/plugins/onebrain/skills/update/update.sh
+++ b/.claude/plugins/onebrain/skills/update/update.sh
@@ -45,16 +45,6 @@ for item in json.load(sys.stdin).get('tree', []):
 ALLOW_FILES=(".gitignore")
 ALLOW_DIRS=(".claude/plugins/onebrain" ".claude-plugin")
 
-# Snapshot local version before any files are overwritten (used for cache logic later)
-LOCAL_VER=$(python3 -c "
-import json
-try:
-    v = json.load(open('${PLUGIN_DIR}/.claude-plugin/plugin.json')).get('version') or ''
-    print(v if isinstance(v, str) and v else '')
-except:
-    print('')
-" 2>/dev/null || echo "")
-
 # Tracking arrays
 MODIFIED=() ADDED=() UNCHANGED=() FAILED=() DELETED=()
 
@@ -152,7 +142,7 @@ if [[ "${APPLY}" == true ]]; then
   done
   [[ ${_nullglob_was_set} -eq 0 ]] && shopt -u nullglob
   if [[ -n "${CLEARED_RAW}" ]]; then
-    CLEARED_LIST=$(printf '%s' "${CLEARED_RAW}" | sort -u | tr '\n' ' ' | sed 's/[[:space:]]*$//')
+    CLEARED_LIST=$(printf '%s' "${CLEARED_RAW}" | sort -u | tr '\n' ',' | sed 's/,$//' | sed 's/,/, /g')
     CACHE_NOTE="  cache: cleared all cached versions (${CLEARED_LIST}) — start a new Claude Code session to reload the plugin"
   fi
 fi

--- a/.claude/plugins/onebrain/skills/update/update.sh
+++ b/.claude/plugins/onebrain/skills/update/update.sh
@@ -49,7 +49,8 @@ ALLOW_DIRS=(".claude/plugins/onebrain" ".claude-plugin")
 LOCAL_VER=$(python3 -c "
 import json
 try:
-    print(json.load(open('${PLUGIN_DIR}/.claude-plugin/plugin.json'))['version'])
+    v = json.load(open('${PLUGIN_DIR}/.claude-plugin/plugin.json')).get('version') or ''
+    print(v if isinstance(v, str) and v else '')
 except:
     print('')
 " 2>/dev/null || echo "")
@@ -127,17 +128,34 @@ for dir in "${ALLOW_DIRS[@]}"; do
   fi
 done
 
-# Clear plugin cache when version is unchanged (apply mode only)
+# Clear stale plugin cache entries (apply mode only)
+# Removes all cached versions except the current one to prevent stale hooks/skills from loading.
 # LOCAL_VER was snapshotted before the apply loop to avoid reading the already-overwritten file.
+# Note: deleting a version loaded by the current session causes PostToolUse hook errors until
+# the session is restarted — this is expected and resolves on next session start.
 CACHE_NOTE=""
-if [[ "${APPLY}" == true ]]; then
-  UPSTREAM_VER=$(curl -sf "${RAW_BASE}/.claude/plugins/onebrain/.claude-plugin/plugin.json" 2>/dev/null | \
-    python3 -c "import json,sys; print(json.load(sys.stdin)['version'])" 2>/dev/null || echo "")
-
-  if [[ -n "${LOCAL_VER}" && "${LOCAL_VER}" == "${UPSTREAM_VER}" ]]; then
-    rm -rf "${HOME}/.claude/plugins/cache/onebrain/onebrain/${LOCAL_VER}" 2>/dev/null || true
-    rm -rf "${HOME}/.claude/plugins/cache/onebrain-local/onebrain/${LOCAL_VER}" 2>/dev/null || true
-    CACHE_NOTE="  cache: cleared plugin cache for v${LOCAL_VER}"
+if [[ "${APPLY}" == true && -n "${LOCAL_VER}" ]]; then
+  CLEARED_RAW=""
+  shopt -q nullglob && _nullglob_was_set=1 || _nullglob_was_set=0
+  shopt -s nullglob
+  for cache_dir in \
+    "${HOME}/.claude/plugins/cache/onebrain/onebrain" \
+    "${HOME}/.claude/plugins/cache/onebrain-local/onebrain"
+  do
+    if [[ -d "${cache_dir}" ]]; then
+      for ver_dir in "${cache_dir}"/*/; do
+        ver=$(basename "${ver_dir}")
+        if [[ "${ver}" != "${LOCAL_VER}" ]]; then
+          rm -rf "${ver_dir}" 2>/dev/null || true
+          CLEARED_RAW="${CLEARED_RAW}${ver}"$'\n'
+        fi
+      done
+    fi
+  done
+  [[ ${_nullglob_was_set} -eq 0 ]] && shopt -u nullglob
+  if [[ -n "${CLEARED_RAW}" ]]; then
+    CLEARED_LIST=$(printf '%s' "${CLEARED_RAW}" | sort -u | tr '\n' ' ' | sed 's/[[:space:]]*$//')
+    CACHE_NOTE="  cache: cleared stale versions (${CLEARED_LIST}), kept v${LOCAL_VER} — start a new Claude Code session to reload the plugin"
   fi
 fi
 

--- a/.claude/plugins/onebrain/skills/update/update.sh
+++ b/.claude/plugins/onebrain/skills/update/update.sh
@@ -128,13 +128,13 @@ for dir in "${ALLOW_DIRS[@]}"; do
   fi
 done
 
-# Clear stale plugin cache entries (apply mode only)
-# Removes all cached versions except the current one to prevent stale hooks/skills from loading.
-# LOCAL_VER was snapshotted before the apply loop to avoid reading the already-overwritten file.
-# Note: deleting a version loaded by the current session causes PostToolUse hook errors until
-# the session is restarted — this is expected and resolves on next session start.
+# Clear plugin cache on apply — removes all cached versions so Claude Code re-reads from vault
+# on the next session start, guaranteeing the latest plugin version is always loaded.
+# Confirmed safe: Claude Code re-loads from source (directory) when cache is absent.
+# Note: PostToolUse hook errors may appear for the remainder of the current session —
+# this is expected and resolves on next session start.
 CACHE_NOTE=""
-if [[ "${APPLY}" == true && -n "${LOCAL_VER}" ]]; then
+if [[ "${APPLY}" == true ]]; then
   CLEARED_RAW=""
   shopt -q nullglob && _nullglob_was_set=1 || _nullglob_was_set=0
   shopt -s nullglob
@@ -145,17 +145,15 @@ if [[ "${APPLY}" == true && -n "${LOCAL_VER}" ]]; then
     if [[ -d "${cache_dir}" ]]; then
       for ver_dir in "${cache_dir}"/*/; do
         ver=$(basename "${ver_dir}")
-        if [[ "${ver}" != "${LOCAL_VER}" ]]; then
-          rm -rf "${ver_dir}" 2>/dev/null || true
-          CLEARED_RAW="${CLEARED_RAW}${ver}"$'\n'
-        fi
+        rm -rf "${ver_dir}" 2>/dev/null || true
+        CLEARED_RAW="${CLEARED_RAW}${ver}"$'\n'
       done
     fi
   done
   [[ ${_nullglob_was_set} -eq 0 ]] && shopt -u nullglob
   if [[ -n "${CLEARED_RAW}" ]]; then
     CLEARED_LIST=$(printf '%s' "${CLEARED_RAW}" | sort -u | tr '\n' ' ' | sed 's/[[:space:]]*$//')
-    CACHE_NOTE="  cache: cleared stale versions (${CLEARED_LIST}), kept v${LOCAL_VER} — start a new Claude Code session to reload the plugin"
+    CACHE_NOTE="  cache: cleared all cached versions (${CLEARED_LIST}) — start a new Claude Code session to reload the plugin"
   fi
 fi
 


### PR DESCRIPTION
## Summary

- **Cache cleanup:** Clear entire plugin cache on every `--apply` run so Claude Code always loads the latest version on next session start. Previously only stale versions were removed, leaving old cached versions (with removed hooks like `open-in-obsidian`) in place.
- **Open-in-obsidian:** Remove `open "obsidian://..."` from `/daily`, `/tasks`, and `/moc` skills — was stealing terminal focus on every run.

## Changes

- `update.sh` / `update.ps1` — wipe all cached versions on apply (confirmed safe: Claude Code re-loads from vault source when cache is absent)
- `daily/SKILL.md` — removed "Open in Obsidian" section
- `tasks/SKILL.md` — removed Step 3 (open) + simplified confirm
- `moc/SKILL.md` — removed Step 5 (open) + simplified confirm
- `plugin.json` — bumped to v1.8.2

## Test plan

- [ ] Run `/update` (apply) — output shows `cache: cleared all cached versions (...) — start a new Claude Code session to reload the plugin`
- [ ] Start new session after apply — OneBrain loads correctly without cache
- [ ] Run `/daily` — note created, Obsidian does NOT open
- [ ] Run `/tasks` — TASKS.md updated, Obsidian does NOT open
- [ ] Run `/moc` — MOC.md updated, Obsidian does NOT open