### PR TITLE
fix(wrapup): enforce full checkpoint incorporation before marking merged (v1.8.7)

### DIFF
--- a/.claude/plugins/onebrain/.claude-plugin/plugin.json
+++ b/.claude/plugins/onebrain/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "onebrain",
-  "version": "1.8.6",
+  "version": "1.8.7",
   "description": "OneBrain — Where human and AI thinking become one. A powerful thinking partner powered by AI synergy.",
   "author": {
     "name": "OneBrain Contributors"

--- a/.claude/plugins/onebrain/INSTRUCTIONS.md
+++ b/.claude/plugins/onebrain/INSTRUCTIONS.md
@@ -193,10 +193,10 @@ The sub-agent receives the payload from Phase 1 and performs all work that requi
    - Count remaining:
      - **0 files**: skip
      - **1–5 files**: for each date group, synthesize a session log silently:
+       - **Read every checkpoint file in the group** and extract its full content
        - Count existing `YYYY-MM-DD-session-*.md` for that date → next NN (zero-padded)
-       - Write `[logs folder]/YYYY/MM/YYYY-MM-DD-session-NN.md` with frontmatter `auto-saved: true`, `synthesized_from_checkpoints: true`
-       - Sections: What We Worked On, Key Decisions, Action Items, Open Questions
-       - Set `merged: true` on each source checkpoint file
+       - Write `[logs folder]/YYYY/MM/YYYY-MM-DD-session-NN.md` with frontmatter `auto-saved: true`, `synthesized_from_checkpoints: true` — **all Key Decisions, Action Items, and Open Questions from every checkpoint must appear explicitly in the log before writing**
+       - Set `merged: true` only on checkpoint files whose content was read and incorporated above
        - Set `orphan_action: merged:{N}`
      - **>5 files**: set `orphan_action: prompt_wrapup:{N}`
 

--- a/.claude/plugins/onebrain/INSTRUCTIONS.md
+++ b/.claude/plugins/onebrain/INSTRUCTIONS.md
@@ -256,11 +256,11 @@ Before your final response in a session, silently save a session summary if ALL 
 2. No `/wrapup` was run during this session (check the logs folder for a file matching today's date with matching topics)
 
 If conditions are met:
-- Glob today's `[logs folder]/YYYY/MM/YYYY-MM-DD-checkpoint-*.md` files with `merged` absent or not `true` — read and incorporate their content as additional context
+- Glob today's `[logs folder]/YYYY/MM/YYYY-MM-DD-checkpoint-*.md` files with `merged` absent or not `true` — **read every file in this list** and fully incorporate all of their content into the session summary (not just as background context). Every unmerged checkpoint must appear in the summary before being marked merged.
 - Determine NN: count existing `[logs folder]/YYYY/MM/YYYY-MM-DD-session-*.md` files for today; NN = count + 1, zero-padded to 2 digits (01, 02, …)
-- Write to `[logs folder]/YYYY/MM/YYYY-MM-DD-session-NN.md` using the same format as `/wrapup` (see `.claude/plugins/onebrain/skills/wrapup/SKILL.md` for format)
+- Write to `[logs folder]/YYYY/MM/YYYY-MM-DD-session-NN.md` using the same format as `/wrapup` (see `.claude/plugins/onebrain/skills/wrapup/SKILL.md` for format). **Do not write the session log if any unmerged checkpoint's content is absent from the relevant sections** — every checkpoint's Key Decisions, Action Items, and Open Questions must appear explicitly in the output.
 - Add `auto-saved: true` to the frontmatter
-- Mark any incorporated checkpoint files as `merged: true`
+- Mark as `merged: true` only the checkpoint files that were read and incorporated above
 - If a genuinely useful long-term insight emerged, append it to the "Key Learnings & Patterns" section of `[agent folder]/MEMORY.md` and update the `updated:` frontmatter date to today
 - Do NOT show any output about the auto-save to the user
 

--- a/.claude/plugins/onebrain/skills/wrapup/SKILL.md
+++ b/.claude/plugins/onebrain/skills/wrapup/SKILL.md
@@ -24,8 +24,8 @@ Use these variables for all file paths in the steps below.
 1. Get today's date as `YYYY-MM-DD`. Extract `YYYY` and `MM`.
 2. Glob `[logs folder]/YYYY/MM/YYYY-MM-DD-checkpoint-*.md` (also check yesterday's folder if session started before midnight — i.e., `[logs folder]/YYYY/MM_PREV/YYYY-MM-DD_PREV-checkpoint-*.md` for the prior calendar day)
 3. Filter: keep only files where frontmatter field `merged` is absent or not `true`
-4. If any found: read each file — use their content as **additional context** when reviewing the session in Step 3. Unmerged checkpoints capture activity that may have been compressed out of current context.
-5. Store the list of found checkpoint paths for use in Step 5.
+4. If any found: **read every file in the filtered list** and extract its content. Every checkpoint must be fully incorporated into the session summary in Step 4 — not just used as background context. Checkpoints capture activity that may have been compressed out of current context; missing any of them means losing that history.
+5. Store the list of found checkpoint paths for use in Step 5. **Only paths that were read and incorporated go on this list.**
 
 If none found: continue normally.
 
@@ -54,6 +54,8 @@ Reflect on the conversation that just occurred. Identify:
 ---
 
 ## Step 4: Write the Session Log
+
+> **If checkpoints were found in Step 1:** do not write the session log until the content of every checkpoint file read in Step 1 is reflected in the sections below. All Key Decisions, Action Items, and Open Questions from checkpoints must appear explicitly — not summarized into a single line.
 
 Create `[logs folder]/YYYY/MM/YYYY-MM-DD-session-NN.md`:
 

--- a/.claude/plugins/onebrain/skills/wrapup/SKILL.md
+++ b/.claude/plugins/onebrain/skills/wrapup/SKILL.md
@@ -107,7 +107,7 @@ _Omit this section if the session had no notable friction or technique worth log
 
 ## Step 5: Mark Checkpoints as Merged
 
-If checkpoints were found in Step 1:
+If the Step 1 checkpoint list is non-empty (i.e., at least one file was read and incorporated):
 
 For each checkpoint file path stored in Step 1:
 1. Read the file's frontmatter

--- a/.claude/plugins/onebrain/skills/wrapup/SKILL.md
+++ b/.claude/plugins/onebrain/skills/wrapup/SKILL.md
@@ -24,7 +24,7 @@ Use these variables for all file paths in the steps below.
 1. Get today's date as `YYYY-MM-DD`. Extract `YYYY` and `MM`.
 2. Glob `[logs folder]/YYYY/MM/YYYY-MM-DD-checkpoint-*.md` (also check yesterday's folder if session started before midnight — i.e., `[logs folder]/YYYY/MM_PREV/YYYY-MM-DD_PREV-checkpoint-*.md` for the prior calendar day)
 3. Filter: keep only files where frontmatter field `merged` is absent or not `true`
-4. If any found: **read every file in the filtered list** and extract its content. Every checkpoint must be fully incorporated into the session summary in Step 4 — not just used as background context. Checkpoints capture activity that may have been compressed out of current context; missing any of them means losing that history.
+4. If any found: **read every file in the filtered list** and extract its content. Every checkpoint must be fully incorporated during the review in Step 3 and reflected in the log written in Step 4 — not just used as background context. Checkpoints capture activity that may have been compressed out of current context; missing any of them means losing that history.
 5. Store the list of found checkpoint paths for use in Step 5. **Only paths that were read and incorporated go on this list.**
 
 If none found: continue normally.


### PR DESCRIPTION
## Summary

- Checkpoints were marked `merged: true` even when their content wasn't incorporated into the session log — silent history loss when earlier checkpoints fell out of the context window
- Fixed `/wrapup` SKILL.md: Step 1 now requires all checkpoint paths to be explicitly read; Step 4 adds a hard gate — do not write the session log until every checkpoint's content is reflected
- Fixed Auto Session Summary in INSTRUCTIONS.md: same hard gate on the write step; `merged: true` only set on files that were read and incorporated

## Test plan

- [ ] Run a session with 2+ auto-checkpoints, then run `/wrapup` — verify all checkpoints' Key Decisions, Action Items, and Open Questions appear in the session log
- [ ] Confirm all incorporated checkpoints have `merged: true` after wrapup
- [ ] Run a session with 0 checkpoints — verify wrapup still works normally