### PR TITLE
fix: replace [[wikilinks]] with quoted names in terminal output

### DIFF
--- a/.claude/plugins/onebrain/.claude-plugin/plugin.json
+++ b/.claude/plugins/onebrain/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "onebrain",
-  "version": "1.8.10",
+  "version": "1.8.11",
   "description": "OneBrain — Where human and AI thinking become one. A powerful thinking partner powered by AI synergy.",
   "author": {
     "name": "OneBrain Contributors"

--- a/.claude/plugins/onebrain/INSTRUCTIONS.md
+++ b/.claude/plugins/onebrain/INSTRUCTIONS.md
@@ -210,8 +210,8 @@ The sub-agent receives the payload from Phase 1 and performs all work that requi
    ## Daily Briefing · Ddd DD Mon YYYY · inbox N
 
    **Tasks due today:**
-   - [ ] Task description 📅 YYYY-MM-DD (from [[Note Name]])
-   - [ ] Overdue task 📅 YYYY-MM-DD (overdue - from [[Note Name]])
+   - [ ] Task description 📅 YYYY-MM-DD (from "Note Name")
+   - [ ] Overdue task 📅 YYYY-MM-DD (overdue - from "Note Name")
 
    **Open from last session:**
    - [ ] Action item text

--- a/.claude/plugins/onebrain/skills/braindump/SKILL.md
+++ b/.claude/plugins/onebrain/skills/braindump/SKILL.md
@@ -85,4 +85,4 @@ If any item is a direct update, task, or decision for an active project in MEMOR
 ## Step 5: Confirm
 
 Say in one line:
-> Filed to `00-inbox/YYYY-MM-DD-braindump.md`. [If tasks: Extracted N tasks.] [If project link: Added note to [[Project]].]
+> Filed to `00-inbox/YYYY-MM-DD-braindump.md`. [If tasks: Extracted N tasks.] [If project link: Added note to "Project".]

--- a/.claude/plugins/onebrain/skills/capture/SKILL.md
+++ b/.claude/plugins/onebrain/skills/capture/SKILL.md
@@ -101,4 +101,4 @@ Related: [[Link 1]]
 ## Step 5: Confirm
 
 Say in one line:
-> Captured to `[file path]`. [If links added: Linked to [[Note A]], [[Note B]].]
+> Captured to `[file path]`. [If links added: Linked to "Note A", "Note B".]

--- a/.claude/plugins/onebrain/skills/connect/SKILL.md
+++ b/.claude/plugins/onebrain/skills/connect/SKILL.md
@@ -49,11 +49,11 @@ Look for:
 Group suggestions by note. For each suggestion, show:
 
 ```
-## [[Note A]] → [[Note B]]
+## Note A → Note B
 Type: Conceptual overlap
 Reason: Both discuss [shared concept]
-Suggested addition to [[Note A]]:
-  Near "...existing text..." → add [[Note B]]
+Suggested addition to "Note A":
+  Near "...existing text..." → add "Note B"
 ```
 
 Maximum 10 suggestions. Ask user to approve each batch before implementing.
@@ -68,7 +68,7 @@ For each approved suggestion:
 - Add the wikilink inline or in a "## Related" section at the bottom
 
 After implementing:
-> Added [[Note B]] link to [[Note A]].
+> Added "Note B" link to "Note A".
 
 ---
 

--- a/.claude/plugins/onebrain/skills/consolidate/SKILL.md
+++ b/.claude/plugins/onebrain/skills/consolidate/SKILL.md
@@ -62,8 +62,8 @@ Confirm routing with the user for the first 3 items. After that, proceed autonom
 > `[filename]`: This looks like [classification] : I'd route it to `[destination-folder]/`. Does that work, or would you prefer a different folder?
 
 Also show merge options if relevant:
-> I'd merge this into [[Existing Note]] : it adds context about [topic].
-> Or I could create a new note: `[[New Note Name]]`.
+> I'd merge this into "Existing Note" : it adds context about [topic].
+> Or I could create a new note: "New Note Name".
 > What do you prefer?
 
 **Mixed-content notes:** If a single inbox item contains content that belongs in multiple folders (e.g., a braindump with both personal insights and project tasks), offer to split it: create separate notes for each content type, each routed to its correct folder. Ask the user to confirm before splitting.
@@ -108,7 +108,7 @@ Ask preference once: "After processing, should I archive originals or delete the
 Report:
 > Inbox processed:
 > - Merged N items into existing notes
-> - Created N new knowledge notes: [[Note A]], [[Note B]]
+> - Created N new knowledge notes: "Note A", "Note B"
 > - Archived N originals
 > - N tasks remain open across your vault
 >

--- a/.claude/plugins/onebrain/skills/daily/SKILL.md
+++ b/.claude/plugins/onebrain/skills/daily/SKILL.md
@@ -52,8 +52,8 @@ If normal mode: Glob `[logs_folder]/**/*.md`. Find the most recent session log w
 (morning mode only — skip if no prior session found)
 
 **Tasks due today:**
-- [ ] Task description 📅 YYYY-MM-DD (from [[Note Name]])
-- [ ] Overdue task 📅 YYYY-MM-DD (overdue - from [[Note Name]])
+- [ ] Task description 📅 YYYY-MM-DD (from "Note Name")
+- [ ] Overdue task 📅 YYYY-MM-DD (overdue - from "Note Name")
 
 **Open from last session:**
 - [ ] Action item text

--- a/.claude/plugins/onebrain/skills/summarize/SKILL.md
+++ b/.claude/plugins/onebrain/skills/summarize/SKILL.md
@@ -120,8 +120,8 @@ published: [Publication date if known]
 > Summary saved to `[resources]/[subfolder]/[Title].md`.
 >
 > This looks related to:
-> - [[Related Note 1]] : [why]
-> - [[Related Note 2]] : [why]
+> - "Related Note 1" : [why]
+> - "Related Note 2" : [why]
 >
 > Want me to add links?
 
@@ -137,6 +137,6 @@ Refresh `updated` in the Bookmarks.md frontmatter. Do this silently : no confirm
 
 **Clean up bookmark:** After adding the wikilink, ask:
 
-> This URL was in your Bookmarks.md : I've linked it to [[Article Title]]. Want me to remove the bookmark entry now that you have a full summary note?
+> This URL was in your Bookmarks.md : I've linked it to "Article Title". Want me to remove the bookmark entry now that you have a full summary note?
 
 If the user confirms, remove the bookmark entry from `Bookmarks.md` and refresh `updated` in its frontmatter.

--- a/.claude/plugins/onebrain/skills/update/SKILL.md
+++ b/.claude/plugins/onebrain/skills/update/SKILL.md
@@ -34,7 +34,7 @@ Compare the local plugin version against the remote before prompting the user.
 3. Compare:
    - **Same version:** Report `OneBrain is already up to date (vX.Y.Z).` and stop — do not proceed to Step 1.
    - **Remote fetch fails:** Skip this check silently and proceed to Step 1 as normal.
-   - **Different version:** Proceed to Step 1, and include the version delta in the prompt: `Update available: vX.Y.Z → vA.B.C. Proceed?`
+   - **Different version:** Proceed to Step 1, and include the version delta in the prompt: `Update available: vX.Y.Z →  vA.B.C. Proceed?`
 
 ---
 

--- a/.claude/plugins/onebrain/skills/update/SKILL.md
+++ b/.claude/plugins/onebrain/skills/update/SKILL.md
@@ -34,7 +34,7 @@ Compare the local plugin version against the remote before prompting the user.
 3. Compare:
    - **Same version:** Report `OneBrain is already up to date (vX.Y.Z).` and stop — do not proceed to Step 1.
    - **Remote fetch fails:** Skip this check silently and proceed to Step 1 as normal.
-   - **Different version:** Proceed to Step 1, and include the version delta in the prompt: `Update available: vX.Y.Z →  vA.B.C. Proceed?`
+   - **Different version:** Proceed to Step 1, and include the version delta in the prompt: `Update available: vX.Y.Z → vA.B.C. Proceed?`
 
 ---
 

--- a/.claude/plugins/onebrain/skills/update/SKILL.md
+++ b/.claude/plugins/onebrain/skills/update/SKILL.md
@@ -22,6 +22,22 @@ Your notes, memory, and personal settings are never touched.
 
 ---
 
+## Step 0: Version Check
+
+Compare the local plugin version against the remote before prompting the user.
+
+1. Read local version from `.claude/plugins/onebrain/.claude-plugin/plugin.json`
+2. Fetch remote version:
+   ```bash
+   curl -sf "https://raw.githubusercontent.com/kengio/onebrain/main/.claude/plugins/onebrain/.claude-plugin/plugin.json"
+   ```
+3. Compare:
+   - **Same version:** Report `OneBrain is already up to date (vX.Y.Z).` and stop — do not proceed to Step 1.
+   - **Remote fetch fails:** Skip this check silently and proceed to Step 1 as normal.
+   - **Different version:** Proceed to Step 1, and include the version delta in the prompt: `Update available: vX.Y.Z → vA.B.C. Proceed?`
+
+---
+
 ## Step 1: Explain & Confirm
 
 Tell the user what will and won't be updated:


### PR DESCRIPTION
## Summary

- `[[Note Name]]` wikilinks in terminal output are unclickable and hard to read
- Replace with `"Note Name"` (double quotes) in all output templates
- Vault note templates written to disk retain `[[...]]` — required by Obsidian

## Files changed

- `INSTRUCTIONS.md` — daily briefing format (Phase 2)
- `skills/daily/SKILL.md` — daily briefing display
- `skills/braindump/SKILL.md` — confirmation message
- `skills/capture/SKILL.md` — confirmation message
- `skills/consolidate/SKILL.md` — merge suggestion + summary report
- `skills/summarize/SKILL.md` — related notes suggestions + bookmark cleanup
- `skills/connect/SKILL.md` — suggestion format + implementation confirmation