### PR TITLE
fix(update): wrap script in main() to prevent bash mid-run misread (v1.8.3)

### DIFF
--- a/.claude/plugins/onebrain/.claude-plugin/plugin.json
+++ b/.claude/plugins/onebrain/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "onebrain",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "description": "OneBrain — Where human and AI thinking become one. A powerful thinking partner powered by AI synergy.",
   "author": {
     "name": "OneBrain Contributors"

--- a/.claude/plugins/onebrain/skills/update/update.sh
+++ b/.claude/plugins/onebrain/skills/update/update.sh
@@ -5,8 +5,13 @@
 # Usage:
 #   bash .claude/plugins/onebrain/skills/update/update.sh           # dry-run (compare only)
 #   bash .claude/plugins/onebrain/skills/update/update.sh --apply   # apply updates
+#
+# Note: wrapped in main() so bash reads the entire script before execution — prevents
+# misaligned reads if this file is replaced by its own --apply run.
 
 set -uo pipefail
+
+main() {
 
 APPLY=false
 [[ "${1:-}" == "--apply" ]] && APPLY=true
@@ -126,7 +131,8 @@ done
 CACHE_NOTE=""
 if [[ "${APPLY}" == true ]]; then
   CLEARED_RAW=""
-  shopt -q nullglob && _nullglob_was_set=1 || _nullglob_was_set=0
+  local _nullglob_was_set=0
+  shopt -q nullglob && _nullglob_was_set=1 || true
   shopt -s nullglob
   for cache_dir in \
     "${HOME}/.claude/plugins/cache/onebrain/onebrain" \
@@ -168,3 +174,6 @@ if [[ ${#FAILED[@]} -gt 0 ]]; then
   exit 1
 fi
 echo "status: ok"
+
+} # end main
+main "$@"


### PR DESCRIPTION
## Summary

- `update.sh --apply` downloads and overwrites `update.sh` itself mid-execution
- Bash reads scripts in buffered chunks — if it re-reads the file after replacement, it parses misaligned content from the new version
- This caused: `update.sh: line 129: absent.: command not found` (a fragment from a comment in the new file)
- Fix: wrap entire body in `main()` — bash reads the full function body before executing any of it, eliminating the mid-execution re-read window
- Also localizes `_nullglob_was_set` for cleaner scoping

## Test plan

- [ ] `bash -n update.sh` passes syntax check
- [ ] Dry-run produces clean output with no errors
- [ ] `--apply` run no longer produces `absent.: command not found`

🤖 Generated with [Claude Code](https://claude.com/claude-code)