### PR TITLE
fix: Windows-compatible timezone time command

### DIFF
--- a/.claude/plugins/onebrain/INSTRUCTIONS.md
+++ b/.claude/plugins/onebrain/INSTRUCTIONS.md
@@ -138,13 +138,13 @@ Run before responding to any user message:
    >
    > **Agent memory (on-demand only):** `[agent folder]/memory/` is searched only when the user's request relates to a past pattern. Never loaded at startup.
 
-2. Get current local time (single call, can run in parallel with step 1). Replace **both** occurrences of `[timezone]` with the value from `vault.yml` (e.g. `Asia/Bangkok`). Python is tried first — it works on macOS, Linux, and Windows. `TZ=... date` is the last-resort fallback for Unix systems without Python:
+2. Get current local time (single call, can run in parallel with step 1). Replace **both** occurrences of `[timezone]` with the value from `vault.yml` (e.g. `Asia/Bangkok`). Python is tried first — it works on macOS, Linux, and Windows (via Git Bash). `TZ=... date` is the last-resort fallback for Unix systems without Python:
    ```bash
-   python3 -c "from datetime import datetime; from zoneinfo import ZoneInfo; print(datetime.now(ZoneInfo('[timezone]')).strftime('%H:%M'))" 2>/dev/null || python -c "from datetime import datetime; from zoneinfo import ZoneInfo; print(datetime.now(ZoneInfo('[timezone]')).strftime('%H:%M'))" 2>/dev/null || TZ=[timezone] date '+%H:%M'
+   python3 -c "from datetime import datetime; from zoneinfo import ZoneInfo; print(datetime.now(ZoneInfo('[timezone]')).strftime('%H:%M'))" 2>/dev/null || TZ=[timezone] date '+%H:%M'
    ```
    Notes:
    - `zoneinfo` requires Python 3.9+. On older Pythons, that arm fails silently and falls through.
-   - `||` works in bash, CMD, and PowerShell — no backslash continuation needed.
+   - `||` works in bash and Git Bash. On Windows, run this via Git Bash — CMD and PowerShell 5.1 (the Windows default) do not support `||` as a conditional operator.
    - If all arms fail, skip the time-of-day greeting modifier and treat as the 09:00–17:00 bucket (no emoji).
 
 3. Send greeting immediately in this format:

--- a/.claude/plugins/onebrain/INSTRUCTIONS.md
+++ b/.claude/plugins/onebrain/INSTRUCTIONS.md
@@ -138,13 +138,14 @@ Run before responding to any user message:
    >
    > **Agent memory (on-demand only):** `[agent folder]/memory/` is searched only when the user's request relates to a past pattern. Never loaded at startup.
 
-2. Get current local time (single bash call, can run in parallel with step 1):
+2. Get current local time (single call, can run in parallel with step 1). Replace **both** occurrences of `[timezone]` with the value from `vault.yml` (e.g. `Asia/Bangkok`). Python is tried first — it works on macOS, Linux, and Windows. `TZ=... date` is the last-resort fallback for Unix systems without Python:
    ```bash
-   TZ=[timezone] date '+%H:%M' 2>/dev/null || \
-   python3 -c "from datetime import datetime; from zoneinfo import ZoneInfo; print(datetime.now(ZoneInfo('[timezone]')).strftime('%H:%M'))" 2>/dev/null || \
-   python -c "from datetime import datetime; from zoneinfo import ZoneInfo; print(datetime.now(ZoneInfo('[timezone]')).strftime('%H:%M'))"
+   python3 -c "from datetime import datetime; from zoneinfo import ZoneInfo; print(datetime.now(ZoneInfo('[timezone]')).strftime('%H:%M'))" 2>/dev/null || python -c "from datetime import datetime; from zoneinfo import ZoneInfo; print(datetime.now(ZoneInfo('[timezone]')).strftime('%H:%M'))" 2>/dev/null || TZ=[timezone] date '+%H:%M'
    ```
-   The first form works on macOS/Linux. The Python fallback handles Windows where `TZ=value command` syntax and `date '+%H:%M'` are not supported. Replace `[timezone]` with the value from `vault.yml` (e.g. `Asia/Bangkok`).
+   Notes:
+   - `zoneinfo` requires Python 3.9+. On older Pythons, that arm fails silently and falls through.
+   - `||` works in bash, CMD, and PowerShell — no backslash continuation needed.
+   - If all arms fail, skip the time-of-day greeting modifier and treat as the 09:00–17:00 bucket (no emoji).
 
 3. Send greeting immediately in this format:
 

