### PR TITLE
feat(session): two-phase startup — immediate greeting + background sub-agent (v1.8.4)

### DIFF
--- a/.claude/plugins/onebrain/.claude-plugin/plugin.json
+++ b/.claude/plugins/onebrain/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "onebrain",
-  "version": "1.8.5",
+  "version": "1.8.4",
   "description": "OneBrain — Where human and AI thinking become one. A powerful thinking partner powered by AI synergy.",
   "author": {
     "name": "OneBrain Contributors"

--- a/.claude/plugins/onebrain/.claude-plugin/plugin.json
+++ b/.claude/plugins/onebrain/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "onebrain",
-  "version": "1.8.3",
+  "version": "1.8.5",
   "description": "OneBrain — Where human and AI thinking become one. A powerful thinking partner powered by AI synergy.",
   "author": {
     "name": "OneBrain Contributors"

--- a/.claude/plugins/onebrain/INSTRUCTIONS.md
+++ b/.claude/plugins/onebrain/INSTRUCTIONS.md
@@ -123,60 +123,110 @@ If qmd tools are not available, or if `qmd_collection` is not present in `vault.
 
 ## Session Behavior
 
-At the start of every session, perform these steps:
+Session startup runs in two phases. Phase 1 greets the user immediately. Phase 2 runs in a background sub-agent so the main agent stays free to respond.
 
-1. Read vault.yml for folder names and configuration — sets `[agent folder]` from `folders.agent` (default: `05-agent`) and `[logs folder]` from `folders.logs` (default: `07-logs`). Also read `.claude/plugins/onebrain/.claude-plugin/plugin.json` and note the `version` field — include it in your greeting (e.g. "OneBrain v1.5.6"). If the file doesn't exist, skip the version.
-2. Read `[agent folder]/MEMORY.md` to load identity, personality, and active projects
-   > **Agent context (lazy load):** If the session involves a domain-specific topic (e.g., research, writing, technical work), grep `[agent folder]/context/` for notes relevant to that topic and use them as background context. Do not load all context files every session — only when relevant.
+### Phase 1 — Immediate
+
+Run before responding to any user message:
+
+1. Read `vault.yml`, `.claude/plugins/onebrain/.claude-plugin/plugin.json`, and `[agent folder]/MEMORY.md` **in parallel**.
+   - `vault.yml`: get `folders`, `timezone` (default: `Asia/Bangkok` if absent)
+   - `plugin.json`: get `version` for greeting; if file absent, skip version
+   - `MEMORY.md`: load identity, personality, active projects and their task dates
+
+   > **Agent context (lazy load):** If the session involves a domain-specific topic, grep `[agent folder]/context/` for relevant notes. Do not load all context files every session.
    >
-   > **Agent memory (on-demand only):** `[agent folder]/memory/` is searched during a session when the user's request seems to relate to a past pattern or preference. It is never loaded at startup.
-3. Check inbox count
-4. Read the most recent session log entries — up to 3, or fewer if not enough exist (used for pattern detection in step 5)
-5. Greet the user by name with time-aware tone and one proactive insight
+   > **Agent memory (on-demand only):** `[agent folder]/memory/` is searched only when the user's request relates to a past pattern. Never loaded at startup.
 
-   **Time of day** — default timezone: `Asia/Bangkok`. Use current local time:
+2. Get current local time: run `TZ=[timezone] date '+%H:%M'` (single bash call, can run in parallel with step 1).
 
-   | Time | Label | Tone |
-   |------|-------|------|
-   | before 9:00 | morning | brief, energizing |
-   | 9:00–12:00 | mid-morning | normal |
-   | 12:00–17:00 | afternoon | normal |
-   | 17:00–21:00 | evening | winding down, reflective |
-   | after 21:00 | late night | quiet, concise |
+3. Send greeting immediately in this format:
 
-   **Proactive insight** — surface exactly ONE item, in priority order:
-   1. A task that is overdue or due within 2 days on weekdays, or due within 1 day on weekends — sourced from task dates listed in active projects in MEMORY.md
-   2. A pattern or recurring theme — only if at least 2 of the logs loaded in step 4 mention the same topic or project; do not surface if only 1 log was available
-   3. A connection between a recent inbox capture (since the last session log timestamp) and an existing knowledge note — attempt only if priorities 1 and 2 yield nothing; find via Glob `00-inbox/*.md` sorted by date
-   4. A project listed as active in MEMORY.md with no mention in any of the logs loaded in step 4 and no session log from the past 7 days
+   ```
+   **OneBrain vX.X.X**
+   [greeting] [name] [emoji]
+   ```
 
-   Keep the insight to 1–2 sentences. Don't ask a question — just surface it.
+   Time-of-day mapping (adapt greeting words to user's language at runtime):
 
-   **Skip the insight** if: MEMORY.md active projects list no tasks AND no session log exists from the past 7 days. Also skip if the user's opening message already addresses the highest-priority qualifying item.
+   | Local time | Concept | Emoji |
+   |---|---|---|
+   | before 09:00 | morning | ☀️ |
+   | 09:00–17:00 | (none) | — |
+   | 17:00–21:00 | evening | 🌆 |
+   | after 21:00 | late night | 🌙 |
 
-   On weekends (Saturday/Sunday): use a lighter, less task-focused tone.
+   On weekends: use lighter, less task-focused tone.
 
-   **Command Response Profiles take precedence** — time-of-day tone applies only to greetings and free responses, not to skill outputs (those follow their own profile).
+   **Command Response Profiles take precedence** — time-of-day tone applies only to greetings and free responses, not skill outputs.
 
-   **No-repeat rule** — don't ask about facts already in loaded context (MEMORY.md, session logs, vault.yml, plugin.json). If the user's current message contradicts something in context, trust their message over context.
+   **No-repeat rule** — do not ask about facts already in loaded context. If the user's message contradicts context, trust their message.
 
-### Orphan Checkpoint Cleanup
+4. Dispatch a **background sub-agent** (`run_in_background: true`) with this prompt payload:
 
-After greeting the user, silently check for orphaned checkpoints from previous sessions:
+   ```
+   vault_root: [absolute vault root path]
+   agent_folder: [from vault.yml folders.agent]
+   logs_folder: [from vault.yml folders.logs]
+   inbox_folder: [from vault.yml folders.inbox]
+   today: YYYY-MM-DD
+   active_tasks: [task list with dates extracted from MEMORY.md Active Projects section]
+   is_weekend: true|false
+   ```
 
-1. Glob `[logs folder]/**/*-checkpoint-*.md` where the date in the filename is **before today** and frontmatter `merged` is absent or not `true`
-2. Filter: ignore files older than 3 days — too stale to be useful
-3. Count remaining files; branch on count:
-   - **0 files**: skip (no latency impact)
-   - **1–5 files**: group by date → for each date group, synthesize a session log silently:
-     - Count existing `YYYY-MM-DD-session-*.md` for that date, use next number
-     - Write `[logs folder]/YYYY/MM/YYYY-MM-DD-session-NN.md` with frontmatter `auto-saved: true` and `synthesized_from_checkpoints: true`
-     - Content synthesized from checkpoint files: What We Worked On, Key Decisions, Action Items, Open Questions
-     - Mark each checkpoint `merged: true`
-   - **more than 5 files**: surface to user after greeting:
-     > "{N} orphaned checkpoints from {X} sessions found — run /wrapup to synthesize them?"
+Main agent is now ready to respond to the user.
 
-Do not show any output about this cleanup to the user unless the count exceeds 5 files.
+### Phase 2 — Background Sub-agent
+
+The sub-agent receives the payload from Phase 1 and performs all work that requires multiple file reads. It does NOT read MEMORY.md — `active_tasks` are passed in the prompt.
+
+**Sub-agent steps:**
+
+1. **Session logs** — Glob `[logs_folder]/**/*.md`, exclude `*-checkpoint-*.md`, sort by name descending. Read up to 3 most recent files.
+
+2. **Inbox count** — Glob `[inbox_folder]/*.md`, count files.
+
+3. **Orphan checkpoints** — Glob `[logs_folder]/**/*-checkpoint-*.md`:
+   - Keep only files where the date in the filename is **before today**
+   - Discard files older than 3 days
+   - Count remaining:
+     - **0 files**: skip
+     - **1–5 files**: for each date group, synthesize a session log silently:
+       - Count existing `YYYY-MM-DD-session-*.md` for that date → next NN (zero-padded)
+       - Write `[logs_folder]/YYYY/MM/YYYY-MM-DD-session-NN.md` with frontmatter `auto-saved: true`, `synthesized_from_checkpoints: true`
+       - Sections: What We Worked On, Key Decisions, Action Items, Open Questions
+       - Set `merged: true` on each source checkpoint file
+       - Set `orphan_action: merged:{N}`
+     - **>5 files**: set `orphan_action: prompt_wrapup:{N}`
+
+4. **Proactive insight** — surface exactly ONE item, in priority order:
+   1. Task in `active_tasks` that is overdue or due within 2 days (weekday) / 1 day (weekend)
+   2. Recurring topic — same topic/project mentioned in ≥2 of the 3 session logs
+   3. Inbox file newer than latest session log timestamp that links to an existing knowledge note
+   4. Project in `active_tasks` with no session log in the past 7 days
+
+   Skip insight if: `active_tasks` contains no dated tasks AND no session log exists from the past 7 days. Also skip if the user's first message already addresses the top qualifying item.
+
+5. **Return** to main agent:
+   ```
+   inbox_count: N
+   insight: "text" | ""
+   insight_type: task_due | pattern | connection | stale_project | none
+   orphan_action: none | merged:{N} | prompt_wrapup:{N}
+   ```
+
+### Follow-up Message
+
+After the sub-agent completes, the main agent sends one follow-up message:
+
+| Condition | Message |
+|---|---|
+| insight present | `{insight} · inbox {inbox_count}` |
+| no insight, inbox 0 | `inbox empty` |
+| no insight, inbox > 0 | `inbox {inbox_count} items` |
+| orphan_action = prompt_wrapup:{N} | append ` · {N} orphaned checkpoints — run /wrapup?` |
+
+**Rule:** If the user sent a message before the sub-agent finished, respond to that message first, then send the follow-up. Never drop the follow-up.
 
 ### Recalling Information
 

--- a/.claude/plugins/onebrain/INSTRUCTIONS.md
+++ b/.claude/plugins/onebrain/INSTRUCTIONS.md
@@ -182,18 +182,18 @@ The sub-agent receives the payload from Phase 1 and performs all work that requi
 
 **Sub-agent steps:**
 
-1. **Session logs** — Glob `[logs_folder]/**/*.md`, exclude `*-checkpoint-*.md`, sort by name descending. Read up to 3 most recent files.
+1. **Session logs** — Glob `[logs folder]/**/*.md`, exclude `*-checkpoint-*.md`, sort by name descending. Read up to 3 most recent files.
 
-2. **Inbox count** — Glob `[inbox_folder]/*.md`, count files.
+2. **Inbox count** — Glob `[inbox folder]/*.md`, count files.
 
-3. **Orphan checkpoints** — Glob `[logs_folder]/**/*-checkpoint-*.md`:
+3. **Orphan checkpoints** — Glob `[logs folder]/**/*-checkpoint-*.md`:
    - Keep only files where the date in the filename is **before today**
    - Discard files older than 3 days
    - Count remaining:
      - **0 files**: skip
      - **1–5 files**: for each date group, synthesize a session log silently:
        - Count existing `YYYY-MM-DD-session-*.md` for that date → next NN (zero-padded)
-       - Write `[logs_folder]/YYYY/MM/YYYY-MM-DD-session-NN.md` with frontmatter `auto-saved: true`, `synthesized_from_checkpoints: true`
+       - Write `[logs folder]/YYYY/MM/YYYY-MM-DD-session-NN.md` with frontmatter `auto-saved: true`, `synthesized_from_checkpoints: true`
        - Sections: What We Worked On, Key Decisions, Action Items, Open Questions
        - Set `merged: true` on each source checkpoint file
        - Set `orphan_action: merged:{N}`
@@ -202,7 +202,7 @@ The sub-agent receives the payload from Phase 1 and performs all work that requi
 4. **Proactive insight** — surface exactly ONE item, in priority order:
    1. Task in `active_tasks` that is overdue or due within 2 days (weekday) / 1 day (weekend)
    2. Recurring topic — same topic/project mentioned in ≥2 of the 3 session logs
-   3. Inbox file newer than latest session log timestamp that links to an existing knowledge note
+   3. Inbox file newer than latest session log timestamp that links to an existing knowledge note — check by Globbing `[knowledge_folder]/**/*.md` and scanning for a wikilink match
    4. Project in `active_tasks` with no session log in the past 7 days
 
    Skip insight if: `active_tasks` contains no dated tasks AND no session log exists from the past 7 days. Also skip if the user's first message already addresses the top qualifying item.
@@ -224,6 +224,7 @@ After the sub-agent completes, the main agent sends one follow-up message:
 | insight present | `{insight} · inbox {inbox_count}` |
 | no insight, inbox 0 | `inbox empty` |
 | no insight, inbox > 0 | `inbox {inbox_count} items` |
+| orphan_action = merged:{N} | (silent, no extra output) |
 | orphan_action = prompt_wrapup:{N} | append ` · {N} orphaned checkpoints — run /wrapup?` |
 
 **Rule:** If the user sent a message before the sub-agent finished, respond to that message first, then send the follow-up. Never drop the follow-up.

--- a/.claude/plugins/onebrain/INSTRUCTIONS.md
+++ b/.claude/plugins/onebrain/INSTRUCTIONS.md
@@ -169,6 +169,7 @@ Run before responding to any user message:
    agent_folder: [from vault.yml folders.agent]
    logs_folder: [from vault.yml folders.logs]
    inbox_folder: [from vault.yml folders.inbox]
+   knowledge_folder: [from vault.yml folders.knowledge]
    today: YYYY-MM-DD
    active_tasks: [task list with dates extracted from MEMORY.md Active Projects section]
    is_weekend: true|false
@@ -211,7 +212,6 @@ The sub-agent receives the payload from Phase 1 and performs all work that requi
    ```
    inbox_count: N
    insight: "text" | ""
-   insight_type: task_due | pattern | connection | stale_project | none
    orphan_action: none | merged:{N} | prompt_wrapup:{N}
    ```
 
@@ -219,13 +219,20 @@ The sub-agent receives the payload from Phase 1 and performs all work that requi
 
 After the sub-agent completes, the main agent sends one follow-up message:
 
-| Condition | Message |
+First, choose the base message from insight rows:
+
+| Insight condition | Base message |
 |---|---|
 | insight present | `{insight} · inbox {inbox_count}` |
 | no insight, inbox 0 | `inbox empty` |
 | no insight, inbox > 0 | `inbox {inbox_count} items` |
-| orphan_action = merged:{N} | (silent, no extra output) |
-| orphan_action = prompt_wrapup:{N} | append ` · {N} orphaned checkpoints — run /wrapup?` |
+
+Then, apply orphan modifier (these compose on top of the base message, they do not replace it):
+
+| orphan_action | Modifier |
+|---|---|
+| `none` or `merged:{N}` | (no change — silent) |
+| `prompt_wrapup:{N}` | append ` · {N} orphaned checkpoints — run /wrapup?` |
 
 **Rule:** If the user sent a message before the sub-agent finished, respond to that message first, then send the follow-up. Never drop the follow-up.
 

--- a/.claude/plugins/onebrain/INSTRUCTIONS.md
+++ b/.claude/plugins/onebrain/INSTRUCTIONS.md
@@ -152,7 +152,7 @@ Run before responding to any user message:
    | Local time | Concept | Emoji |
    |---|---|---|
    | before 09:00 | morning | ☀️ |
-   | 09:00–17:00 | (none) | — |
+   | 09:00–17:00 | (omit time word and emoji) | — |
    | 17:00–21:00 | evening | 🌆 |
    | after 21:00 | late night | 🌙 |
 
@@ -203,7 +203,7 @@ The sub-agent receives the payload from Phase 1 and performs all work that requi
 4. **Proactive insight** — surface exactly ONE item, in priority order:
    1. Task in `active_tasks` that is overdue or due within 2 days (weekday) / 1 day (weekend)
    2. Recurring topic — same topic/project mentioned in ≥2 of the 3 session logs
-   3. Inbox file newer than latest session log timestamp that links to an existing knowledge note — check by Globbing `[knowledge_folder]/**/*.md` and scanning for a wikilink match
+   3. Inbox file newer than latest session log timestamp whose content contains a `[[wikilink]]` that matches an existing file in `[knowledge folder]` — scan the inbox file's text for wikilink syntax, then verify at least one target exists by Globbing `[knowledge folder]/**/*.md`
    4. Project in `active_tasks` with no session log in the past 7 days
 
    Skip insight if: `active_tasks` contains no dated tasks AND no session log exists from the past 7 days. Also skip if the user's first message already addresses the top qualifying item.
@@ -217,7 +217,7 @@ The sub-agent receives the payload from Phase 1 and performs all work that requi
 
 ### Follow-up Message
 
-After the sub-agent completes, the main agent sends one follow-up message:
+When the background sub-agent returns its payload, the main agent reads `inbox_count`, `insight`, and `orphan_action` and sends exactly one follow-up message using the tables below:
 
 First, choose the base message from insight rows:
 
@@ -231,7 +231,7 @@ Then, apply orphan modifier (these compose on top of the base message, they do n
 
 | orphan_action | Modifier |
 |---|---|
-| `none` or `merged:{N}` | (no change — silent) |
+| `none` or `merged:*` (any count) | (no change — silent) |
 | `prompt_wrapup:{N}` | append ` · {N} orphaned checkpoints — run /wrapup?` |
 
 **Rule:** If the user sent a message before the sub-agent finished, respond to that message first, then send the follow-up. Never drop the follow-up.

--- a/.claude/plugins/onebrain/skills/update/SKILL.md
+++ b/.claude/plugins/onebrain/skills/update/SKILL.md
@@ -252,7 +252,7 @@ Rules:
 - **Never overwrite existing value** — only add if absent
 - Insert immediately after the line containing `method:`. If `method:` is absent, append as a top-level key before the `folders:` block.
 - If `vault.yml` does not exist: skip silently
-- Report: "Added `timezone: Asia/Bangkok` to `vault.yml`. Update this value if your local timezone is different."
+- Report: "Added `timezone: Asia/Bangkok` to `vault.yml`. Edit the `timezone:` key in `vault.yml` if your local timezone is different."
 - If already present: skip silently (no output)
 
 ---

--- a/.claude/plugins/onebrain/skills/update/SKILL.md
+++ b/.claude/plugins/onebrain/skills/update/SKILL.md
@@ -250,6 +250,7 @@ timezone: Asia/Bangkok
 
 Rules:
 - **Never overwrite existing value** — only add if absent
+- Insert immediately after the line containing `method:`. If `method:` is absent, append as a top-level key before the `folders:` block.
 - If `vault.yml` does not exist: skip silently
 - Report: "Added `timezone: Asia/Bangkok` to `vault.yml`. Update this value if your local timezone is different."
 - If already present: skip silently (no output)

--- a/.claude/plugins/onebrain/skills/update/SKILL.md
+++ b/.claude/plugins/onebrain/skills/update/SKILL.md
@@ -239,6 +239,23 @@ Stop and PreCompact hooks must be registered in the vault's `.claude/settings.js
 
 ---
 
+## Step 4h: Ensure timezone in vault.yml (If Missing)
+
+Read `vault.yml`. If a `timezone:` top-level key is **absent**, insert it immediately after the `method:` line:
+
+```yaml
+method: onebrain
+timezone: Asia/Bangkok
+```
+
+Rules:
+- **Never overwrite existing value** — only add if absent
+- If `vault.yml` does not exist: skip silently
+- Report: "Added `timezone: Asia/Bangkok` to `vault.yml`. Update this value if your local timezone is different."
+- If already present: skip silently (no output)
+
+---
+
 ## Step 5: Report
 
 Show a final summary of everything updated and migrated. Then suggest:


### PR DESCRIPTION
## Summary

- **Phase 1 (immediate):** Read `vault.yml` + `plugin.json` + `MEMORY.md` in parallel + bash time call → greet user instantly with `**OneBrain vX.X.X**` / `[greeting] [name]` format
- **Phase 2 (background sub-agent):** Reads session logs, inbox count, orphan checkpoints, proactive insight → sends 1-line follow-up message (base + optional orphan modifier, never dropped)
- **`update` skill Step 4h:** Ensures `timezone` field is present in `vault.yml` on every update run — inserts `Asia/Bangkok` default if absent, never overwrites existing value
- **`vault.yml`:** Added `timezone:` as a top-level config field (read by Phase 1, eliminates need to hardcode timezone in instructions)

## Motivation

Previously the agent read 5+ files sequentially before sending any message, causing a noticeable delay. Users couldn't tell if the agent was ready. The new design greets immediately so the user knows the agent is responsive, then delivers context (inbox count, proactive insight) asynchronously.

## Test Plan

- [ ] Open a new Claude Code session in the vault — greeting should appear before any background output
- [ ] Greeting format: bold version line + greeting line (no combined single line)
- [ ] Follow-up message arrives shortly after: insight (if any) + inbox count
- [ ] Run `/update` on a vault without `timezone:` — confirm field is added and reported
- [ ] Run `/update` on a vault with `timezone:` already set — confirm no overwrite, no output
- [ ] Orphan checkpoint cleanup: create unmerged checkpoints from a prior date, open new session, confirm silent merge in follow-up
- [ ] Orphan > 5: confirm prompt appears appended to follow-up, not as separate message

🤖 Generated with [Claude Code](https://claude.com/claude-code)