### PR TITLE
fix(checkpoint): remove broken PreCompact hook, Stop-only checkpoint system

### DIFF
--- a/.claude/plugins/onebrain/.claude-plugin/plugin.json
+++ b/.claude/plugins/onebrain/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "onebrain",
-  "version": "1.8.5",
+  "version": "1.8.6",
   "description": "OneBrain — Where human and AI thinking become one. A powerful thinking partner powered by AI synergy.",
   "author": {
     "name": "OneBrain Contributors"

--- a/.claude/plugins/onebrain/hooks/checkpoint-hook.ps1
+++ b/.claude/plugins/onebrain/hooks/checkpoint-hook.ps1
@@ -1,19 +1,23 @@
-# OneBrain — Checkpoint Hook (Stop + PreCompact) (Windows)
-# Usage: checkpoint-hook.ps1 [-Mode stop|precompact]
+# OneBrain — Checkpoint Hook (Stop) (Windows)
+# Usage: checkpoint-hook.ps1 [-Mode stop]
 #
-# stop       — fires after every response; checkpoints on message/time threshold
-#              Uses JSON {"decision":"block","reason":"..."} to inject prompt back to Claude.
-# precompact — fires before context compression; checkpoints unless skip window or no activity
-#              Uses JSON {"systemMessage":"..."} — PreCompact does not support decision:block.
+# stop — fires after every response; checkpoints on message/time threshold
+#         Uses JSON {"decision":"block","reason":"..."} to inject prompt back to Claude.
 #
-# Both modes share %TEMP%\onebrain-{ParentPid}.state (COUNT:LAST_TS).
-# 60s skip window prevents double-checkpoints when both fire close together.
+# State file: %TEMP%\onebrain-{ParentPid}.state (COUNT:LAST_TS)
+# COUNT=0 with fresh timestamp in an *existing* state file signals post-checkpoint reset;
+# absence of state file = first run.
 # MIN_ACTIVITY guard: if fewer than 2 messages since last checkpoint, reset and skip —
 # no file is created for sessions with no meaningful activity.
 
 param(
     [string]$Mode = "stop"
 )
+
+if ($Mode -ne "stop") {
+    Write-Error "checkpoint-hook.ps1: unknown mode '$Mode' — only 'stop' is supported"
+    exit 1
+}
 
 $ParentPid = (Get-CimInstance Win32_Process -Filter "ProcessId=$PID" -ErrorAction SilentlyContinue).ParentProcessId
 if (-not $ParentPid) { exit 0 }
@@ -39,27 +43,6 @@ if (Test-Path $StateFile) {
     }
 } else {
     $Count = 0; $LastTs = $Now
-}
-
-# --- PreCompact mode: checkpoint unless no activity since last one ---
-# PreCompact does not support decision:block — uses systemMessage instead.
-if ($Mode -eq "precompact") {
-    if ($Count -lt $MinActivity) {
-        # Not enough activity since last checkpoint — reset counter, skip creating file
-        Set-Content -Path $StateFile -Value "0:$Now" -ErrorAction SilentlyContinue
-        exit 0
-    }
-    $Prompt = "Context compression is imminent. Before compacting, silently save a checkpoint to the vault logs. Steps: (1) Get today's date YYYY-MM-DD, extract YYYY and MM. (2) Count existing checkpoint-*.md files in [logs folder]/YYYY/MM/ to find the next checkpoint number NN (zero-padded, starts at 01). (3) Write [logs folder]/YYYY/MM/YYYY-MM-DD-checkpoint-NN.md with this exact frontmatter: tags: [checkpoint, session-log], date: YYYY-MM-DD, checkpoint: NN, trigger: precompact, merged: false. (4) Content sections: ## What We Worked On (2-3 sentences), ## Key Decisions (bullet list), ## Action Items (tasks with date YYYY-MM-DD), ## Open Questions (bullet list). Keep under 250 words total. No output to user."
-    # Build JSON before writing state — leave state unchanged on failure
-    $Json = try { ConvertTo-Json @{systemMessage = $Prompt} -Compress } catch { $null }
-    if (-not $Json) { exit 1 }
-    try {
-        Set-Content -Path $StateFile -Value "0:$Now" -ErrorAction Stop
-    } catch {
-        exit 2
-    }
-    Write-Output $Json
-    exit 0
 }
 
 # --- Stop mode: check thresholds against vault.yml config ---