--- a/.claude/plugins/onebrain/INSTRUCTIONS.md
+++ b/.claude/plugins/onebrain/INSTRUCTIONS.md
@@ -138,7 +138,13 @@ Run before responding to any user message:
    >
    > **Agent memory (on-demand only):** `[agent folder]/memory/` is searched only when the user's request relates to a past pattern. Never loaded at startup.
 
-2. Get current local time: run `TZ=[timezone] date '+%H:%M'` (single bash call, can run in parallel with step 1).
+2. Get current local time (single bash call, can run in parallel with step 1):
+   ```bash
+   TZ=[timezone] date '+%H:%M' 2>/dev/null || \
+   python3 -c "from datetime import datetime; from zoneinfo import ZoneInfo; print(datetime.now(ZoneInfo('[timezone]')).strftime('%H:%M'))" 2>/dev/null || \
+   python -c "from datetime import datetime; from zoneinfo import ZoneInfo; print(datetime.now(ZoneInfo('[timezone]')).strftime('%H:%M'))"
+   ```
+   The first form works on macOS/Linux. The Python fallback handles Windows where `TZ=value command` syntax and `date '+%H:%M'` are not supported. Replace `[timezone]` with the value from `vault.yml` (e.g. `Asia/Bangkok`).
 
 3. Send greeting immediately in this format:
 

--- a/.claude/plugins/onebrain/INSTRUCTIONS.md
+++ b/.claude/plugins/onebrain/INSTRUCTIONS.md
@@ -138,14 +138,14 @@ Run before responding to any user message:
    >
    > **Agent memory (on-demand only):** `[agent folder]/memory/` is searched only when the user's request relates to a past pattern. Never loaded at startup.
 
-2. Get current local time (single call, can run in parallel with step 1). Replace **both** occurrences of `[timezone]` with the value from `vault.yml` (e.g. `Asia/Bangkok`). Python is tried first — it works on macOS, Linux, and Windows (via Git Bash). `TZ=... date` is the last-resort fallback for Unix systems without Python:
+2. Get current local time (single call, can run in parallel with step 1). Replace **both** occurrences of `[timezone]` with the value from `vault.yml` (e.g. `Asia/Bangkok`). Python is tried first — it works on macOS, Linux, and Windows (via Git Bash). `TZ=... date` is the fallback for when Python is absent or fails:
    ```bash
    python3 -c "from datetime import datetime; from zoneinfo import ZoneInfo; print(datetime.now(ZoneInfo('[timezone]')).strftime('%H:%M'))" 2>/dev/null || TZ=[timezone] date '+%H:%M'
    ```
    Notes:
    - `zoneinfo` requires Python 3.9+. On older Pythons, that arm fails silently and falls through.
    - `||` works in bash and Git Bash. On Windows, run this via Git Bash — CMD and PowerShell 5.1 (the Windows default) do not support `||` as a conditional operator.
-   - If all arms fail, skip the time-of-day greeting modifier and treat as the 09:00–17:00 bucket (no emoji).
+   - If both arms fail, skip the time-of-day greeting modifier and treat as the 09:00–17:00 bucket (no emoji).
 
 3. Send greeting immediately in this format:
 


### PR DESCRIPTION
## Summary

- `TZ=[timezone] date '+%H:%M'` ไม่ทำงานบน Windows เพราะ `TZ=value command` syntax ไม่รองรับใน CMD/PowerShell และ `date '+%H:%M'` เป็น Unix-only
- แก้โดยใช้ `python3` เป็น primary arm (ทำงานได้บน macOS/Linux/Windows via Git Bash) และ `TZ=... date` เป็น fallback สำหรับ Unix ที่ไม่มี Python
- Command เป็น single line — ไม่ใช้ backslash continuation ที่ CMD ไม่รองรับ

## Changes

- `INSTRUCTIONS.md` step 2 (get current local time): restructured command + clarified notes

## Notes

- `||` ต้องรันใน bash / Git Bash — CMD และ PowerShell 5.1 (Windows default) ไม่รองรับ conditional `||`
- `zoneinfo` ต้องการ Python 3.9+ หาก fail จะ fall through ไป `TZ=... date` ให้เองเงียบๆ
- ถ้า fail ทั้งคู่ ให้ข้าม time-of-day modifier (treat as 09:00–17:00, no emoji)