### PR TITLE
fix(skills): remove open-in-obsidian from daily, tasks, moc

### DIFF
--- a/.claude/plugins/onebrain/skills/daily/SKILL.md
+++ b/.claude/plugins/onebrain/skills/daily/SKILL.md
@@ -105,19 +105,6 @@ created: YYYY-MM-DD
 
 If a section has no content — including when `## Action Items` is absent from the session log or all its items are already checked — write the heading with a single line: `(none)`
 
-### Open in Obsidian (new file only)
-
-**Only run this section if the daily note was newly created above. If you updated an existing file, skip to Confirm.**
-
-Build the `obsidian://` URI:
-1. Take the absolute path of the daily note file
-2. URL-encode it — keep `/`, `:`, `@` as literal characters:
-   - Python3 (preferred): `python3 -c "import urllib.parse, sys; print(urllib.parse.quote(sys.argv[1], safe='/:@'))" "/absolute/path/to/file.md"`
-   - Node.js fallback: `node -e "const p=process.argv[1]; console.log(encodeURIComponent(p).replace(/%2F/gi,'/').replace(/%3A/gi,':').replace(/%40/gi,'@'))" "/absolute/path/to/file.md"`
-3. Run: `open "obsidian://open?path=[encoded_path]"`
-4. If the open command returns non-zero, show the URI for manual use:
-   > Could not open Obsidian automatically. Open manually: `obsidian://open?path=[encoded_path]`
-
 ### Confirm
 
 - New file created: `Daily note saved and opened → [inbox_folder]/YYYY-MM-DD-daily.md`

--- a/.claude/plugins/onebrain/skills/moc/SKILL.md
+++ b/.claude/plugins/onebrain/skills/moc/SKILL.md
@@ -196,38 +196,6 @@ PINNED_CONTENT
 
 ---
 
-## Step 5: Open in Obsidian
+## Step 5: Confirm
 
-Build the `obsidian://` URI using path-based addressing:
-
-1. Take the absolute path to `MOC.md`
-2. URL-encode it, keeping `/`, `:`, and `@` as literal characters:
-   - Python3 first: `urllib.parse.quote(path, safe='/:@')`
-   - Node.js fallback: `encodeURIComponent(path).replace(/%2F/gi, '/').replace(/%3A/gi, ':').replace(/%40/gi, '@')`
-   - If neither available: go to encoding-failure branch
-3. Build: `uri = "obsidian://open?path=" + encoded_path`
-
-Open via Bash based on platform (detect from `$OSTYPE`). Capture exit code:
-- macOS (`darwin`): `open "<uri>"`
-- Linux (non-WSL): `xdg-open "<uri>"`
-- Linux (WSL): `cmd.exe /c start "" "<uri>"`
-- Windows (msys/cygwin): `cmd.exe /c start "" "<uri>"`
-- Unrecognized platform: skip the open attempt and go to the encoding-failure branch, replacing the reason with "platform not recognized".
-
----
-
-## Step 6: Confirm
-
-**Exit code 0 (success):** `MOC.md opened in Obsidian.`
-
-**Non-zero exit code (open failed):**
-> "MOC.md was updated but could not be opened automatically in Obsidian.
->
-> Open it manually:
-> - In Obsidian: navigate to `MOC.md` in your vault
-> - Via URI: `obsidian://open?path=[encoded_path]`
->
-> If Obsidian is not installed, visit https://obsidian.md"
-
-**Encoding-failure (no Python3 or Node.js):**
-> "MOC.md was updated but could not be opened automatically — URL encoding is unavailable (Python3 and Node.js both missing). Open it manually in Obsidian by navigating to `MOC.md`."
+`MOC.md updated.`

--- a/.claude/plugins/onebrain/skills/tasks/SKILL.md
+++ b/.claude/plugins/onebrain/skills/tasks/SKILL.md
@@ -122,43 +122,6 @@ Do not proceed to Steps 3 or 4 if the write failed.
 
 ---
 
-## Step 3: Open in Obsidian
+## Step 3: Print confirmation
 
-Build the `obsidian://` URI using path-based addressing:
-
-1. Take the absolute path to `TASKS.md`
-2. URL-encode it, keeping `/`, `:`, and `@` as literal characters:
-   - Priority order: Python3 first, then Node.js
-   - Python3: `urllib.parse.quote(path, safe='/:@')`
-   - Node.js: `encodeURIComponent(path).replace(/%2F/gi, '/').replace(/%3A/gi, ':').replace(/%40/gi, '@')`
-   - If neither runtime is available: go to Step 4 encoding-failure branch
-3. `uri = "obsidian://open?path=" + encoded_path`
-
-Open via Bash based on platform (detect from `$OSTYPE`). Capture the exit code:
-- macOS: `open "<uri>"`
-- Linux (non-WSL): `xdg-open "<uri>"`
-- Linux (WSL): `cmd.exe /c start "" "<uri>"`
-- Windows (msys/cygwin): `cmd.exe /c start "" "<uri>"`
-
-**If exit code 0:** proceed to Step 4 success branch.
-**If non-zero exit code:** proceed to Step 4 open-failure branch.
-
----
-
-## Step 4: Print confirmation
-
-**Success:** `TASKS.md opened in Obsidian.`
-
-**Open-failure (open command returned non-zero, encoding succeeded):**
-
-> "TASKS.md was updated but could not be opened automatically in Obsidian.
->
-> Open it manually:
-> - In Obsidian: navigate to `TASKS.md` in your vault
-> - Via URI: `obsidian://open?path=[encoded_path]`
->
-> If Obsidian is not installed, visit https://obsidian.md"
-
-**Encoding-failure (no Python3 or Node.js available):**
-
-> "TASKS.md was updated but could not be opened automatically — URL encoding is unavailable (Python3 and Node.js both missing). Open it manually in Obsidian by navigating to `[tasks_path]`."
+`TASKS.md updated.`


### PR DESCRIPTION
## Summary

- Removes `open "obsidian://..."` calls from `/daily`, `/tasks`, and `/moc` skills
- Obsidian was stealing terminal focus on every run of these skills
- The PostToolUse hook was removed in v1.8.0 but these skill-level opens remained

## Changes

- `daily/SKILL.md` — removed "Open in Obsidian (new file only)" section
- `tasks/SKILL.md` — replaced Step 3 (open) + Step 4 (confirm) with simple confirm
- `moc/SKILL.md` — replaced Step 5 (open) + Step 6 (confirm) with simple confirm

## Test plan

- [ ] Run `/daily` — note created, Obsidian does NOT open
- [ ] Run `/tasks` — TASKS.md updated, Obsidian does NOT open
- [ ] Run `/moc` — MOC.md updated, Obsidian does NOT open