--- a/.claude/plugins/onebrain/hooks/checkpoint-hook.ps1
+++ b/.claude/plugins/onebrain/hooks/checkpoint-hook.ps1
@@ -7,6 +7,7 @@
 # State file: %TEMP%\onebrain-{ParentPid}.state (COUNT:LAST_TS)
 # COUNT=0 with fresh timestamp in an *existing* state file signals post-checkpoint reset;
 # absence of state file = first run.
+# SkipWindow=60: prevents re-trigger immediately after a checkpoint resets Count to 0.
 # MIN_ACTIVITY guard: if fewer than 2 messages since last checkpoint, reset and skip —
 # no file is created for sessions with no meaningful activity.
 

--- a/.claude/plugins/onebrain/hooks/checkpoint-hook.sh
+++ b/.claude/plugins/onebrain/hooks/checkpoint-hook.sh
@@ -1,20 +1,21 @@
 #!/usr/bin/env bash
-# OneBrain — Checkpoint Hook (Stop + PreCompact)
-# Usage: checkpoint-hook.sh stop|precompact
+# OneBrain — Checkpoint Hook (Stop)
+# Usage: checkpoint-hook.sh stop
 #
-# stop       — fires after every response; checkpoints on message/time threshold
-#              Uses JSON {"decision":"block","reason":"..."} to inject prompt back to Claude.
-# precompact — fires before context compression; checkpoints unless skip window or no activity
-#              Uses JSON {"systemMessage":"..."} — PreCompact does not support decision:block.
+# stop — fires after every response; checkpoints on message/time threshold
+#         Uses JSON {"decision":"block","reason":"..."} to inject prompt back to Claude.
 #
-# Both modes share /tmp/onebrain-{PPID}.state (COUNT:LAST_TS).
-# 60s skip window prevents double-checkpoints when both fire close together.
+# State file: /tmp/onebrain-{PPID}.state (COUNT:LAST_TS)
 # COUNT=0 with fresh timestamp in an *existing* state file signals post-checkpoint reset;
 # absence of state file = first run.
 # MIN_ACTIVITY guard: if fewer than 2 messages since last checkpoint, reset and skip —
 # no file is created for sessions with no meaningful activity.
 
 MODE="${1:-stop}"
+if [ "$MODE" != "stop" ]; then
+  echo "checkpoint-hook.sh: unknown mode '${MODE}' — only 'stop' is supported" >&2
+  exit 1
+fi
 STATE_FILE="/tmp/onebrain-${PPID}.state"
 SKIP_WINDOW=60
 MIN_ACTIVITY=2  # minimum messages since last checkpoint to warrant a new one
@@ -32,28 +33,6 @@ if [ -f "$STATE_FILE" ]; then
   fi
 else
   COUNT=0; LAST_TS=$NOW
-fi
-
-# --- PreCompact mode: checkpoint unless no activity since last one ---
-# PreCompact does not support decision:block — uses systemMessage instead.
-if [ "$MODE" = "precompact" ]; then
-  if [ "$COUNT" -lt $MIN_ACTIVITY ]; then
-    # Not enough activity since last checkpoint — reset counter, skip creating file
-    echo "0:${NOW}" > "$STATE_FILE" 2>/dev/null
-    exit 0
-  fi
-  # Build JSON first — restore state on python3 failure so future triggers still work
-  PROMPT="Context compression is imminent. Before compacting, silently save a checkpoint to the vault logs. Steps: (1) Get today's date YYYY-MM-DD, extract YYYY and MM. (2) Count existing checkpoint-*.md files in [logs folder]/YYYY/MM/ to find the next checkpoint number NN (zero-padded, starts at 01). (3) Write [logs folder]/YYYY/MM/YYYY-MM-DD-checkpoint-NN.md with this exact frontmatter: tags: [checkpoint, session-log], date: YYYY-MM-DD, checkpoint: NN, trigger: precompact, merged: false. (4) Content sections: ## What We Worked On (2-3 sentences), ## Key Decisions (bullet list), ## Action Items (tasks with date YYYY-MM-DD), ## Open Questions (bullet list). Keep under 250 words total. No output to user."
-  JSON=$(python3 -c "import json,sys; print(json.dumps({'systemMessage':sys.argv[1]}))" "$PROMPT" 2>/dev/null)
-  if [ -z "$JSON" ]; then
-    # python3 unavailable or failed — leave state unchanged so future triggers still work
-    exit 1
-  fi
-  if ! echo "0:${NOW}" > "$STATE_FILE" 2>/dev/null; then
-    exit 2
-  fi
-  printf '%s\n' "$JSON"
-  exit 0
 fi
 
 # --- Stop mode: check thresholds against vault.yml config ---

