### PR TITLE
feat: auto-sort MEMORY.md Key Learnings after /recap and /doctor --fix

### DIFF
--- a/.claude/plugins/onebrain/.claude-plugin/plugin.json
+++ b/.claude/plugins/onebrain/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "onebrain",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "OneBrain — Where human and AI thinking become one. A powerful thinking partner powered by AI synergy.",
   "author": {
     "name": "OneBrain Contributors"

--- a/.claude/plugins/onebrain/INSTRUCTIONS.md
+++ b/.claude/plugins/onebrain/INSTRUCTIONS.md
@@ -144,7 +144,7 @@ OneBrain organizes knowledge across four tiers, each more compressed and longer-
 **Confidence metadata** (used in MEMORY.md Key Learnings):
 - `[conf:high]` — empirically tested or confirmed across ≥2 sessions
 - `[conf:medium]` — observed once, plausible
-- `[conf:low]` — inferred or from indirect source
+- `[conf:low]` — inferred, assumed, or from a single indirect source
 - `[verified:YYYY-MM-DD]` — date last confirmed; entries not verified in >90 days should be re-checked
 - Run `/doctor --fix` to audit all entries, repair missing or stale confidence scores in bulk, and interactively fix broken wikilinks across the vault
 

--- a/.claude/plugins/onebrain/INSTRUCTIONS.md
+++ b/.claude/plugins/onebrain/INSTRUCTIONS.md
@@ -1,4 +1,4 @@
-# OneBrain : AI Instructions for Claude Code
+# OneBrain : AI Instructions
 
 You are a personal chief of staff operating inside an Obsidian vault called OneBrain.
 Read `[agent_folder]/MEMORY.md` at the start of every session to load identity and context.

--- a/.claude/plugins/onebrain/INSTRUCTIONS.md
+++ b/.claude/plugins/onebrain/INSTRUCTIONS.md
@@ -1,5 +1,19 @@
 # OneBrain : AI Instructions
 
+## Configuration
+
+These variables are used throughout this file. Start with the defaults below, then read `vault.yml` and override with the actual values. If `vault.yml` is missing, use the defaults as-is.
+
+| Variable | vault.yml key | Default |
+|---|---|---|
+| `[agent_folder]` | `folders.agent` | `05-agent` |
+| `[logs_folder]` | `folders.logs` | `07-logs` |
+| `[inbox_folder]` | `folders.inbox` | `00-inbox` |
+| `[timezone]` | `timezone` | `Asia/Bangkok` |
+| `[qmd_collection]` | `qmd_collection` | _(absent = qmd disabled)_ |
+
+---
+
 You are a personal chief of staff operating inside an Obsidian vault called OneBrain.
 Read `[agent_folder]/MEMORY.md` at the start of every session to load identity and context.
 

--- a/.claude/plugins/onebrain/INSTRUCTIONS.md
+++ b/.claude/plugins/onebrain/INSTRUCTIONS.md
@@ -11,18 +11,17 @@ These variables are used throughout this file. Start with the defaults below, th
 | `[inbox_folder]` | `folders.inbox` | `00-inbox` |
 | `[projects_folder]` | `folders.projects` | `01-projects` |
 | `[knowledge_folder]` | `folders.knowledge` | `03-knowledge` |
-| `[timezone]` | `timezone` | `Asia/Bangkok` |
 | `[qmd_collection]` | `qmd_collection` | _(absent = qmd disabled)_ |
 
 ---
 
-You are a personal chief of staff operating inside an Obsidian vault called OneBrain.
-Read `[agent_folder]/MEMORY.md` at the start of every session to load identity and context.
-
 ## Your Role
 
+You are a personal chief of staff operating inside an Obsidian vault called OneBrain.
 Help the user capture, organize, synthesize, and retrieve knowledge inside this vault.
 Be proactive: surface connections, flag stale tasks, suggest next actions based on what you know.
+
+> Session startup (Phase 1 below) handles loading MEMORY.md automatically.
 
 ## Vault Structure
 
@@ -54,7 +53,7 @@ Use these priority markers when relevant:
 - `⏫` Medium priority
 - `🔽` Low priority
 
-Tasks live inline in project/knowledge notes : never author tasks directly in a standalone file. `TASKS.md` at the vault root is a read-only dashboard (live query blocks), not a place to create tasks.
+Tasks live embedded in the body of project/knowledge notes — never author tasks directly in a standalone file. `TASKS.md` at the vault root is a read-only dashboard (live query blocks), not a place to create tasks.
 
 ## Note Linking
 
@@ -64,7 +63,7 @@ Always use Obsidian wikilink syntax to connect related notes:
 [[Note Title|display text]]
 ```
 
-When creating a new note, suggest 2-3 relevant links to existing notes.
+When creating a new note, search the vault first (using qmd or Grep), then suggest 2-3 relevant wikilinks to existing notes.
 
 ## Note Frontmatter
 
@@ -79,8 +78,8 @@ created: YYYY-MM-DD
 ## Personality (Personalized During Onboarding)
 
 Read the "AI Personality Instructions" and "Agent Identity" sections in `[agent_folder]/MEMORY.md` and follow them.
-The agent has a name and personality set during onboarding : use the name and match the personality style.
-Until onboarding is complete, use a helpful, concise, and professional tone.
+The agent has a name and personality set during onboarding — use the name and match the personality style.
+If `[agent_folder]/MEMORY.md` has no "Agent Identity" section, onboarding has not run yet — use a helpful, concise, and professional tone until then.
 
 ## Available Workflows
 
@@ -150,7 +149,7 @@ OneBrain organizes knowledge across four tiers, each more compressed and longer-
 
 **Promotion criteria:**
 - `inbox → session log`: auto via /wrapup at session end
-- `session log → MEMORY.md`: /recap (bulk, periodic); /wrapup (1 insight per session, optional); /learn (manual, explicit)
+- `session log → MEMORY.md`: /recap (bulk, periodic); /wrapup (1 insight per session, optional)
 - `session logs + notes → knowledge note`: /distill (topic-focused, spans multiple sessions — does NOT touch MEMORY.md)
 - `knowledge note lesson → MEMORY.md`: /learn (writes to `memory/` file) → /recap (promotes to MEMORY.md Key Learnings); two hops, not direct
 - `MEMORY.md → skill`: when a workflow pattern repeats across many sessions, suggest creating a skill manually
@@ -197,15 +196,11 @@ Run before responding to any user message:
    >
    > **Agent memory (on-demand only):** `[agent_folder]/memory/` is searched only when the user's request relates to a past pattern. Never loaded at startup.
 
-2. Get current local time using `[timezone]` (from Configuration). Run in parallel with step 1. Python is tried first — it works on macOS, Linux, and Windows (via Git Bash). `TZ=... date` is the fallback for when Python is absent or fails:
+2. Get the current local machine time. Run in parallel with step 1:
    ```bash
-   python3 -c "from datetime import datetime; from zoneinfo import ZoneInfo; print(datetime.now(ZoneInfo('[timezone]')).strftime('%H:%M'))" 2>/dev/null || node -e "const d=new Date(); console.log(d.toLocaleTimeString('en-GB',{timeZone:'[timezone]',hour:'2-digit',minute:'2-digit'}))" 2>/dev/null || TZ=[timezone] date '+%H:%M' 2>/dev/null
+   python3 -c "from datetime import datetime; print(datetime.now().strftime('%H:%M'))" 2>/dev/null || node -e "const d=new Date(); console.log(d.toLocaleTimeString('en-GB',{hour:'2-digit',minute:'2-digit'}))" 2>/dev/null || date '+%H:%M' 2>/dev/null
    ```
-   Notes:
-   - `zoneinfo` requires Python 3.9+. On older Pythons, that arm fails silently and falls through.
-   - Node.js fallback works on Windows, macOS, and Linux without any modules.
-   - `TZ=... date` is a last resort for Unix-only environments without Node.
-   - If all arms fail, skip the time-of-day greeting modifier and treat as the 09:00–17:00 bucket (no emoji).
+   If all arms fail, skip the time-of-day greeting modifier and treat as the 09:00–17:00 bucket (no emoji).
 
 3. Send greeting immediately in this format:
 
@@ -213,6 +208,10 @@ Run before responding to any user message:
    **OneBrain vX.X.X**
    [greeting] [name] [emoji]
    ```
+
+   - `vX.X.X` = version from `plugin.json`; omit if file absent
+   - `[name]` = agent name from the "Agent Identity" section of MEMORY.md; omit if not found
+   - `[greeting]` and `[emoji]` come from the time-of-day table below
 
    Time-of-day mapping (adapt greeting words to user's language at runtime):
 
@@ -232,7 +231,7 @@ Run before responding to any user message:
 4. Dispatch a **background sub-agent** (`run_in_background: true`) with this prompt payload:
 
    ```
-   vault_root: [absolute vault root path]
+   vault_root: [absolute path to the directory containing vault.yml]
    agent_folder: [agent_folder]
    logs_folder: [logs_folder]
    inbox_folder: [inbox_folder]
@@ -247,7 +246,7 @@ Main agent is now ready to respond to the user.
 
 ### Phase 2 : Background Sub-agent
 
-The sub-agent receives the payload from Phase 1 and performs all work that requires multiple file reads. It does NOT read MEMORY.md : `active_tasks` are passed in the prompt.
+The sub-agent receives the payload from Phase 1 and performs all work that requires multiple file reads. It does NOT read MEMORY.md — `active_tasks` are passed in the prompt. All folder values in the payload are relative to `vault_root`; construct full paths as `vault_root/folder_value`.
 
 **Sub-agent steps:**
 
@@ -263,8 +262,9 @@ The sub-agent receives the payload from Phase 1 and performs all work that requi
    - Include the source note name for each task
 
    **Open from last session:**
-   - Glob `[logs_folder]/**/*.md`, find the most recent session log whose `date` frontmatter is **before today**
-   - Extract unchecked `- [ ]` items from its `## Action Items` section
+   - Glob `[logs_folder]/**/*.md` matching filename pattern `YYYY-MM-DD-session-*.md`; find the most recent one whose `date` frontmatter is **before today**
+   - If no such file exists, skip this section
+   - Otherwise extract unchecked `- [ ]` items from its `## Action Items` section
 
    Assemble into this format (adapt language to match the user's):
    ```
@@ -295,7 +295,7 @@ The sub-agent receives the payload from Phase 1 and performs all work that requi
    - **0 files** : nothing to do; set `orphan_action: none`
    - **1–5 files** : auto-synthesize silently, per date group:
      1. Read every checkpoint file in the group and extract its full content
-     2. Count existing session logs for that date (`YYYY-MM-DD-session-*.md`) → next NN (zero-padded)
+     2. Count existing session logs for that date (`YYYY-MM-DD-session-*.md`) → next NN, zero-padded to 2 digits (e.g. `01`, `02`)
      3. Write a session log to `[logs_folder]/YYYY/MM/YYYY-MM-DD-session-NN.md` with frontmatter fields `auto-saved: true` and `synthesized_from_checkpoints: true`
         - **Every Key Decision, Action Item, and Open Question from every checkpoint must appear explicitly in the log** : do not write the file until all checkpoint content is reflected
      4. For each checkpoint file whose content was read and incorporated: set `merged: true` in its frontmatter
@@ -328,17 +328,16 @@ When the user asks you to recall something (a decision, preference, fact, or pas
 
 Stop as soon as you find a confident answer. If the answer spans multiple layers, synthesize across them.
 
-At the end of every session:
-- Session summaries are auto-saved to the logs folder when the session ends (if 3+ exchanges occurred). Users can still run `/wrapup` manually for a visible summary.
-
 ### Auto Session Summary
+
+Session summaries are auto-saved silently at session end. Users can still run `/wrapup` manually for a visible summary.
 
 Before your final response in a session, silently save a session summary if ALL of these are true:
 1. The session had 3 or more user↔assistant exchanges
 2. No `/wrapup` was run during this session (check the logs folder for a file matching today's date with matching topics)
 
 If conditions are met:
-- Glob today's `[logs_folder]/YYYY/MM/YYYY-MM-DD-checkpoint-*.md` files with `merged` absent or not `true` : **read every file in this list** and fully incorporate all of their content into the session summary (not just as background context). Every unmerged checkpoint must appear in the summary before being marked merged.
+- Glob today's checkpoint files — substitute today's actual date for `YYYY`, `MM`, `YYYY-MM-DD` in the path: `[logs_folder]/YYYY/MM/YYYY-MM-DD-checkpoint-*.md`. Keep files where `merged` is absent or not `true` : **read every file in this list** and fully incorporate all of their content into the session summary (not just as background context). Every unmerged checkpoint must appear in the summary before being marked merged.
 - Determine NN: count existing `[logs_folder]/YYYY/MM/YYYY-MM-DD-session-*.md` files for today; NN = count + 1, zero-padded to 2 digits (01, 02, …). **Verify** `YYYY-MM-DD-session-NN.md` does not already exist before writing (the Phase 2 sub-agent may have written one concurrently); if it does, increment NN until a free slot is found.
 - Write to `[logs_folder]/YYYY/MM/YYYY-MM-DD-session-NN.md` using the same format as `/wrapup` (see `.claude/plugins/onebrain/skills/wrapup/SKILL.md` for format). **Do not write the session log if any unmerged checkpoint's content is absent from the relevant sections** : every checkpoint's Key Decisions, Action Items, and Open Questions must appear explicitly in the output.
 - Add `auto-saved: true` to the frontmatter; if the checkpoint glob returned at least one file and all were successfully incorporated, also add `synthesized_from_checkpoints: true` — omit this field entirely if no checkpoints were found or incorporated
@@ -348,14 +347,14 @@ If conditions are met:
 
 ## File Naming Conventions
 
-- Knowledge notes: `03-knowledge/[subfolder]/Topic Name.md` (title case, subfolder in kebab-case)
+- Knowledge notes: `[knowledge_folder]/[subfolder]/Topic Name.md` (title case, subfolder in kebab-case)
 - Area notes: `02-areas/[subfolder]/Topic Name.md` (subfolder in kebab-case)
 - Resource notes: `04-resources/[subfolder]/Topic Name.md` (subfolder in kebab-case)
-- Project notes: `01-projects/[subfolder]/Project Name.md` (subfolder in kebab-case)
+- Project notes: `[projects_folder]/[subfolder]/Project Name.md` (subfolder in kebab-case)
 - Archive items: `06-archive/YYYY/MM/filename.md` (organized by date archived)
 - Session logs: `[logs_folder]/YYYY/MM/YYYY-MM-DD-session-NN.md`
 - Checkpoints: `[logs_folder]/YYYY/MM/YYYY-MM-DD-checkpoint-NN.md` (auto-generated by hooks, not manual)
-- Inbox items: `00-inbox/YYYY-MM-DD-topic.md` (flat, no subfolders)
+- Inbox items: `[inbox_folder]/YYYY-MM-DD-topic.md` (flat, no subfolders)
 
 **Subfolder rules:**
 - Always kebab-case (lowercase, hyphens not spaces): `machine-learning`, `web-development`
@@ -370,7 +369,7 @@ Different commands have different verbosity expectations. Match output to the pr
 | Profile | Commands | Behavior |
 |---------|----------|----------|
 | **Capture** | `/capture`, `/braindump`, `/bookmark`, `/learn` | Write the note, confirm done in 1 line. No elaboration. |
-| **Automated** | cron jobs, auto wrapup, `/wrapup` | Structured output only (bullets/sections). No commentary. Under 300 words. |
+| **Automated** | cron jobs, Auto Session Summary, `/wrapup` | Structured output only (bullets/sections). No commentary. Under 300 words. |
 | **Interactive** | `/research`, `/connect`, `/consolidate`, `/reading-notes`, `/weekly`, `/distill`, `/recap` | Normal verbosity : depth matches task complexity. |
 | **Diagnostic** | `/doctor` | Structured report output. No meta-commentary. Lead with findings. |
 | **Config/Setup** | `/onboarding`, `/tasks`, `/moc`, `/qmd` | Confirm actions taken. No verbose explanation unless asked. |

--- a/.claude/plugins/onebrain/INSTRUCTIONS.md
+++ b/.claude/plugins/onebrain/INSTRUCTIONS.md
@@ -9,6 +9,8 @@ These variables are used throughout this file. Start with the defaults below, th
 | `[agent_folder]` | `folders.agent` | `05-agent` |
 | `[logs_folder]` | `folders.logs` | `07-logs` |
 | `[inbox_folder]` | `folders.inbox` | `00-inbox` |
+| `[projects_folder]` | `folders.projects` | `01-projects` |
+| `[knowledge_folder]` | `folders.knowledge` | `03-knowledge` |
 | `[timezone]` | `timezone` | `Asia/Bangkok` |
 | `[qmd_collection]` | `qmd_collection` | _(absent = qmd disabled)_ |
 
@@ -130,12 +132,10 @@ Without embeddings, `mcp__plugin_onebrain_qmd__query` uses BM25 keyword search o
 Whenever you add, edit, or delete any file in the vault, check first whether qmd is available by looking for `mcp__plugin_onebrain_qmd__query` in your tool list. If it is available, immediately run:
 
 ```bash
-qmd update -c <collection>
+qmd update -c [qmd_collection]
 ```
 
-where `<collection>` is the collection name from `vault.yml` (`qmd_collection` field, e.g. `ob-1-441565`). This keeps the search index in sync and prevents stale entries from appearing in results.
-
-If qmd tools are not available, or if `qmd_collection` is not present in `vault.yml`, skip this step entirely.
+This keeps the search index in sync. If qmd tools are not available, or `[qmd_collection]` is absent, skip this step entirely.
 
 ## Memory Tier Model
 
@@ -144,8 +144,8 @@ OneBrain organizes knowledge across four tiers, each more compressed and longer-
 | Tier | Storage | Lifespan | Promoted by |
 |---|---|---|---|
 | **Working memory** | `00-inbox/` + current session | Hours | /wrapup, /consolidate |
-| **Episodic memory** | `07-logs/` session logs | Days–weeks | /recap |
-| **Semantic memory** | `05-agent/MEMORY.md` Key Learnings | Months | /recap, /wrapup (1 insight), /learn |
+| **Episodic memory** | `[logs_folder]/` session logs | Days–weeks | /recap |
+| **Semantic memory** | `[agent_folder]/MEMORY.md` Key Learnings | Months | /recap, /wrapup (1 insight), /learn |
 | **Procedural memory** | `.claude/plugins/onebrain/skills/` | Permanent | Manual (/learn signals workflow pattern) |
 
 **Promotion criteria:**
@@ -188,8 +188,8 @@ Session startup runs in two phases. Phase 1 greets the user immediately. Phase 2
 
 Run before responding to any user message:
 
-1. Read `vault.yml`, `.claude/plugins/onebrain/.claude-plugin/plugin.json`, and `[agent_folder]/MEMORY.md` **in parallel**.
-   - `vault.yml`: get `folders`, `timezone` (default: `Asia/Bangkok` if absent)
+1. Read `vault.yml`, `.claude/plugins/onebrain/.claude-plugin/plugin.json`, and `[agent_folder]/MEMORY.md` **in parallel**. Use Configuration defaults for any variable while `vault.yml` is loading; override with actual values once it resolves.
+   - `vault.yml`: override the **Configuration** variables at the top of this file with actual values
    - `plugin.json`: get `version` for greeting; if file absent, skip version
    - `MEMORY.md`: load identity, personality, active projects and their task dates
 
@@ -197,7 +197,7 @@ Run before responding to any user message:
    >
    > **Agent memory (on-demand only):** `[agent_folder]/memory/` is searched only when the user's request relates to a past pattern. Never loaded at startup.
 
-2. Get current local time (single call, can run in parallel with step 1). Replace **both** occurrences of `[timezone]` with the value from `vault.yml` (e.g. `Asia/Bangkok`). Python is tried first — it works on macOS, Linux, and Windows (via Git Bash). `TZ=... date` is the fallback for when Python is absent or fails:
+2. Get current local time using `[timezone]` (from Configuration). Run in parallel with step 1. Python is tried first — it works on macOS, Linux, and Windows (via Git Bash). `TZ=... date` is the fallback for when Python is absent or fails:
    ```bash
    python3 -c "from datetime import datetime; from zoneinfo import ZoneInfo; print(datetime.now(ZoneInfo('[timezone]')).strftime('%H:%M'))" 2>/dev/null || node -e "const d=new Date(); console.log(d.toLocaleTimeString('en-GB',{timeZone:'[timezone]',hour:'2-digit',minute:'2-digit'}))" 2>/dev/null || TZ=[timezone] date '+%H:%M' 2>/dev/null
    ```
@@ -233,11 +233,11 @@ Run before responding to any user message:
 
    ```
    vault_root: [absolute vault root path]
-   agent_folder: [from vault.yml folders.agent]
-   logs_folder: [from vault.yml folders.logs]
-   inbox_folder: [from vault.yml folders.inbox]
-   knowledge_folder: [from vault.yml folders.knowledge]
-   projects_folder: [from vault.yml folders.projects, default 01-projects]
+   agent_folder: [agent_folder]
+   logs_folder: [logs_folder]
+   inbox_folder: [inbox_folder]
+   knowledge_folder: [knowledge_folder]
+   projects_folder: [projects_folder]
    today: YYYY-MM-DD
    active_tasks: [task list with dates extracted from MEMORY.md Active Projects section]
    is_weekend: true|false

--- a/.claude/plugins/onebrain/INSTRUCTIONS.md
+++ b/.claude/plugins/onebrain/INSTRUCTIONS.md
@@ -91,7 +91,7 @@ These workflows are documented in `.claude/plugins/onebrain/skills/`:
 | `/wrapup` | `wrapup/SKILL.md` | Wrap up session → session log | user says bye or signals end of session |
 | `/learn` | `learn/SKILL.md` | Teach the agent : facts or behavioral preferences | user tells the agent to remember or learn something |
 | `/clone` | `clone/SKILL.md` | Package agent context for vault transfer | (manual only) |
-| `/reorganize` | `reorganize/SKILL.md` | Migrate flat notes into subfolders (one-time) | : (manual only, high impact) |
+| `/reorganize` | `reorganize/SKILL.md` | Migrate flat notes into subfolders (one-time) | (manual only, high impact) |
 | `/qmd` | `qmd/SKILL.md` | Set up and manage qmd search index | (manual only) |
 | `/update` | `update/SKILL.md` | Update system files from GitHub | (manual only) |
 | `/doctor` | `doctor/SKILL.md` | Vault + config health check: broken links, orphan notes, stale MEMORY.md entries, plugin config | user asks to check vault health, diagnose issues, or run /doctor |

--- a/.claude/plugins/onebrain/skills/daily/SKILL.md
+++ b/.claude/plugins/onebrain/skills/daily/SKILL.md
@@ -18,7 +18,7 @@ Read `vault.yml` and extract:
 
 Count inbox items: Glob `[inbox_folder]/*.md` and store the count as `[inbox_count]`.
 
-Determine today's date (`YYYY-MM-DD`) and current local time in Asia/Bangkok:
+Determine today's date (`YYYY-MM-DD`) and current local time (local machine time):
 - **Morning mode**: before 10:00
 - **Normal mode**: 10:00 and later
 

--- a/.claude/plugins/onebrain/skills/doctor/SKILL.md
+++ b/.claude/plugins/onebrain/skills/doctor/SKILL.md
@@ -195,7 +195,13 @@ After Pass B, report:
 
 ### Final step
 
-After all fix passes complete (whether or not all passes ran), if `qmd_collection` is set in vault.yml, run:
+After all fix passes complete (whether or not all passes ran), if Pass A made any changes to MEMORY.md, re-sort the `## Key Learnings & Patterns` section in-place:
+1. `[conf:high]` entries first, newest → oldest
+2. `[conf:medium]` entries next, newest → oldest
+3. `[conf:low]` entries last, newest → oldest
+4. Preserve the `<!-- conf:high -->` / `<!-- conf:medium -->` / `<!-- conf:low -->` comment markers as group separators
+
+Then, if `qmd_collection` is set in vault.yml, run:
 ```bash
 qmd update -c [qmd_collection]
 ```

--- a/.claude/plugins/onebrain/skills/doctor/SKILL.md
+++ b/.claude/plugins/onebrain/skills/doctor/SKILL.md
@@ -133,7 +133,7 @@ Collect auto-fixable issues from the Key Learnings scan:
 
 If 0 issues: skip this pass, note "No MEMORY.md issues to fix."
 
-Otherwise, confirm with AskUserQuestion:
+Otherwise, confirm with AskUserQuestion (if user declines, skip this pass — no changes written):
 > Found N MEMORY.md issues. Apply confidence score fixes?
 > - Add missing [conf:medium] baseline to untagged entries
 > - Downgrade stale confidence scores
@@ -195,7 +195,7 @@ After Pass B, report:
 
 ### Final step
 
-After all fix passes complete (whether or not all passes ran), if Pass A made any changes to MEMORY.md, re-sort the `## Key Learnings & Patterns` section in-place:
+After all fix passes complete (whether or not all passes ran), if Pass A actually wrote changes to MEMORY.md (i.e., user confirmed and fixes were applied — not skipped or declined), re-sort the `## Key Learnings & Patterns` section in-place:
 1. `[conf:high]` entries first, newest → oldest
 2. `[conf:medium]` entries next, newest → oldest
 3. `[conf:low]` entries last, newest → oldest
@@ -203,7 +203,7 @@ After all fix passes complete (whether or not all passes ran), if Pass A made an
 5. If a conf group has no entries, omit that group's comment marker entirely rather than leaving an empty section
 6. Entries with no `[conf:...]` tag: treat as `[conf:medium]` for sorting purposes only (do not add a tag)
 
-Then, if `qmd_collection` is set in vault.yml, run:
+Then, if any files were written to disk (Pass A or Pass B made confirmed changes), and `qmd_collection` is set in vault.yml, run:
 ```bash
 qmd update -c [qmd_collection]
 ```

--- a/.claude/plugins/onebrain/skills/doctor/SKILL.md
+++ b/.claude/plugins/onebrain/skills/doctor/SKILL.md
@@ -75,6 +75,7 @@ Run all applicable checks based on flags (default: all). Collect findings before
 **vault.yml:**
 - Verify all declared folder paths exist in the vault
 - Check `qmd_collection` is present (warn if absent — qmd search won't work)
+- Check if `timezone` key is present — it is no longer used; warn the user to remove it
 
 **plugin.json:**
 - Read `.claude/plugins/onebrain/.claude-plugin/plugin.json`
@@ -105,6 +106,7 @@ Use this format:
 🟢 vault.yml: OK
 🟢 plugin.json: OK (vX.X.X)
 🔴 qmd_collection: missing — qmd search will not work
+🟡 vault.yml: `timezone` key found — no longer used, safe to remove
 
 ---
 N issues found (M critical 🔴, P warnings 🟡)

--- a/.claude/plugins/onebrain/skills/doctor/SKILL.md
+++ b/.claude/plugins/onebrain/skills/doctor/SKILL.md
@@ -213,7 +213,7 @@ After all fix passes complete (whether or not all passes ran), if Pass A actuall
 5. If a conf group has no entries, omit that group's comment marker entirely rather than leaving an empty section
 6. Entries with no `[conf:...]` tag: treat as `[conf:medium]` for sorting purposes only (do not add a tag)
 
-Then, if any files were written to disk (Pass A or Pass B made confirmed changes), and `qmd_collection` is set in vault.yml, run:
+Then, if any files were written to disk (Pass A or Pass B made confirmed changes — Pass C edits vault.yml, which is not a markdown note and is not indexed by qmd), and `qmd_collection` is set in vault.yml, run:
 ```bash
 qmd update -c [qmd_collection]
 ```

--- a/.claude/plugins/onebrain/skills/doctor/SKILL.md
+++ b/.claude/plugins/onebrain/skills/doctor/SKILL.md
@@ -74,7 +74,6 @@ Run all applicable checks based on flags (default: all). Collect findings before
 
 **vault.yml:**
 - Verify all declared folder paths exist in the vault
-- Check `timezone` is a non-empty string
 - Check `qmd_collection` is present (warn if absent — qmd search won't work)
 
 **plugin.json:**

--- a/.claude/plugins/onebrain/skills/doctor/SKILL.md
+++ b/.claude/plugins/onebrain/skills/doctor/SKILL.md
@@ -122,7 +122,7 @@ If no issues:
 
 ## Step 4: Auto-fix (`--fix` flag only)
 
-Run both fix passes. Each pass confirms with the user before writing.
+Run all fix passes. Each pass confirms with the user before writing.
 
 ### Pass A: MEMORY.md confidence scores
 
@@ -193,6 +193,15 @@ For each unique broken link name:
 After Pass B, report:
 > Fixed N broken links across M files. P links could not be matched automatically — fix manually.
 > Modified files: [list of file paths that were changed]
+
+### Pass C: Deprecated vault.yml keys
+
+If `timezone` key was found in vault.yml (from Step 2 config check): confirm with AskUserQuestion:
+> `timezone` in vault.yml is no longer used — the agent now uses local machine time. Remove it?
+
+If **yes**: remove the `timezone` line from vault.yml. If **no**: leave as-is.
+
+If `timezone` was not found: skip this pass, note "No deprecated keys to clean up."
 
 ### Final step
 

--- a/.claude/plugins/onebrain/skills/doctor/SKILL.md
+++ b/.claude/plugins/onebrain/skills/doctor/SKILL.md
@@ -199,7 +199,9 @@ After all fix passes complete (whether or not all passes ran), if Pass A made an
 1. `[conf:high]` entries first, newest → oldest
 2. `[conf:medium]` entries next, newest → oldest
 3. `[conf:low]` entries last, newest → oldest
-4. Preserve the `<!-- conf:high -->` / `<!-- conf:medium -->` / `<!-- conf:low -->` comment markers as group separators
+4. Preserve each `<!-- conf:* ... -->` comment line exactly as-is (the markers may have additional text after the tier name, e.g. `<!-- conf:high — empirically confirmed -->`); do not strip or rewrite them
+5. If a conf group has no entries, omit that group's comment marker entirely rather than leaving an empty section
+6. Entries with no `[conf:...]` tag: treat as `[conf:medium]` for sorting purposes only (do not add a tag)
 
 Then, if `qmd_collection` is set in vault.yml, run:
 ```bash

--- a/.claude/plugins/onebrain/skills/onboarding/SKILL.md
+++ b/.claude/plugins/onebrain/skills/onboarding/SKILL.md
@@ -205,7 +205,6 @@ updated: [TODAY'S DATE]
 
 **Tone:** [tone]
 **Detail level:** [detail_level]
-**Timezone:** [not set]
 
 ## Goals & Focus Areas
 

--- a/.claude/plugins/onebrain/skills/recap/SKILL.md
+++ b/.claude/plugins/onebrain/skills/recap/SKILL.md
@@ -102,7 +102,7 @@ After dedup, if no new insights remain (all were dropped as identical/subset —
 
 Exit : do not proceed to Step 5, 6, 7, or 8.
 
-If merges occurred in Step 4 (i.e., MEMORY.md was modified in-place) but no new entries remain to append: skip Step 5, but continue to Steps 6, 7, and 8.
+If merges occurred in Step 4 (i.e., MEMORY.md was modified in-place) but no new entries remain to append: skip the append portion of Step 5 (do not write new bullets), but still run the archive offer in Step 5, then continue to Steps 6, 7, and 8.
 
 ---
 

--- a/.claude/plugins/onebrain/skills/recap/SKILL.md
+++ b/.claude/plugins/onebrain/skills/recap/SKILL.md
@@ -143,7 +143,9 @@ After writing all entries, re-sort the `## Key Learnings & Patterns` section in-
 1. `[conf:high]` entries first, newest → oldest
 2. `[conf:medium]` entries next, newest → oldest
 3. `[conf:low]` entries last, newest → oldest
-4. Preserve the `<!-- conf:high -->` / `<!-- conf:medium -->` / `<!-- conf:low -->` comment markers as group separators
+4. Preserve each `<!-- conf:* ... -->` comment line exactly as-is (the markers may have additional text after the tier name, e.g. `<!-- conf:high — empirically confirmed -->`); do not strip or rewrite them
+5. If a conf group has no entries, omit that group's comment marker entirely rather than leaving an empty section
+6. Entries with no `[conf:...]` tag: treat as `[conf:medium]` for sorting purposes only (do not add a tag)
 
 ---
 

--- a/.claude/plugins/onebrain/skills/recap/SKILL.md
+++ b/.claude/plugins/onebrain/skills/recap/SKILL.md
@@ -127,7 +127,8 @@ Set `[verified:YYYY-MM-DD]` to today's date when first written. For merged entri
 Also update the `updated:` field in the frontmatter to today's date.
 
 **Archive eligible `memory/` files:**
-"Successfully promoted" includes: (a) entries appended as new, (b) entries merged into an existing entry ("extends or refines"), and (c) entries used to supersede an existing entry ("contradicts" case) — all three count as promoted. For each file in `new_memory_files` that was promoted by either path (not dropped as identical/subset), offer to archive it using AskUserQuestion:
+This step runs regardless of whether new entries were appended or only in-place merges/supersessions occurred.
+"Successfully promoted" includes: (a) entries appended as new, (b) entries merged into an existing entry ("extends or refines"), and (c) entries used to supersede an existing entry ("contradicts" case) — all three count as promoted. For each file in `new_memory_files` that was promoted by any path (not dropped as identical/subset), offer to archive it using AskUserQuestion:
 > Promoted N patterns from `memory/` to MEMORY.md. These files can now be archived:
 > - `memory/YYYY-MM-DD-slug.md` — [one-line summary]
 > Archive them? (yes / no)
@@ -161,11 +162,19 @@ Count the total lines in `[agent_folder]/MEMORY.md`. If the count exceeds 180:
 
 ## Step 8: Confirm
 
+Use the appropriate message based on what occurred:
+
+If new entries were appended (with or without merges):
 ```
 Recap complete. Added N new insights to MEMORY.md (M already captured : skipped).
 ```
 
-If nothing new was appended (all were deduped — no merges, no new entries):
+If only in-place merges or supersessions occurred (no new appends):
+```
+Recap complete. Updated M existing entries in MEMORY.md (merged or superseded). No new insights appended.
+```
+
+If nothing was written (all were deduped as identical/subset — no merges, no new entries):
 ```
 Recap complete. No new insights to add : all N insights already captured in MEMORY.md.
 ```

--- a/.claude/plugins/onebrain/skills/recap/SKILL.md
+++ b/.claude/plugins/onebrain/skills/recap/SKILL.md
@@ -97,10 +97,12 @@ Apply this dedup table to **all** candidate entries — whether sourced from ses
 
 To merge: rewrite the existing bullet in-place to incorporate the new detail, keeping the original date.
 
-After dedup, if no new insights remain:
+After dedup, if no new insights remain (all were dropped as identical/subset — meaning no merges and no new appends occurred):
 > All insights are already captured in MEMORY.md : nothing new to add.
 
-Exit : do not write.
+Exit : do not proceed to Step 5, 6, 7, or 8.
+
+If merges or supersessions occurred in Step 4 (i.e., MEMORY.md was modified in-place) but no new entries remain to append: skip Step 5, but continue to Steps 6, 7, and 8.
 
 ---
 
@@ -139,7 +141,7 @@ If **no**: leave in place — the file remains as the detailed version.
 
 ## Step 6: Sort Key Learnings
 
-After writing all entries, re-sort the `## Key Learnings & Patterns` section in-place:
+If MEMORY.md was modified in Step 4 (merges, supersessions) or Step 5 (new appends), re-sort the `## Key Learnings & Patterns` section in-place:
 1. `[conf:high]` entries first, newest → oldest
 2. `[conf:medium]` entries next, newest → oldest
 3. `[conf:low]` entries last, newest → oldest
@@ -163,7 +165,7 @@ Count the total lines in `[agent_folder]/MEMORY.md`. If the count exceeds 180:
 Recap complete. Added N new insights to MEMORY.md (M already captured : skipped).
 ```
 
-If nothing was written (all deduped):
+If nothing new was appended (all were deduped — no merges, no new entries):
 ```
 Recap complete. No new insights to add : all N insights already captured in MEMORY.md.
 ```

--- a/.claude/plugins/onebrain/skills/recap/SKILL.md
+++ b/.claude/plugins/onebrain/skills/recap/SKILL.md
@@ -102,7 +102,7 @@ After dedup, if no new insights remain (all were dropped as identical/subset —
 
 Exit : do not proceed to Step 5, 6, 7, or 8.
 
-If merges or supersessions occurred in Step 4 (i.e., MEMORY.md was modified in-place) but no new entries remain to append: skip Step 5, but continue to Steps 6, 7, and 8.
+If merges occurred in Step 4 (i.e., MEMORY.md was modified in-place) but no new entries remain to append: skip Step 5, but continue to Steps 6, 7, and 8.
 
 ---
 
@@ -169,9 +169,9 @@ If new entries were appended (with or without merges):
 Recap complete. Added N new insights to MEMORY.md (M already captured : skipped).
 ```
 
-If only in-place merges or supersessions occurred (no new appends):
+If only in-place merges occurred (no new appends):
 ```
-Recap complete. Updated M existing entries in MEMORY.md (merged or superseded). No new insights appended.
+Recap complete. Updated M existing entries in MEMORY.md (merged). No new insights appended.
 ```
 
 If nothing was written (all were deduped as identical/subset — no merges, no new entries):

--- a/.claude/plugins/onebrain/skills/recap/SKILL.md
+++ b/.claude/plugins/onebrain/skills/recap/SKILL.md
@@ -137,7 +137,17 @@ If **no**: leave in place — the file remains as the detailed version.
 
 ---
 
-## Step 6: Overflow check
+## Step 6: Sort Key Learnings
+
+After writing all entries, re-sort the `## Key Learnings & Patterns` section in-place:
+1. `[conf:high]` entries first, newest → oldest
+2. `[conf:medium]` entries next, newest → oldest
+3. `[conf:low]` entries last, newest → oldest
+4. Preserve the `<!-- conf:high -->` / `<!-- conf:medium -->` / `<!-- conf:low -->` comment markers as group separators
+
+---
+
+## Step 7: Overflow check
 
 Count the total lines in `[agent_folder]/MEMORY.md`. If the count exceeds 180:
 
@@ -145,7 +155,7 @@ Count the total lines in `[agent_folder]/MEMORY.md`. If the count exceeds 180:
 
 ---
 
-## Step 7: Confirm
+## Step 8: Confirm
 
 ```
 Recap complete. Added N new insights to MEMORY.md (M already captured : skipped).

--- a/.claude/plugins/onebrain/skills/update/SKILL.md
+++ b/.claude/plugins/onebrain/skills/update/SKILL.md
@@ -254,24 +254,6 @@ The Stop hook must be registered in the vault's `.claude/settings.json` : it is 
 
 ---
 
-## Step 4h: Ensure timezone in vault.yml (If Missing)
-
-Read `vault.yml`. If a `timezone:` top-level key is **absent**, insert it immediately after the `method:` line:
-
-```yaml
-method: onebrain
-timezone: Asia/Bangkok
-```
-
-Rules:
-- **Never overwrite existing value** : only add if absent
-- Insert immediately after the line containing `method:`. If `method:` is absent, append as a top-level key before the `folders:` block.
-- If `vault.yml` does not exist: skip silently
-- Report: "Added `timezone: Asia/Bangkok` to `vault.yml`. Edit the `timezone:` key in `vault.yml` if your local timezone is different."
-- If already present: skip silently (no output)
-
----
-
 ## Step 5: Report
 
 Show a final summary of everything updated and migrated. Then suggest:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ Good contributions include:
 ├── .claude-plugin/
 │   └── plugin.json                      Plugin manifest (name, version, description)
 ├── INSTRUCTIONS.md                      Agent instructions — loaded by CLAUDE.md/GEMINI.md/AGENTS.md
-├── skills/                              One directory per slash command (18 skills)
+├── skills/                              One directory per slash command (24 skills)
 │   └── [name]/
 │       └── SKILL.md                     The skill prompt — what the AI follows when invoked
 ├── hooks/


### PR DESCRIPTION
## Summary

This PR delivers three independent improvements to OneBrain and one system-wide refactor:

### `/recap` — Auto-sort Key Learnings after writing (Step 6)
After appending new learnings to `MEMORY.md`, sort the Key Learnings section in place:
- Order: `conf:high` → `conf:medium` → `conf:low`
- Within each group: newest first (by date prefix)
- Preserve `<!-- conf:* ... -->` comment markers as-is
- Omit empty groups entirely
- Untagged entries treated as `conf:medium` for sort order

### `/doctor --fix` — Same sort, applied conditionally (Final step)
After Pass A runs fixes, if any changes were made, apply the same Key Learnings sort to `MEMORY.md`. Keeps the file tidy after bulk repairs.

### INSTRUCTIONS.md — Comprehensive refactor
- Centralized config variables table with defaults (vault root, folders, timezone removed)
- Removed `timezone` config variable — the agent now uses local machine time directly (no `TZ=` overrides, no `ZoneInfo` imports, no vault.yml key required)
- Clarified all `[variable]` references throughout Phase 1 and Phase 2
- Fixed orphaned intro section
- Improved Phase 1/2 startup clarity
- File naming conventions now reference config vars consistently

### Timezone cleanup (all skills)
Removed every remaining `timezone` reference across skill files following the INSTRUCTIONS.md refactor:
- `onboarding/SKILL.md`: removed `Timezone` field from MEMORY.md template
- `doctor/SKILL.md`: removed `timezone` vault.yml config check
- `update/SKILL.md`: removed Step 4h (auto-add timezone to vault.yml)
- `daily/SKILL.md`: replaced hardcoded `Asia/Bangkok` with "local machine time"

### CONTRIBUTING.md
Updated skill count: 18 → 24.

### plugin.json
Version bump: 1.9.0 → 1.9.1.

## Test plan
- [ ] Run `/recap` — verify Key Learnings are sorted after new entries are appended
- [ ] Run `/doctor --fix` — verify sort runs when Pass A made changes, skipped when no changes
- [ ] Confirm `<!-- conf:* -->` comment markers are preserved after sort
- [ ] Confirm empty confidence groups are omitted from output
- [ ] Run `/daily` — verify it uses local machine time (no `Asia/Bangkok` reference)
- [ ] Run `/update` — confirm Step 4h no longer adds timezone to vault.yml
- [ ] Run `/doctor` — confirm no timezone config check in report
- [ ] Run `/onboarding` — confirm MEMORY.md template has no Timezone field
- [ ] Verify no `timezone`, `TZ=`, `ZoneInfo`, or `Asia/Bangkok` remain in any skill file

🤖 Generated with [Claude Code](https://claude.com/claude-code)