--- a/.claude/plugins/onebrain/hooks/checkpoint-hook.sh
+++ b/.claude/plugins/onebrain/hooks/checkpoint-hook.sh
@@ -8,6 +8,7 @@
 # State file: /tmp/onebrain-{PPID}.state (COUNT:LAST_TS)
 # COUNT=0 with fresh timestamp in an *existing* state file signals post-checkpoint reset;
 # absence of state file = first run.
+# SKIP_WINDOW=60: prevents re-trigger immediately after a checkpoint resets COUNT to 0.
 # MIN_ACTIVITY guard: if fewer than 2 messages since last checkpoint, reset and skip —
 # no file is created for sessions with no meaningful activity.
 

--- a/.claude/plugins/onebrain/skills/update/SKILL.md
+++ b/.claude/plugins/onebrain/skills/update/SKILL.md
@@ -216,7 +216,9 @@ The Stop hook must be registered in the vault's `.claude/settings.json` — it i
 
 1. Derive the vault root (directory containing `vault.yml`)
 2. Set hook path: `[vault_root]/.claude/plugins/onebrain/hooks/checkpoint-hook.sh`
-3. Read `.claude/settings.json`. If it cannot be parsed as JSON: report error and skip.
+3. Read `.claude/settings.json`:
+   - If the file does not exist: treat it as `{}` (the write in step 7 will create it)
+   - If the file exists but cannot be parsed as JSON: report error and skip
 4. Check if `hooks.Stop` already contains a command referencing `checkpoint-hook.sh stop`. Set `stop_added = false` if already present, `stop_added = true` if added.
 5. If **absent**: add the Stop hook entry under `hooks.Stop` (create `hooks` key if missing), set `stop_added = true`:
    ```json
@@ -225,10 +227,13 @@ The Stop hook must be registered in the vault's `.claude/settings.json` — it i
      "hooks": [{ "type": "command", "command": "bash \"[hook_path]\" stop" }]
    }
    ```
-6. If `hooks.PreCompact` contains an entry referencing `checkpoint-hook.sh precompact`: remove that entry; if the `PreCompact` array is now empty, remove the `PreCompact` key entirely. Set `precompact_removed = true`.
+6. Check `hooks.PreCompact`:
+   - If it contains an entry referencing `checkpoint-hook.sh precompact`: remove that entry; set `precompact_removed = true`
+   - If the `PreCompact` array is now empty (or was already empty): remove the `PreCompact` key entirely
 7. If `stop_added` OR `precompact_removed`: write the updated JSON back to `.claude/settings.json`, then report:
-   - If `stop_added`: "Registered Stop checkpoint hook in `.claude/settings.json`. Note: paths are absolute — re-run `/update` if you move this vault."
-   - If only `precompact_removed` (Stop was already present): "Removed legacy PreCompact checkpoint hook from `.claude/settings.json`."
+   - If `stop_added` AND `precompact_removed`: "Registered Stop checkpoint hook and removed legacy PreCompact entry in `.claude/settings.json`. Note: paths are absolute — re-run `/update` if you move this vault."
+   - If `stop_added` only: "Registered Stop checkpoint hook in `.claude/settings.json`. Note: paths are absolute — re-run `/update` if you move this vault."
+   - If `precompact_removed` only (Stop was already present): "Removed legacy PreCompact checkpoint hook from `.claude/settings.json`."
 8. If neither `stop_added` nor `precompact_removed`: skip silently (no output)
 
 ---

--- a/.claude/plugins/onebrain/skills/update/SKILL.md
+++ b/.claude/plugins/onebrain/skills/update/SKILL.md
@@ -210,32 +210,26 @@ Rules:
 
 ---
 
-## Step 4g: Register Checkpoint Hooks in Project settings.json (If Missing)
+## Step 4g: Register Stop Checkpoint Hook in Project settings.json (If Missing)
 
-Stop and PreCompact hooks must be registered in the vault's `.claude/settings.json` — they are not picked up from plugin `hooks.json` automatically. This step ensures they are present.
+The Stop hook must be registered in the vault's `.claude/settings.json` — it is not picked up from plugin `hooks.json` automatically. This step ensures it is present.
 
 1. Derive the vault root (directory containing `vault.yml`)
 2. Set hook path: `[vault_root]/.claude/plugins/onebrain/hooks/checkpoint-hook.sh`
 3. Read `.claude/settings.json`. If it cannot be parsed as JSON: report error and skip.
-4. Check if `hooks.Stop` already contains a command referencing `checkpoint-hook.sh stop`
-5. If **absent**: add the Stop hook entry under `hooks.Stop` (create `hooks` key if missing):
+4. Check if `hooks.Stop` already contains a command referencing `checkpoint-hook.sh stop`. Set `stop_added = false` if already present, `stop_added = true` if added.
+5. If **absent**: add the Stop hook entry under `hooks.Stop` (create `hooks` key if missing), set `stop_added = true`:
    ```json
    {
      "matcher": "",
      "hooks": [{ "type": "command", "command": "bash \"[hook_path]\" stop" }]
    }
    ```
-6. Check if `hooks.PreCompact` already contains a command referencing `checkpoint-hook.sh precompact`
-7. If **absent**: add the PreCompact hook entry under `hooks.PreCompact`:
-   ```json
-   {
-     "matcher": "",
-     "hooks": [{ "type": "command", "command": "bash \"[hook_path]\" precompact" }]
-   }
-   ```
-8. Write the updated JSON back to `.claude/settings.json`
-9. Report: "Registered Stop + PreCompact checkpoint hooks in `.claude/settings.json`. Note: paths are absolute — re-run `/update` if you move this vault."
-10. If both were already present: skip silently (no output)
+6. If `hooks.PreCompact` contains an entry referencing `checkpoint-hook.sh precompact`: remove that entry; if the `PreCompact` array is now empty, remove the `PreCompact` key entirely. Set `precompact_removed = true`.
+7. If `stop_added` OR `precompact_removed`: write the updated JSON back to `.claude/settings.json`, then report:
+   - If `stop_added`: "Registered Stop checkpoint hook in `.claude/settings.json`. Note: paths are absolute — re-run `/update` if you move this vault."
+   - If only `precompact_removed` (Stop was already present): "Removed legacy PreCompact checkpoint hook from `.claude/settings.json`."
+8. If neither `stop_added` nor `precompact_removed`: skip silently (no output)
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,7 +142,7 @@ Most hooks support a `matcher` field to filter by tool name or event subtype. `U
 
 3. Make scripts defensive — they run on every matching event, so they should exit silently if there's nothing to do.
 
-4. **Stop and PreCompact hooks must NOT use `"async": true`** — these hooks can inject prompts by writing to stdout, but only if they complete synchronously before Claude's next response. Async execution fires too late for prompt injection.
+4. **Stop hooks must NOT use `"async": true`** — they inject prompts via `decision:block` written to stdout, which requires synchronous completion before Claude's next response. Async execution fires too late for prompt injection. PreCompact hooks do not support `decision:block` and cannot inject prompts.
 
 ## Install Scripts
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,7 +113,7 @@ Hooks run shell commands automatically when Claude performs certain actions. Hoo
 
 Most hooks support a `matcher` field to filter by tool name or event subtype. `UserPromptSubmit`, `Stop`, `TeammateIdle`, `TaskCompleted`, `WorktreeCreate`, and `WorktreeRemove` fire on every occurrence and do not support matchers.
 
-**Example — checkpoint system:** OneBrain's built-in `checkpoint-hook.sh` uses both `Stop` and `PreCompact` hooks to auto-save session snapshots. The Stop hook fires after every response and tracks message count + elapsed time; the PreCompact hook fires before context compression. Both share a `/tmp/onebrain-{PPID}.state` file to coordinate and avoid duplicate checkpoints. This is the reference implementation for hooks that need to share state across event types.
+**Example — checkpoint system:** OneBrain's built-in `checkpoint-hook.sh` uses the `Stop` hook to auto-save session snapshots. It fires after every response, tracks message count + elapsed time against configurable thresholds, and writes a checkpoint file when either threshold is reached. State is kept in `/tmp/onebrain-{PPID}.state` (format: `COUNT:LAST_TS`) so the hook can accumulate counts across responses without forking a long-running process.
 
 **To add a hook:**
 


### PR DESCRIPTION
## Summary

- PreCompact hook's `systemMessage` output cannot trigger Claude tool calls during context compaction — checkpoint files were never written (broken by design, confirmed via Claude Code hook docs)
- Removed precompact mode from `checkpoint-hook.sh` and `checkpoint-hook.ps1`; added unknown-mode guard (exit 1) so bad invocations fail loudly
- Updated `update/SKILL.md` Step 4g to register Stop hook only + automatically remove any legacy PreCompact entry from existing vault `settings.json` on next `/update`
- Updated `CONTRIBUTING.md` checkpoint example to reflect Stop-only design

## Test Plan

- [ ] Verify Stop hook still fires and creates checkpoint files after N messages / N minutes
- [ ] Verify `checkpoint-hook.sh unknown-arg` exits 1 with error message
- [ ] Run `/update` on a vault that has PreCompact registered — confirm entry is removed from `settings.json`