### PR TITLE
feat: add 5 agents + Phase 2 sub-agent enhancements (v1.9.3)

### DIFF
--- a/.claude/plugins/onebrain/.claude-plugin/plugin.json
+++ b/.claude/plugins/onebrain/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "onebrain",
-  "version": "1.9.4",
+  "version": "1.9.3",
   "description": "OneBrain — Where human and AI thinking become one. A powerful thinking partner powered by AI synergy.",
   "author": {
     "name": "OneBrain Contributors"

--- a/.claude/plugins/onebrain/.claude-plugin/plugin.json
+++ b/.claude/plugins/onebrain/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "onebrain",
-  "version": "1.9.2",
+  "version": "1.9.3",
   "description": "OneBrain — Where human and AI thinking become one. A powerful thinking partner powered by AI synergy.",
   "author": {
     "name": "OneBrain Contributors"

--- a/.claude/plugins/onebrain/.claude-plugin/plugin.json
+++ b/.claude/plugins/onebrain/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "onebrain",
-  "version": "1.9.3",
+  "version": "1.9.4",
   "description": "OneBrain — Where human and AI thinking become one. A powerful thinking partner powered by AI synergy.",
   "author": {
     "name": "OneBrain Contributors"

--- a/.claude/plugins/onebrain/INSTRUCTIONS.md
+++ b/.claude/plugins/onebrain/INSTRUCTIONS.md
@@ -115,15 +115,15 @@ These workflows are documented in `.claude/plugins/onebrain/skills/`:
 | `/doctor` | `doctor/SKILL.md` | Vault + config health check: broken links, orphan notes, stale MEMORY.md entries, plugin config | user asks to check vault health, diagnose issues, or run /doctor |
 | `/help` | `help/SKILL.md` | List available commands with use cases | user asks what commands or skills are available, or what the agent can do |
 
-**Background Agents** — These agents live in `.claude/plugins/onebrain/agents/` and are dispatched automatically by skills. They are never invoked directly by the user.
+**Agents** — These agents live in `.claude/plugins/onebrain/agents/` and are dispatched automatically by skills. They are never invoked directly by the user.
 
-| Agent File | Dispatched by | Purpose |
-|-----------|--------------|---------|
-| `knowledge-linker.md` | `/connect` | Find and add wikilinks between related notes |
-| `link-suggester.md` | `/learn` | Auto-add up to 3 wikilinks to newly written notes |
-| `tag-suggester.md` | `/capture`, `/reading-notes` | Auto-add up to 3 tags from vault vocabulary to new notes |
-| `inbox-classifier.md` | `/consolidate` | Pre-classify inbox notes with folder/subfolder/link recommendations |
-| `task-extractor.md` | `/braindump` | Extract action items and format them as vault tasks |
+| Agent File | Dispatched by | Mode | Purpose |
+|-----------|--------------|------|---------|
+| `knowledge-linker.md` | `/connect` | foreground | Find and add wikilinks between related notes |
+| `link-suggester.md` | `/learn` | background | Auto-add up to 3 wikilinks to newly written notes |
+| `tag-suggester.md` | `/capture`, `/reading-notes` | background | Auto-add up to 3 tags from vault vocabulary to new notes |
+| `inbox-classifier.md` | `/consolidate` | foreground parallel | Pre-classify inbox notes with folder/subfolder/link recommendations |
+| `task-extractor.md` | `/braindump` | background | Extract action items and format them as vault tasks |
 
 **Skill Routing:** When a user message clearly maps to a skill above, invoke it directly : no `/command` needed. If intent is ambiguous, use AskUserQuestion to confirm before invoking. When trigger conditions overlap, prefer the lighter-weight skill (e.g. `/capture` over `/braindump`, `/bookmark` over `/summarize`). Skills marked "manual only" require explicit `/command` always.
 
@@ -260,7 +260,7 @@ Main agent is now ready to respond to the user.
 
 ### Phase 2 : Background Sub-agent
 
-The sub-agent receives the payload from Phase 1 and performs all work that requires multiple file reads. It does NOT read MEMORY.md — `active_tasks` are passed in the prompt. All folder values in the payload are relative to `vault_root`; construct full paths as `vault_root/folder_value`.
+The sub-agent receives the payload from Phase 1 and performs all work that requires multiple file reads. It does NOT read MEMORY.md for content — `active_tasks` are passed in the prompt. It may count lines in MEMORY.md for the overflow guard (Step 5). All folder values in the payload are relative to `vault_root`; construct full paths as `vault_root/folder_value`.
 
 **Sub-agent steps:**
 
@@ -367,7 +367,7 @@ When the background sub-agent returns, the main agent sends exactly one follow-u
 
 1. Display the `briefing` text
 2. If `orphan_action` is `prompt_wrapup:{N}`: append `📋 {N} checkpoints : /wrapup?`
-3. If `context_hints` is non-empty: read each file as `vault_root/hint_path` into context (do not display anything to the user). If any file cannot be read, skip it.
+3. If `context_hints` is non-empty: read each file as `vault_root/hint_path` into context (do not display anything to the user). If any file cannot be read, skip that file.
 4. If `stale_notes` is non-empty: append to the briefing message:
    ```
    **Stale projects (30+ days):**

--- a/.claude/plugins/onebrain/INSTRUCTIONS.md
+++ b/.claude/plugins/onebrain/INSTRUCTIONS.md
@@ -121,6 +121,9 @@ These workflows are documented in `.claude/plugins/onebrain/skills/`:
 |-----------|--------------|---------|
 | `knowledge-linker.md` | `/connect` | Find and add wikilinks between related notes |
 | `link-suggester.md` | `/learn` | Auto-add up to 3 wikilinks to newly written notes |
+| `tag-suggester.md` | `/capture`, `/reading-notes` | Auto-add up to 3 tags from vault vocabulary to new notes |
+| `inbox-classifier.md` | `/consolidate` | Pre-classify inbox notes with folder/subfolder/link recommendations |
+| `task-extractor.md` | `/braindump` | Extract action items and format them as vault tasks |
 
 **Skill Routing:** When a user message clearly maps to a skill above, invoke it directly : no `/command` needed. If intent is ambiguous, use AskUserQuestion to confirm before invoking. When trigger conditions overlap, prefer the lighter-weight skill (e.g. `/capture` over `/braindump`, `/bookmark` over `/summarize`). Skills marked "manual only" require explicit `/command` always.
 

--- a/.claude/plugins/onebrain/INSTRUCTIONS.md
+++ b/.claude/plugins/onebrain/INSTRUCTIONS.md
@@ -264,6 +264,10 @@ The sub-agent receives the payload from Phase 1 and performs all work that requi
    - Group: overdue first, then due today
    - Include the source note name for each task
 
+   **Coming up (next 3 days):**
+   - From the same grep results, keep tasks where date > today AND date ≤ today+3
+   - Include the source note name for each task
+
    **Open from last session:**
    - Glob `[logs_folder]/**/*.md` matching filename pattern `YYYY-MM-DD-session-*.md`; find the most recent one whose `date` frontmatter is **before today**
    - If no such file exists, skip this section
@@ -277,12 +281,16 @@ The sub-agent receives the payload from Phase 1 and performs all work that requi
    - [ ] Task description 📅 YYYY-MM-DD (from "Note Name")
    - [ ] Overdue task 📅 YYYY-MM-DD (overdue - from "Note Name")
 
+   **Coming up (3 days):**
+   - [ ] Task description 📅 YYYY-MM-DD (from "Note Name")
+
    **Open from last session:**
    - [ ] Action item text
    ```
    - `Ddd` is the abbreviated day of week (Mon, Tue, Wed, Thu, Fri, Sat, Sun)
    - Omit `· inbox N` if `inbox_count` is 0
-   - If both task sources are empty, use a single line: `No tasks or open items for today.`
+   - Omit the "Coming up" section entirely if no tasks fall in that window
+   - If both task sources (due/overdue and open from last session) are empty, use a single line: `No tasks or open items for today.`
 
 2. **Orphan checkpoints** : Find checkpoint files from past sessions that were never turned into a session log. These need to be either auto-synthesized (if few) or flagged to the user (if many).
 
@@ -305,10 +313,38 @@ The sub-agent receives the payload from Phase 1 and performs all work that requi
      5. Set `orphan_action: merged:{N}` (where N = total number of checkpoints merged)
    - **>5 files** : too many to synthesize safely; set `orphan_action: prompt_wrapup:{N}` and let the user decide
 
-3. **Return** to main agent:
+3. **Context pre-loader** — Identify context files relevant to active projects so the main agent can load them on session start.
+
+   - Read `active_tasks` from the payload and extract distinctive project name keywords (e.g. "OneBrain" from "OneBrain v2.0.0", "Finastra" from "Finastra onboarding") — use the most distinctive single word per project, lowercased
+   - For each keyword, Glob `[agent_folder]/context/` for files whose filename contains that keyword (case-insensitive)
+   - Collect all matching file paths (relative to `vault_root`); deduplicate; keep max 3 total
+   - Store as `context_hints: [list of relative file paths]`
+   - If no matches found or `[agent_folder]/context/` does not exist, store `context_hints: []`
+
+4. **Stale note scanner** — Find project and area notes that have not been touched recently.
+
+   - Glob `[projects_folder]/**/*.md` and `[areas_folder]/**/*.md`
+   - For each file, check its filesystem last-modified date (mtime)
+   - Keep only files where mtime is more than 30 days before today
+   - Exclude any file whose name starts with `TASKS` or `MOC`
+   - Sort results by mtime ascending (stalest first)
+   - Keep max 5 results
+   - Store as `stale_notes: [{path, days_since_modified}]` (paths relative to `vault_root`)
+   - If none found, store `stale_notes: []`
+
+5. **MEMORY.md overflow guard** — Check whether the agent memory file is approaching its size limit.
+
+   - Count total lines in `[agent_folder]/MEMORY.md`
+   - If count > 160: store `memory_lines: N` (actual line count)
+   - If count ≤ 160: store `memory_lines: 0`
+
+6. **Return** to main agent:
    ```
    briefing: "[assembled briefing text from step 1]"
    orphan_action: none | merged:{N} | prompt_wrapup:{N}
+   context_hints: [path1, path2, ...]
+   stale_notes: [{path, days_since_modified}, ...]
+   memory_lines: N
    ```
 
 ### Session-Start Briefing
@@ -317,7 +353,16 @@ When the background sub-agent returns, the main agent sends exactly one follow-u
 
 1. Display the `briefing` text
 2. If `orphan_action` is `prompt_wrapup:{N}`: append `📋 {N} checkpoints : /wrapup?`
-3. Always append a hint on a new line, in italics, adapted to the user's language. Example: `_รัน /daily อีกครั้งเพื่อดูสถานะได้ครับ_`
+3. If `context_hints` is non-empty: silently read each file in the list — do NOT display anything to the user, just load the content into context so it is available for the session
+4. If `stale_notes` is non-empty: append to the briefing message:
+   ```
+   **Stale projects (30+ days):**
+   - `[path]` (N days)
+   ```
+   Show max 3 entries; if there are more, add `(+N more — run /doctor for full list)`
+5. If `memory_lines` > 0: append one line to the briefing:
+   `⚠️ MEMORY.md is N lines — consider /distill`
+6. Always append a hint on a new line, in italics, adapted to the user's language. Example: `_รัน /daily อีกครั้งเพื่อดูสถานะได้ครับ_`
 
 **Rule:** If the user sent a message before the sub-agent finished, respond to that message first, then send the follow-up. Never drop the follow-up.
 

--- a/.claude/plugins/onebrain/INSTRUCTIONS.md
+++ b/.claude/plugins/onebrain/INSTRUCTIONS.md
@@ -66,7 +66,7 @@ Always use Obsidian wikilink syntax to connect related notes:
 [[Note Title|display text]]
 ```
 
-When creating a new note, search the vault first (using qmd or Grep), then suggest 2-3 relevant wikilinks to existing notes.
+When creating a new note, search the vault first (using qmd or Grep), then automatically add the top 1–3 relevant wikilinks under a `## Related` section.
 
 ## Note Frontmatter
 
@@ -114,6 +114,13 @@ These workflows are documented in `.claude/plugins/onebrain/skills/`:
 | `/update` | `update/SKILL.md` | Update system files from GitHub | (manual only) |
 | `/doctor` | `doctor/SKILL.md` | Vault + config health check: broken links, orphan notes, stale MEMORY.md entries, plugin config | user asks to check vault health, diagnose issues, or run /doctor |
 | `/help` | `help/SKILL.md` | List available commands with use cases | user asks what commands or skills are available, or what the agent can do |
+
+**Background Agents** — These agents live in `.claude/plugins/onebrain/agents/` and are dispatched automatically by skills. They are never invoked directly by the user.
+
+| Agent File | Dispatched by | Purpose |
+|-----------|--------------|---------|
+| `knowledge-linker.md` | `/connect` | Find and add wikilinks between related notes |
+| `link-suggester.md` | `/learn` | Auto-add up to 3 wikilinks to newly written notes |
 
 **Skill Routing:** When a user message clearly maps to a skill above, invoke it directly : no `/command` needed. If intent is ambiguous, use AskUserQuestion to confirm before invoking. When trigger conditions overlap, prefer the lighter-weight skill (e.g. `/capture` over `/braindump`, `/bookmark` over `/summarize`). Skills marked "manual only" require explicit `/command` always.
 
@@ -240,6 +247,7 @@ Run before responding to any user message:
    inbox_folder: [inbox_folder]
    knowledge_folder: [knowledge_folder]
    projects_folder: [projects_folder]
+   areas_folder: [areas_folder]
    today: YYYY-MM-DD
    active_tasks: [task list with dates extracted from MEMORY.md Active Projects section]
    is_weekend: true|false
@@ -290,7 +298,7 @@ The sub-agent receives the payload from Phase 1 and performs all work that requi
    - `Ddd` is the abbreviated day of week (Mon, Tue, Wed, Thu, Fri, Sat, Sun)
    - Omit `· inbox N` if `inbox_count` is 0
    - Omit the "Coming up" section entirely if no tasks fall in that window
-   - If both task sources (due/overdue and open from last session) are empty, use a single line: `No tasks or open items for today.`
+   - If all three task sources (due/overdue, coming up, and open from last session) are empty, use a single line: `No tasks or open items for today.`
 
 2. **Orphan checkpoints** : Find checkpoint files from past sessions that were never turned into a session log. These need to be either auto-synthesized (if few) or flagged to the user (if many).
 
@@ -309,6 +317,7 @@ The sub-agent receives the payload from Phase 1 and performs all work that requi
      2. Count existing session logs for that date (`YYYY-MM-DD-session-*.md`) → next NN, zero-padded to 2 digits (e.g. `01`, `02`)
      3. Write a session log to `[logs_folder]/YYYY/MM/YYYY-MM-DD-session-NN.md` with frontmatter fields `auto-saved: true` and `synthesized_from_checkpoints: true`
         - **Every Key Decision, Action Item, and Open Question from every checkpoint must appear explicitly in the log** : do not write the file until all checkpoint content is reflected
+        - **If the write fails**: do not mark any checkpoints as `merged: true`; set `orphan_action: none` and stop — do not attempt further checkpoint processing
      4. For each checkpoint file whose content was read and incorporated: set `merged: true` in its frontmatter
      5. Set `orphan_action: merged:{N}` (where N = total number of checkpoints merged)
    - **>5 files** : too many to synthesize safely; set `orphan_action: prompt_wrapup:{N}` and let the user decide
@@ -321,48 +330,50 @@ The sub-agent receives the payload from Phase 1 and performs all work that requi
    - Store as `context_hints: [list of relative file paths]`
    - If no matches found or `[agent_folder]/context/` does not exist, store `context_hints: []`
 
-4. **Stale note scanner** — Find project and area notes that have not been touched recently.
+4. **Stale note scanner** — Find project and area notes that have not been touched recently. (Resources are excluded intentionally — stale resources are managed via `/consolidate`.)
 
    - Glob `[projects_folder]/**/*.md` and `[areas_folder]/**/*.md`
    - For each file, check its filesystem last-modified date (mtime)
    - Keep only files where mtime is more than 30 days before today
    - Exclude any file whose name starts with `TASKS` or `MOC`
    - Sort results by mtime ascending (stalest first)
-   - Keep max 5 results
+   - Keep max 5 results; if a folder does not exist, skip it
+   - Compute `days_since_modified` as `floor((today - mtime_date).days)` — always an integer
    - Store as `stale_notes: [{path, days_since_modified}]` (paths relative to `vault_root`)
    - If none found, store `stale_notes: []`
 
 5. **MEMORY.md overflow guard** — Check whether the agent memory file is approaching its size limit.
 
    - Count total lines in `[agent_folder]/MEMORY.md`
-   - If count > 160: store `memory_lines: N` (actual line count)
-   - If count ≤ 160: store `memory_lines: 0`
+   - Include `memory_lines: N` in the return payload only if count > 160; otherwise omit
 
 6. **Return** to main agent:
    ```
    briefing: "[assembled briefing text from step 1]"
    orphan_action: none | merged:{N} | prompt_wrapup:{N}
    context_hints: [path1, path2, ...]
-   stale_notes: [{path, days_since_modified}, ...]
-   memory_lines: N
+   stale_notes: [{path: string (vault-relative), days_since_modified: integer}, ...]
+   memory_lines: N          # only present when MEMORY.md exceeds 160 lines
    ```
 
 ### Session-Start Briefing
 
 When the background sub-agent returns, the main agent sends exactly one follow-up message:
 
+**Fallback defaults** — If the sub-agent fails or returns incomplete data, use these defaults and still send the follow-up: `briefing: "Daily briefing unavailable."`, `orphan_action: none`, `context_hints: []`, `stale_notes: []`, `memory_lines` absent.
+
 1. Display the `briefing` text
 2. If `orphan_action` is `prompt_wrapup:{N}`: append `📋 {N} checkpoints : /wrapup?`
-3. If `context_hints` is non-empty: silently read each file in the list — do NOT display anything to the user, just load the content into context so it is available for the session
+3. If `context_hints` is non-empty: read each file as `vault_root/hint_path` into context (do not display anything to the user). If any file cannot be read, skip it.
 4. If `stale_notes` is non-empty: append to the briefing message:
    ```
    **Stale projects (30+ days):**
    - `[path]` (N days)
    ```
    Show max 3 entries; if there are more, add `(+N more — run /doctor for full list)`
-5. If `memory_lines` > 0: append one line to the briefing:
-   `⚠️ MEMORY.md is N lines — consider /distill`
-6. Always append a hint on a new line, in italics, adapted to the user's language. Example: `_รัน /daily อีกครั้งเพื่อดูสถานะได้ครับ_`
+5. If `memory_lines` is present in the payload: append one line to the briefing:
+   `⚠️ MEMORY.md is N lines — consider /recap`
+6. Always append a hint on a new line, in italics, adapted to the user's language. Example: `_Run /daily again to check your status_`
 
 **Rule:** If the user sent a message before the sub-agent finished, respond to that message first, then send the follow-up. Never drop the follow-up.
 

--- a/.claude/plugins/onebrain/agents/inbox-classifier.md
+++ b/.claude/plugins/onebrain/agents/inbox-classifier.md
@@ -1,12 +1,12 @@
 ---
 name: Inbox Classifier
-description: "Classifies a single inbox note and recommends a target folder, subfolder, filename, and related wikilinks for use by /consolidate"
+description: "Classifies an inbox note and recommends target folder, subfolder, filename, and wikilinks for /consolidate"
 color: orange
 ---
 
 # Inbox Classifier Agent
 
-You are a vault routing assistant. You receive one inbox note and return a structured classification recommendation. You do NOT write any files — your output is used by `/consolidate` to drive routing decisions.
+You are a vault routing assistant. You receive one inbox note and return a structured classification recommendation. You do NOT write any files.
 
 ## Input
 
@@ -18,20 +18,20 @@ You receive:
 
 ## Process
 
-1. **Check source frontmatter**: If the note has a `source:` field set to `/research`, `/summarize`, or `/reading-notes`, immediately classify as `resource` and skip to step 4.
+1. **Check source frontmatter**: If `source:` is `/research`, `/summarize`, or `/reading-notes`, classify as `resource` and skip to step 4.
 
 2. **Classify content type** from `note_content`:
-   - `knowledge` — your own synthesis, insight, or conclusion
-   - `resource` — external info, reference material, or source notes
-   - `project` — specific work tied to an active project
-   - `area` — ongoing responsibility (health, finances, career, relationships)
-   - `archive` — outdated, superseded, or irrelevant content
+   - `knowledge` — synthesis, insight, or conclusion
+   - `resource` — external info, reference, or source material
+   - `project` — work tied to an active project
+   - `area` — ongoing responsibility (health, finances, career)
+   - `archive` — outdated, superseded, or irrelevant
 
-3. **Suggest subfolder**: Glob existing subfolders in the target folder. Pick the best fit (kebab-case, max 2 levels). If nothing fits, invent a concise new name.
+3. **Suggest subfolder**: Glob existing subfolders in the target folder. Pick the best fit (kebab-case, max 2 levels). If none fits, invent a concise new name.
 
-4. **Suggest filename**: Derive a clean Title Case name from the note content (2–5 words, no date prefix).
+4. **Suggest filename**: Title Case, 2–5 words, no date prefix.
 
-5. **Find 1–2 related notes**: Grep `[knowledge_folder]/**/*.md` and `[resources_folder]/**/*.md` for 2–3 keywords from the note. Return the top 1–2 file titles as wikilink candidates.
+5. **Find 1–2 related notes**: Grep `[knowledge_folder]/**/*.md` and `[resources_folder]/**/*.md` for 2–3 keywords. Skip folders that do not exist. Return top 1–2 file titles as wikilink candidates.
 
 6. **Return** a structured recommendation (plain text, one field per line):
    ```
@@ -43,7 +43,7 @@ You receive:
 
 ## Constraints
 
-- Return a recommendation only — never write, move, or delete any file
-- If `note_content` is too short to classify confidently (<3 lines), set `type: knowledge` as a safe default and note it in `reason`
+- Never write, move, or delete any file
+- If `note_content` is too short to classify (<3 lines), return `type: error` with `reason: "note_content is too short to classify"` and omit `target` and `links`
 - If no related notes are found, return `links: []`
 - Keep `reason` to one sentence

--- a/.claude/plugins/onebrain/agents/inbox-classifier.md
+++ b/.claude/plugins/onebrain/agents/inbox-classifier.md
@@ -44,6 +44,7 @@ You receive:
 ## Constraints
 
 - Never write, move, or delete any file
-- If `note_content` is too short to classify (<3 lines), return `type: error` with `reason: "note_content is too short to classify"` and omit `target` and `links`
+- If `note_content` is empty or blank (zero non-whitespace characters), return `type: error` with `reason: "note_content is empty"` and omit `target` and `links`
+- If `note_content` is too short to classify (<3 non-empty lines), return `type: error` with `reason: "note_content is too short to classify"` and omit `target` and `links`
 - If no related notes are found, return `links: []`
 - Keep `reason` to one sentence

--- a/.claude/plugins/onebrain/agents/inbox-classifier.md
+++ b/.claude/plugins/onebrain/agents/inbox-classifier.md
@@ -1,0 +1,49 @@
+---
+name: Inbox Classifier
+description: "Classifies a single inbox note and recommends a target folder, subfolder, filename, and related wikilinks for use by /consolidate"
+color: orange
+---
+
+# Inbox Classifier Agent
+
+You are a vault routing assistant. You receive one inbox note and return a structured classification recommendation. You do NOT write any files — your output is used by `/consolidate` to drive routing decisions.
+
+## Input
+
+You receive:
+- `note_path` : vault-relative path of the inbox note
+- `note_content` : full content of the note
+- `vault_root` : absolute path to vault root
+- `knowledge_folder`, `resources_folder`, `areas_folder`, `projects_folder` : folder paths (relative to vault_root)
+
+## Process
+
+1. **Check source frontmatter**: If the note has a `source:` field set to `/research`, `/summarize`, or `/reading-notes`, immediately classify as `resource` and skip to step 4.
+
+2. **Classify content type** from `note_content`:
+   - `knowledge` — your own synthesis, insight, or conclusion
+   - `resource` — external info, reference material, or source notes
+   - `project` — specific work tied to an active project
+   - `area` — ongoing responsibility (health, finances, career, relationships)
+   - `archive` — outdated, superseded, or irrelevant content
+
+3. **Suggest subfolder**: Glob existing subfolders in the target folder. Pick the best fit (kebab-case, max 2 levels). If nothing fits, invent a concise new name.
+
+4. **Suggest filename**: Derive a clean Title Case name from the note content (2–5 words, no date prefix).
+
+5. **Find 1–2 related notes**: Grep `[knowledge_folder]/**/*.md` and `[resources_folder]/**/*.md` for 2–3 keywords from the note. Return the top 1–2 file titles as wikilink candidates.
+
+6. **Return** a structured recommendation (plain text, one field per line):
+   ```
+   type: [knowledge|resource|project|area|archive]
+   target: [folder]/[subfolder]/[Suggested Note Title].md
+   links: ["[[Note A]]", "[[Note B]]"]
+   reason: [one sentence explaining the classification]
+   ```
+
+## Constraints
+
+- Return a recommendation only — never write, move, or delete any file
+- If `note_content` is too short to classify confidently (<3 lines), set `type: knowledge` as a safe default and note it in `reason`
+- If no related notes are found, return `links: []`
+- Keep `reason` to one sentence

--- a/.claude/plugins/onebrain/agents/knowledge-linker.md
+++ b/.claude/plugins/onebrain/agents/knowledge-linker.md
@@ -8,24 +8,30 @@ color: blue
 
 You are a knowledge graph specialist. Your job is to find meaningful connections between notes in this Obsidian vault and suggest wikilinks to strengthen the knowledge network.
 
-## When Invoked
+## Input
 
-You are invoked by the `/connect` skill when the user wants to find connections between notes.
+You receive:
+- `vault_root` : absolute path to vault root
+- `knowledge_folder`, `resources_folder`, `areas_folder`, `projects_folder` : folder paths (relative to vault_root)
 
 ## Process
 
-1. **Scan the vault**: List all `.md` files in `[knowledge_folder]/**/*.md`, `[resources_folder]/**/*.md`, `[areas_folder]/**/*.md`, and `[projects_folder]/**/*.md` (recursive - notes may be in subfolders)
-2. **Build a mental map**: Read each file's title, tags, and first paragraph
+1. **Scan the vault**: List all `.md` files in `[knowledge_folder]/**/*.md`, `[resources_folder]/**/*.md`, `[areas_folder]/**/*.md`, and `[projects_folder]/**/*.md` (recursive — notes may be in subfolders). Skip folders that do not exist. If all folders are absent or return zero files, return: "No notes found to link." and stop. Cap the scan at 200 files — if more exist, note that the scan is partial.
+
+2. **Build a mental map**: Read each file's title, tags, and first paragraph.
+
 3. **Identify connections**: Look for:
    - Shared topics or concepts
    - Notes that reference the same idea without linking to each other
    - Notes where one provides context for another
    - Notes that form a natural sequence or hierarchy
+
 4. **Suggest wikilinks**: For each connection found, propose:
    - Which note to add the link in
    - Where in the note to add it (quote the surrounding text)
    - The exact wikilink to add: `[[Note Title]]`
-5. **Present findings**: Show a summary of suggested links, grouped by note
+
+5. **Return findings**: Output a summary of suggested links, grouped by note, using the Output Format below.
 
 ## Output Format
 
@@ -40,10 +46,12 @@ You are invoked by the `/connect` skill when the user wants to find connections 
 - Add link to [[Note D]] : Note D provides background for this concept
 ```
 
-## Guidelines
+If the scan was partial, append: `_(partial scan — N files scanned of M total)_`
 
-- Prioritize meaningful connections over superficial keyword matches
-- Don't suggest linking every note to every other note : be selective
-- Focus on links that would genuinely help the user navigate their knowledge
-- Maximum 10 suggestions per run to avoid overwhelming the user
+## Constraints
+
+- Maximum 10 suggestions per run
 - Return suggestions only — never write to any file
+- Prioritize meaningful connections over superficial keyword matches — be selective
+- Skip folders that do not exist
+- Cap scan at 200 files; note partial scan in output if limit is reached

--- a/.claude/plugins/onebrain/agents/knowledge-linker.md
+++ b/.claude/plugins/onebrain/agents/knowledge-linker.md
@@ -46,4 +46,4 @@ You are invoked by the `/connect` skill when the user wants to find connections 
 - Don't suggest linking every note to every other note : be selective
 - Focus on links that would genuinely help the user navigate their knowledge
 - Maximum 10 suggestions per run to avoid overwhelming the user
-- Ask before making any changes : present suggestions first
+- Return suggestions only — never write to any file

--- a/.claude/plugins/onebrain/agents/link-suggester.md
+++ b/.claude/plugins/onebrain/agents/link-suggester.md
@@ -1,0 +1,46 @@
+---
+name: Link Suggester
+description: "After a new note is written, scans the vault for related notes and suggests 2-3 wikilinks to add"
+color: green
+---
+
+# Link Suggester Agent
+
+You are a knowledge graph assistant. A new note was just written to the vault. Your job is to find the 2–3 most meaningful wikilink connections to suggest adding to it.
+
+## Input
+
+You receive:
+- `new_note_path` : vault-relative path of the newly written note
+- `new_note_content` : full content of the note
+- `vault_root` : absolute path to vault root
+- `knowledge_folder`, `resources_folder`, `areas_folder`, `projects_folder` : folder paths (relative to vault_root)
+
+## Process
+
+1. **Extract 3–5 keywords** from `new_note_content`: prefer proper nouns, tool names, project names, or multi-word phrases. Avoid generic words like "use", "note", "session".
+
+2. **Search for related notes**: Use Grep to search `[knowledge_folder]/**/*.md`, `[resources_folder]/**/*.md`, `[areas_folder]/**/*.md`, and `[projects_folder]/**/*.md` for those keywords (case-insensitive). Collect files with ≥2 keyword hits. Exclude `new_note_path` itself.
+
+3. **Filter to top 3**: Rank by number of keyword hits. If tied, prefer knowledge/ over resources/ over others.
+
+4. **Check for existing links**: Read `new_note_content`. Skip any candidate already wikilinked in the note.
+
+5. **Present suggestions** (only if ≥1 candidate found):
+   ```
+   💡 Related notes you might want to link:
+   - [[Note Title]] — [one-line reason why it's relevant]
+   - [[Note Title 2]] — [reason]
+   ```
+   Then ask: "Add any of these links? (list numbers, or skip)"
+
+6. **If user confirms**: Append the selected wikilinks to the note under a `## Related` section (create it if absent; if it exists, append to it). Use `[[Note Title]]` format.
+
+7. **If no candidates found or user skips**: Confirm silently, do nothing.
+
+## Constraints
+
+- Maximum 3 suggestions
+- Never modify any file except `new_note_path`
+- Never add a link to a file that doesn't exist
+- If the note already has a `## Related` section, append to it — do not create a duplicate

--- a/.claude/plugins/onebrain/agents/link-suggester.md
+++ b/.claude/plugins/onebrain/agents/link-suggester.md
@@ -1,6 +1,6 @@
 ---
 name: Link Suggester
-description: "After a new note is written, scans the vault for related notes and suggests 2-3 wikilinks to add"
+description: "After a new note is written, scans the vault for related notes and automatically adds up to 3 wikilinks under a ## Related section"
 color: green
 ---
 
@@ -18,29 +18,28 @@ You receive:
 
 ## Process
 
-1. **Extract 3–5 keywords** from `new_note_content`: prefer proper nouns, tool names, project names, or multi-word phrases. Avoid generic words like "use", "note", "session".
+1. **Extract 3–5 keywords** from `new_note_content`: prefer proper nouns, tool names, project names, or multi-word phrases. Avoid generic words like "use", "note", "session". If fewer than 2 distinctive keywords can be extracted, stop (do nothing).
 
-2. **Search for related notes**: Use Grep to search `[knowledge_folder]/**/*.md`, `[resources_folder]/**/*.md`, `[areas_folder]/**/*.md`, and `[projects_folder]/**/*.md` for those keywords (case-insensitive). Collect files with ≥2 keyword hits. Exclude `new_note_path` itself.
+2. **Search for related notes**: Use Grep to search `[knowledge_folder]/**/*.md`, `[resources_folder]/**/*.md`, `[areas_folder]/**/*.md`, and `[projects_folder]/**/*.md` for those keywords (case-insensitive). Skip any folder that does not exist. Collect files with ≥2 keyword hits. Exclude `new_note_path` itself.
 
 3. **Filter to top 3**: Rank by number of keyword hits. If tied, prefer knowledge/ over resources/ over others.
 
 4. **Check for existing links**: Read `new_note_content`. Skip any candidate already wikilinked in the note.
 
-5. **Present suggestions** (only if ≥1 candidate found):
+5. **Auto-add links**: If ≥1 candidate found, append wikilinks to a `## Related` section in the note (create if absent; append if exists). Use `[[Note Title]]` format. Then present to the user:
    ```
-   💡 Related notes you might want to link:
+   💡 Linked related notes:
    - [[Note Title]] — [one-line reason why it's relevant]
    - [[Note Title 2]] — [reason]
    ```
-   Then ask: "Add any of these links? (list numbers, or skip)"
-
-6. **If user confirms**: Append the selected wikilinks to the note under a `## Related` section (create it if absent; if it exists, append to it). Use `[[Note Title]]` format.
-
-7. **If no candidates found or user skips**: Confirm silently, do nothing.
+   If no candidates found, do nothing.
 
 ## Constraints
 
 - Maximum 3 suggestions
 - Never modify any file except `new_note_path`
 - Never add a link to a file that doesn't exist
+- Before writing, verify `new_note_path` still exists. If it does not, inform the user: "The note `[path]` no longer exists — links were not added."
 - If the note already has a `## Related` section, append to it — do not create a duplicate
+- Do not search agent memory folders — agent files are not valid wikilink targets
+- Do not write to files inside the agent folder (`05-agent/` or whatever `agent_folder` resolves to) — if `new_note_path` is under `agent_folder`, exit silently

--- a/.claude/plugins/onebrain/agents/tag-suggester.md
+++ b/.claude/plugins/onebrain/agents/tag-suggester.md
@@ -1,6 +1,6 @@
 ---
 name: Tag Suggester
-description: "After a new note is written, scans existing vault tags and suggests up to 3 tags to add to the note's frontmatter"
+description: "Scans vault tags and suggests up to 3 to add to a new note's frontmatter"
 color: yellow
 ---
 
@@ -20,26 +20,26 @@ You receive:
 
 1. **Check existing tags in the note**: Parse the `tags:` frontmatter field from `new_note_content`. If the note already has ≥3 tags, stop (do nothing).
 
-2. **Collect vault tag vocabulary**: Grep for `^tags:` and `^  - ` lines in frontmatter across `[knowledge_folder]/**/*.md`, `[resources_folder]/**/*.md`, `[areas_folder]/**/*.md`, `[projects_folder]/**/*.md`. Build a flat deduplicated list of all tags in use. Skip any folder that does not exist.
+2. **Collect vault tag vocabulary**: Grep for `^tags:` and `^  - ` lines in frontmatter across `[knowledge_folder]/**/*.md`, `[resources_folder]/**/*.md`, `[areas_folder]/**/*.md`, `[projects_folder]/**/*.md`. Build a deduplicated list of all tags in use. Skip folders that do not exist.
 
-3. **Extract 3–5 keywords** from `new_note_content`: prefer proper nouns, tool names, domain terms, or topic phrases. Avoid generic words like "note", "session", "use". If fewer than 2 distinctive keywords, stop (do nothing).
+3. **Extract 3–5 keywords** from `new_note_content`: prefer proper nouns, tool names, domain terms. Avoid generic words ("note", "session", "use"). If fewer than 2 distinctive keywords, stop.
 
-4. **Match to existing tags**: For each keyword, find the closest tag(s) in the vocabulary (exact or partial match, case-insensitive). Prefer existing tags over inventing new ones. If no match exists for a clearly distinctive concept, suggest a new kebab-case lowercase tag (1–2 words max).
+4. **Match to existing tags**: For each keyword, find the closest tag(s) in the vocabulary (exact or partial, case-insensitive). Prefer existing tags over new ones. If no match exists for a distinctive concept, suggest a new kebab-case tag (1–2 words max).
 
-5. **Skip tags already in the note**. Keep up to 3 candidates total, prioritising existing vocabulary.
+5. **Skip tags already in the note**. Keep up to 3 candidates, prioritising existing vocabulary.
 
-6. **Add tags to frontmatter**: Edit `new_note_path` — insert the selected tags into the `tags:` array. Then notify the user:
+6. **Add tags to frontmatter**: Insert the selected tags into the `tags:` array in `new_note_path`. If `tags:` is a scalar (e.g. `tags: existing-tag`) rather than a list, convert it to a list first (e.g. `tags: [existing-tag]`) before appending. If writing fails, do nothing silently — do not notify the user. On success, notify the user:
    ```
    🏷️ Added tags: tag1, tag2
    ```
 
-7. **If no candidates found**: Do nothing silently.
+7. **No candidates found**: Do nothing silently.
 
 ## Constraints
 
 - Maximum 3 new tags per run
 - Prefer existing tag vocabulary over inventing new terms
 - Never modify any content outside the `tags:` frontmatter field
-- If the `tags:` field is missing from frontmatter entirely, add it as `tags: [tag1]` — do not restructure the frontmatter otherwise
-- If `new_note_path` no longer exists, inform the user: "The note `[path]` no longer exists — tags were not added."
-- Do not tag agent memory files — if `new_note_path` is under the agent folder, exit silently
+- If `tags:` is missing from frontmatter, add it as `tags: [tag1]` — do not restructure other frontmatter fields
+- If `new_note_path` no longer exists, inform the user and stop
+- If `new_note_path` is under the agent folder, exit silently

--- a/.claude/plugins/onebrain/agents/tag-suggester.md
+++ b/.claude/plugins/onebrain/agents/tag-suggester.md
@@ -1,0 +1,45 @@
+---
+name: Tag Suggester
+description: "After a new note is written, scans existing vault tags and suggests up to 3 tags to add to the note's frontmatter"
+color: yellow
+---
+
+# Tag Suggester Agent
+
+You are a vault taxonomy assistant. A new note was just written. Your job is to suggest tags that fit it, using the vault's existing tag vocabulary.
+
+## Input
+
+You receive:
+- `new_note_path` : vault-relative path of the newly written note
+- `new_note_content` : full content of the note (including frontmatter)
+- `vault_root` : absolute path to vault root
+- `knowledge_folder`, `resources_folder`, `areas_folder`, `projects_folder` : folder paths (relative to vault_root)
+
+## Process
+
+1. **Check existing tags in the note**: Parse the `tags:` frontmatter field from `new_note_content`. If the note already has ≥3 tags, stop (do nothing).
+
+2. **Collect vault tag vocabulary**: Grep for `^tags:` and `^  - ` lines in frontmatter across `[knowledge_folder]/**/*.md`, `[resources_folder]/**/*.md`, `[areas_folder]/**/*.md`, `[projects_folder]/**/*.md`. Build a flat deduplicated list of all tags in use. Skip any folder that does not exist.
+
+3. **Extract 3–5 keywords** from `new_note_content`: prefer proper nouns, tool names, domain terms, or topic phrases. Avoid generic words like "note", "session", "use". If fewer than 2 distinctive keywords, stop (do nothing).
+
+4. **Match to existing tags**: For each keyword, find the closest tag(s) in the vocabulary (exact or partial match, case-insensitive). Prefer existing tags over inventing new ones. If no match exists for a clearly distinctive concept, suggest a new kebab-case lowercase tag (1–2 words max).
+
+5. **Skip tags already in the note**. Keep up to 3 candidates total, prioritising existing vocabulary.
+
+6. **Add tags to frontmatter**: Edit `new_note_path` — insert the selected tags into the `tags:` array. Then notify the user:
+   ```
+   🏷️ Added tags: tag1, tag2
+   ```
+
+7. **If no candidates found**: Do nothing silently.
+
+## Constraints
+
+- Maximum 3 new tags per run
+- Prefer existing tag vocabulary over inventing new terms
+- Never modify any content outside the `tags:` frontmatter field
+- If the `tags:` field is missing from frontmatter entirely, add it as `tags: [tag1]` — do not restructure the frontmatter otherwise
+- If `new_note_path` no longer exists, inform the user: "The note `[path]` no longer exists — tags were not added."
+- Do not tag agent memory files — if `new_note_path` is under the agent folder, exit silently

--- a/.claude/plugins/onebrain/agents/task-extractor.md
+++ b/.claude/plugins/onebrain/agents/task-extractor.md
@@ -1,0 +1,58 @@
+---
+name: Task Extractor
+description: "Scans a braindump note for action items and extracts them as properly-formatted vault tasks"
+color: red
+---
+
+# Task Extractor Agent
+
+You are a task capture assistant. A braindump note was just written. Your job is to find buried action items and surface them as properly formatted vault tasks.
+
+## Input
+
+You receive:
+- `note_path` : vault-relative path of the braindump note
+- `note_content` : full content of the note
+- `vault_root` : absolute path to vault root
+- `projects_folder` : path to projects folder (relative to vault_root)
+- `inbox_folder` : path to inbox folder (relative to vault_root)
+- `today` : today's date as YYYY-MM-DD
+
+## Process
+
+1. **Scan for action signals** in `note_content`. Look for:
+   - Imperative phrases: "add X", "fix Y", "send Z", "schedule", "follow up", "review"
+   - Explicit markers: "TODO", "need to", "should", "must", "want to"
+   - Questions that imply an action: "check if X?", "find out Y?"
+   - Avoid extracting vague intentions ("maybe consider...", "it would be nice if...")
+
+2. **Extract up to 5 tasks**. For each, write:
+   ```
+   - [ ] [Clear action description] 📅 [date]
+   ```
+   - Use a date mentioned in context if present; otherwise use `today + 1`
+   - Keep descriptions concise (≤10 words), starting with a verb
+
+3. **If ≥1 task found**: Present them and ask where to append:
+   ```
+   📋 Found N action items:
+   - [ ] Task 1 📅 YYYY-MM-DD
+   - [ ] Task 2 📅 YYYY-MM-DD
+
+   Where should I add these?
+   (a) Append to this braindump note
+   (b) A specific project note — which one?
+   ```
+
+4. **On user response**: Append the tasks under a `## Tasks` section in the chosen note (create the section if absent; append to it if it exists). Confirm in one line:
+   > Added N tasks to `[note path]`.
+
+5. **If no clear action items found**: Do nothing silently.
+
+## Constraints
+
+- Maximum 5 tasks per run
+- Only extract clear, unambiguous action items — when in doubt, skip it
+- Never guess a project note path — always ask if the target isn't the braindump note itself
+- Never modify any file except the user-confirmed target note
+- Use the exact `- [ ] ... 📅 YYYY-MM-DD` format — the Tasks plugin requires it

--- a/.claude/plugins/onebrain/agents/task-extractor.md
+++ b/.claude/plugins/onebrain/agents/task-extractor.md
@@ -1,12 +1,12 @@
 ---
 name: Task Extractor
-description: "Scans a braindump note for action items and extracts them as properly-formatted vault tasks"
+description: "Scans a braindump note for action items and extracts them as vault tasks"
 color: red
 ---
 
 # Task Extractor Agent
 
-You are a task capture assistant. A braindump note was just written. Your job is to find buried action items and surface them as properly formatted vault tasks.
+You are a task capture assistant. A braindump note was just written. Your job is to find buried action items and surface them as formatted vault tasks.
 
 ## Input
 
@@ -21,38 +21,29 @@ You receive:
 ## Process
 
 1. **Scan for action signals** in `note_content`. Look for:
-   - Imperative phrases: "add X", "fix Y", "send Z", "schedule", "follow up", "review"
-   - Explicit markers: "TODO", "need to", "should", "must", "want to"
-   - Questions that imply an action: "check if X?", "find out Y?"
-   - Avoid extracting vague intentions ("maybe consider...", "it would be nice if...")
+   - Imperatives: "add X", "fix Y", "send Z", "schedule", "follow up", "review"
+   - Markers: "TODO", "need to", "should", "must", "want to"
+   - Action-implying questions: "check if X?", "find out Y?"
+   - Skip vague intentions ("maybe consider...", "it would be nice if...")
 
-2. **Extract up to 5 tasks**. For each, write:
+2. **Extract up to 5 tasks**. If `today` is missing or not a valid YYYY-MM-DD date, use the current system date. For each task, write:
    ```
    - [ ] [Clear action description] 📅 [date]
    ```
-   - Use a date mentioned in context if present; otherwise use `today + 1`
-   - Keep descriptions concise (≤10 words), starting with a verb
+   - Use a date from context if present; otherwise `today + 1`
+   - Descriptions: concise (≤10 words), verb-first
 
-3. **If ≥1 task found**: Present them and ask where to append:
-   ```
-   📋 Found N action items:
-   - [ ] Task 1 📅 YYYY-MM-DD
-   - [ ] Task 2 📅 YYYY-MM-DD
+3. **If ≥1 task found**:
+   - Verify `note_path` exists as a file under `vault_root`. If it does not exist, do nothing silently.
+   - Append the tasks under a `## Tasks` section in `note_path` (create the section if absent; append to it if it exists). If writing fails, do nothing silently — do not leave partial content.
+   - Notify the user:
+     > 📋 Added N tasks to `[note_path]`.
 
-   Where should I add these?
-   (a) Append to this braindump note
-   (b) A specific project note — which one?
-   ```
-
-4. **On user response**: Append the tasks under a `## Tasks` section in the chosen note (create the section if absent; append to it if it exists). Confirm in one line:
-   > Added N tasks to `[note path]`.
-
-5. **If no clear action items found**: Do nothing silently.
+4. **No clear action items found**: Do nothing silently.
 
 ## Constraints
 
 - Maximum 5 tasks per run
-- Only extract clear, unambiguous action items — when in doubt, skip it
-- Never guess a project note path — always ask if the target isn't the braindump note itself
-- Never modify any file except the user-confirmed target note
-- Use the exact `- [ ] ... 📅 YYYY-MM-DD` format — the Tasks plugin requires it
+- Only extract clear, unambiguous actions — when in doubt, skip
+- Always append to `note_path` — never write to a different file
+- Use exact `- [ ] ... 📅 YYYY-MM-DD` format (Tasks plugin requirement)

--- a/.claude/plugins/onebrain/skills/braindump/SKILL.md
+++ b/.claude/plugins/onebrain/skills/braindump/SKILL.md
@@ -51,11 +51,6 @@ created: YYYY-MM-DD
 
 [Full text of what the user shared, lightly formatted]
 
-## Extracted Tasks
-
-- [ ] [task 1] 📅 YYYY-MM-DD
-- [ ] [task 2] 📅 YYYY-MM-DD
-
 ## Ideas
 
 - [idea 1]

--- a/.claude/plugins/onebrain/skills/braindump/SKILL.md
+++ b/.claude/plugins/onebrain/skills/braindump/SKILL.md
@@ -84,7 +84,13 @@ If any item is a direct update, task, or decision for an active project in MEMOR
 
 ---
 
-## Step 5: Confirm
+## Step 5: Extract Tasks (background)
+
+After writing, dispatch the **Task Extractor** agent (`agents/task-extractor.md`) as a background sub-agent (`run_in_background: true`, `mode: "bypassPermissions"`), passing `note_path`, `note_content`, `vault_root`, `projects_folder`, `inbox_folder`, and `today` (today's date as YYYY-MM-DD). Proceed to Confirm immediately.
+
+---
+
+## Step 6: Confirm
 
 Say in one line:
-> Filed to `[inbox_folder]/YYYY-MM-DD-braindump.md`. [If tasks: Extracted N tasks.] [If project link: Added note to "Project".]
+> Filed to `[inbox_folder]/YYYY-MM-DD-braindump.md`. [If project link: Added note to "Project".]

--- a/.claude/plugins/onebrain/skills/capture/SKILL.md
+++ b/.claude/plugins/onebrain/skills/capture/SKILL.md
@@ -98,7 +98,13 @@ Related: [[Wikilink found in Step 3]]
 
 ---
 
-## Step 5: Confirm
+## Step 5: Suggest Tags (background)
+
+After writing, dispatch the **Tag Suggester** agent (`agents/tag-suggester.md`) as a background sub-agent (`run_in_background: true`, `mode: "bypassPermissions"`), passing `new_note_path`, `new_note_content`, `vault_root`, and the four folder variables. Proceed to Confirm immediately.
+
+---
+
+## Step 6: Confirm
 
 Say in one line:
 > Captured to `[file path]`.

--- a/.claude/plugins/onebrain/skills/capture/SKILL.md
+++ b/.claude/plugins/onebrain/skills/capture/SKILL.md
@@ -58,8 +58,8 @@ created: YYYY-MM-DD
 
 ## Related
 
-[[Link 1]]
-[[Link 2]]
+[[Wikilink found in Step 3]]
+[[Wikilink found in Step 3]]
 ```
 
 **For knowledge / reference / area note:**
@@ -80,7 +80,7 @@ created: YYYY-MM-DD
 
 ## Related
 
-[[Link 1]]
+[[Wikilink found in Step 3]]
 ```
 
 **For project note:**
@@ -93,24 +93,12 @@ Append to the existing project file:
 
 [Content]
 
-Related: [[Link 1]]
+Related: [[Wikilink found in Step 3]]
 ```
 
 ---
 
-## Step 5: Suggest Links (background)
-
-After writing, dispatch a background sub-agent (`run_in_background: true`, `mode: "bypassPermissions"`) using the Link Suggester agent with:
-- `new_note_path` : the path of the file just written (relative to vault_root)
-- `new_note_content` : the content just written
-- `vault_root` : absolute path to the directory containing vault.yml
-- `knowledge_folder`, `resources_folder`, `areas_folder`, `projects_folder` : from INSTRUCTIONS.md config
-
-The main agent proceeds to the Confirm step immediately — do not wait for the link suggester.
-
----
-
-## Step 6: Confirm
+## Step 5: Confirm
 
 Say in one line:
-> Captured to `[file path]`. [If links added: Linked to "Note A", "Note B".]
+> Captured to `[file path]`.

--- a/.claude/plugins/onebrain/skills/capture/SKILL.md
+++ b/.claude/plugins/onebrain/skills/capture/SKILL.md
@@ -98,7 +98,19 @@ Related: [[Link 1]]
 
 ---
 
-## Step 5: Confirm
+## Step 5: Suggest Links (background)
+
+After writing, dispatch a background sub-agent (`run_in_background: true`, `mode: "bypassPermissions"`) using the Link Suggester agent with:
+- `new_note_path` : the path of the file just written (relative to vault_root)
+- `new_note_content` : the content just written
+- `vault_root` : absolute path to the directory containing vault.yml
+- `knowledge_folder`, `resources_folder`, `areas_folder`, `projects_folder` : from INSTRUCTIONS.md config
+
+The main agent proceeds to the Confirm step immediately — do not wait for the link suggester.
+
+---
+
+## Step 6: Confirm
 
 Say in one line:
 > Captured to `[file path]`. [If links added: Linked to "Note A", "Note B".]

--- a/.claude/plugins/onebrain/skills/capture/SKILL.md
+++ b/.claude/plugins/onebrain/skills/capture/SKILL.md
@@ -100,7 +100,7 @@ Related: [[Wikilink found in Step 3]]
 
 ## Step 5: Suggest Tags (background)
 
-After writing, dispatch the **Tag Suggester** agent (`agents/tag-suggester.md`) as a background sub-agent (`run_in_background: true`, `mode: "bypassPermissions"`), passing `new_note_path`, `new_note_content`, `vault_root`, and the four folder variables. Proceed to Confirm immediately.
+After writing, dispatch the **Tag Suggester** agent (`agents/tag-suggester.md`) as a background sub-agent (`run_in_background: true`, `mode: "bypassPermissions"`), passing `new_note_path`, `new_note_content`, `vault_root`, `knowledge_folder`, `resources_folder`, `areas_folder`, and `projects_folder`. Proceed to Confirm immediately.
 
 ---
 

--- a/.claude/plugins/onebrain/skills/connect/SKILL.md
+++ b/.claude/plugins/onebrain/skills/connect/SKILL.md
@@ -27,6 +27,16 @@ Use qmd if available for semantic search across notes; fallback: Glob `[projects
 - Key concepts mentioned (first 200 words)
 - Existing wikilinks already present
 
+If the total note count exceeds 20, delegate to the **Knowledge Linker** agent instead — see Step 2b.
+
+---
+
+## Step 2b: Delegate to Agent (>20 Notes)
+
+If more than 20 notes are in scope: dispatch the **Knowledge Linker** agent (`agents/knowledge-linker.md`) as a foreground sub-agent (`run_in_background: false`, `mode: "bypassPermissions"`), passing `vault_root`, `knowledge_folder`, `resources_folder`, `areas_folder`, and `projects_folder`. The agent scans the full vault and returns connection suggestions. Once it returns, skip Steps 3–5 and proceed to Step 6.
+
+For ≤20 notes: continue with Step 3.
+
 ---
 
 ## Step 3: Find Connections
@@ -109,6 +119,3 @@ If the user asks to retro-tag existing notes (e.g. "update all notes in 01-proje
 
 ---
 
-## Delegation
-
-This skill uses the Knowledge Linker agent for deep vault scans. The agent is invoked automatically when scanning more than 20 notes.

--- a/.claude/plugins/onebrain/skills/connect/SKILL.md
+++ b/.claude/plugins/onebrain/skills/connect/SKILL.md
@@ -33,7 +33,7 @@ If the total note count exceeds 20, delegate to the **Knowledge Linker** agent i
 
 ## Step 2b: Delegate to Agent (>20 Notes)
 
-If more than 20 notes are in scope: dispatch the **Knowledge Linker** agent (`agents/knowledge-linker.md`) as a foreground sub-agent (`run_in_background: false`, `mode: "bypassPermissions"`), passing `vault_root`, `knowledge_folder`, `resources_folder`, `areas_folder`, and `projects_folder`. The agent scans the full vault and returns connection suggestions. Once it returns, present those suggestions to the user and ask for approval (Step 4), implement approved links (Step 5), then continue from Step 6.
+If more than 20 notes are in scope: dispatch the **Knowledge Linker** agent (`agents/knowledge-linker.md`) as a foreground sub-agent (`run_in_background: false`, `mode: "bypassPermissions"`), passing `vault_root`, `knowledge_folder`, `resources_folder`, `areas_folder`, and `projects_folder`. The agent always scans the full vault regardless of the scope chosen in Step 1. Once it returns, present those suggestions to the user and ask for approval (Step 4), implement approved links (Step 5), then continue from Step 6.
 
 For ≤20 notes: continue with Step 3.
 

--- a/.claude/plugins/onebrain/skills/connect/SKILL.md
+++ b/.claude/plugins/onebrain/skills/connect/SKILL.md
@@ -33,7 +33,7 @@ If the total note count exceeds 20, delegate to the **Knowledge Linker** agent i
 
 ## Step 2b: Delegate to Agent (>20 Notes)
 
-If more than 20 notes are in scope: dispatch the **Knowledge Linker** agent (`agents/knowledge-linker.md`) as a foreground sub-agent (`run_in_background: false`, `mode: "bypassPermissions"`), passing `vault_root`, `knowledge_folder`, `resources_folder`, `areas_folder`, and `projects_folder`. The agent always scans the full vault regardless of the scope chosen in Step 1. Once it returns, present those suggestions to the user and ask for approval (Step 4), implement approved links (Step 5), then continue from Step 6.
+If more than 20 notes are in scope: dispatch the **Knowledge Linker** agent (`agents/knowledge-linker.md`) as a foreground sub-agent (`run_in_background: false`, `mode: "bypassPermissions"`), passing `vault_root`, `knowledge_folder`, `resources_folder`, `areas_folder`, and `projects_folder`. The agent always scans the full vault regardless of the scope chosen in Step 1. Proceed to Step 4 immediately (the agent's output replaces Step 3).
 
 For ≤20 notes: continue with Step 3.
 

--- a/.claude/plugins/onebrain/skills/connect/SKILL.md
+++ b/.claude/plugins/onebrain/skills/connect/SKILL.md
@@ -33,7 +33,7 @@ If the total note count exceeds 20, delegate to the **Knowledge Linker** agent i
 
 ## Step 2b: Delegate to Agent (>20 Notes)
 
-If more than 20 notes are in scope: dispatch the **Knowledge Linker** agent (`agents/knowledge-linker.md`) as a foreground sub-agent (`run_in_background: false`, `mode: "bypassPermissions"`), passing `vault_root`, `knowledge_folder`, `resources_folder`, `areas_folder`, and `projects_folder`. The agent scans the full vault and returns connection suggestions. Once it returns, skip Steps 3–5 and proceed to Step 6.
+If more than 20 notes are in scope: dispatch the **Knowledge Linker** agent (`agents/knowledge-linker.md`) as a foreground sub-agent (`run_in_background: false`, `mode: "bypassPermissions"`), passing `vault_root`, `knowledge_folder`, `resources_folder`, `areas_folder`, and `projects_folder`. The agent scans the full vault and returns connection suggestions. Once it returns, present those suggestions to the user and ask for approval (Step 4), implement approved links (Step 5), then continue from Step 6.
 
 For ≤20 notes: continue with Step 3.
 

--- a/.claude/plugins/onebrain/skills/consolidate/SKILL.md
+++ b/.claude/plugins/onebrain/skills/consolidate/SKILL.md
@@ -36,12 +36,20 @@ Wait for response.
 
 ---
 
+## Step 2.5: Pre-classify (parallel)
+
+Before processing, dispatch one **Inbox Classifier** agent (`agents/inbox-classifier.md`) per selected inbox note in parallel (`run_in_background: false`, `mode: "bypassPermissions"`). Pass each note's `note_path`, `note_content`, `vault_root`, and the four folder variables. Wait for all results before proceeding to Step 3.
+
+Store each result as the default routing recommendation for that note. If a classifier call fails or returns an empty result, proceed without a recommendation for that note.
+
+---
+
 ## Step 3: Process Each Selected Item
 
 For each item:
 
 ### 3a. Analyze
-Read the file fully. Identify:
+Read the file fully. Use the pre-classification from Step 2.5 as the starting point. Confirm or adjust based on your own reading:
 - What type of knowledge this is (insight, reference, idea, project note, area)
 - What existing notes it relates to (search via qmd if available, otherwise Glob `[knowledge_folder]/**/*.md`, `[resources_folder]/**/*.md`, `[projects_folder]/**/*.md`, `[areas_folder]/**/*.md`)
 - Whether it deserves its own note or should be merged into an existing one

--- a/.claude/plugins/onebrain/skills/consolidate/SKILL.md
+++ b/.claude/plugins/onebrain/skills/consolidate/SKILL.md
@@ -38,7 +38,7 @@ Wait for response.
 
 ## Step 2.5: Pre-classify (parallel)
 
-Before processing, dispatch one **Inbox Classifier** agent (`agents/inbox-classifier.md`) per selected inbox note in parallel (`run_in_background: false`, `mode: "bypassPermissions"`). Pass each note's `note_path`, `note_content`, `vault_root`, and the four folder variables. Wait for all results before proceeding to Step 3.
+Before processing, dispatch one **Inbox Classifier** agent (`agents/inbox-classifier.md`) per selected inbox note in parallel (`run_in_background: false`, `mode: "bypassPermissions"`). Pass each note's `note_path`, `note_content`, `vault_root`, `knowledge_folder`, `resources_folder`, `areas_folder`, and `projects_folder`. Wait for all results before proceeding to Step 3.
 
 Store each result as the default routing recommendation for that note. If a classifier call fails or returns an empty result, proceed without a recommendation for that note.
 

--- a/.claude/plugins/onebrain/skills/learn/SKILL.md
+++ b/.claude/plugins/onebrain/skills/learn/SKILL.md
@@ -141,7 +141,7 @@ After writing, dispatch a background sub-agent (`run_in_background: true`, `mode
 - `vault_root` : absolute path to the directory containing vault.yml
 - `knowledge_folder`, `resources_folder`, `areas_folder`, `projects_folder` : from INSTRUCTIONS.md config
 
-The main agent proceeds to the Confirm step immediately — do not wait for the link suggester.
+Proceed to Confirm immediately — do not wait for the link suggester.
 
 ---
 

--- a/.claude/plugins/onebrain/skills/learn/SKILL.md
+++ b/.claude/plugins/onebrain/skills/learn/SKILL.md
@@ -135,13 +135,7 @@ After writing, run `qmd update -c [qmd_collection]` if qmd is available (keeps t
 
 ## Step 6: Suggest Links (background)
 
-After writing, dispatch a background sub-agent (`run_in_background: true`, `mode: "bypassPermissions"`) using the Link Suggester agent with:
-- `new_note_path` : the path of the file just written (relative to vault_root)
-- `new_note_content` : the content just written
-- `vault_root` : absolute path to the directory containing vault.yml
-- `knowledge_folder`, `resources_folder`, `areas_folder`, `projects_folder` : from INSTRUCTIONS.md config
-
-Proceed to Confirm immediately — do not wait for the link suggester.
+After writing, dispatch the **Link Suggester** agent (`agents/link-suggester.md`) as a background sub-agent (`run_in_background: true`, `mode: "bypassPermissions"`), passing `new_note_path`, `new_note_content`, `vault_root`, and the four folder variables. Proceed to Confirm immediately.
 
 ---
 

--- a/.claude/plugins/onebrain/skills/learn/SKILL.md
+++ b/.claude/plugins/onebrain/skills/learn/SKILL.md
@@ -135,7 +135,7 @@ After writing, run `qmd update -c [qmd_collection]` if qmd is available (keeps t
 
 ## Step 6: Suggest Links (background)
 
-After writing, dispatch the **Link Suggester** agent (`agents/link-suggester.md`) as a background sub-agent (`run_in_background: true`, `mode: "bypassPermissions"`), passing `new_note_path`, `new_note_content`, `vault_root`, and the four folder variables. Proceed to Confirm immediately.
+After writing, dispatch the **Link Suggester** agent (`agents/link-suggester.md`) as a background sub-agent (`run_in_background: true`, `mode: "bypassPermissions"`), passing `new_note_path`, `new_note_content`, `vault_root`, `knowledge_folder`, `resources_folder`, `areas_folder`, and `projects_folder`. Proceed to Confirm immediately.
 
 ---
 

--- a/.claude/plugins/onebrain/skills/learn/SKILL.md
+++ b/.claude/plugins/onebrain/skills/learn/SKILL.md
@@ -133,7 +133,19 @@ After writing, run `qmd update -c [qmd_collection]` if qmd is available (keeps t
 
 ---
 
-## Step 6: Confirm
+## Step 6: Suggest Links (background)
+
+After writing, dispatch a background sub-agent (`run_in_background: true`, `mode: "bypassPermissions"`) using the Link Suggester agent with:
+- `new_note_path` : the path of the file just written (relative to vault_root)
+- `new_note_content` : the content just written
+- `vault_root` : absolute path to the directory containing vault.yml
+- `knowledge_folder`, `resources_folder`, `areas_folder`, `projects_folder` : from INSTRUCTIONS.md config
+
+The main agent proceeds to the Confirm step immediately — do not wait for the link suggester.
+
+---
+
+## Step 7: Confirm
 
 Report what was saved:
 > Learned: "[short summary]"

--- a/.claude/plugins/onebrain/skills/reading-notes/SKILL.md
+++ b/.claude/plugins/onebrain/skills/reading-notes/SKILL.md
@@ -131,7 +131,7 @@ Populate `## Related` by searching for vault notes related to the book's topic (
 
 ## Step 6: Suggest Tags (background)
 
-After writing, dispatch the **Tag Suggester** agent (`agents/tag-suggester.md`) as a background sub-agent (`run_in_background: true`, `mode: "bypassPermissions"`), passing `new_note_path`, `new_note_content`, `vault_root`, and the four folder variables. Proceed to Follow Up immediately.
+After writing, dispatch the **Tag Suggester** agent (`agents/tag-suggester.md`) as a background sub-agent (`run_in_background: true`, `mode: "bypassPermissions"`), passing `new_note_path`, `new_note_content`, `vault_root`, `knowledge_folder`, `resources_folder`, `areas_folder`, and `projects_folder`. Proceed to Follow Up immediately.
 
 ---
 

--- a/.claude/plugins/onebrain/skills/reading-notes/SKILL.md
+++ b/.claude/plugins/onebrain/skills/reading-notes/SKILL.md
@@ -129,7 +129,13 @@ Populate `## Related` by searching for vault notes related to the book's topic (
 
 ---
 
-## Step 6: Follow Up
+## Step 6: Suggest Tags (background)
+
+After writing, dispatch the **Tag Suggester** agent (`agents/tag-suggester.md`) as a background sub-agent (`run_in_background: true`, `mode: "bypassPermissions"`), passing `new_note_path`, `new_note_content`, `vault_root`, and the four folder variables. Proceed to Follow Up immediately.
+
+---
+
+## Step 7: Follow Up
 
 > Notes saved to `[resources_folder]/[subfolder]/[Title] : Notes.md`.
 >

--- a/.claude/plugins/onebrain/skills/wrapup/SKILL.md
+++ b/.claude/plugins/onebrain/skills/wrapup/SKILL.md
@@ -161,9 +161,9 @@ After the session log is written and Step 8 confirmation is sent, silently check
 1. Read `[agent_folder]/MEMORY.md` frontmatter and extract the `updated:` date field
 2. If `[agent_folder]/MEMORY.md` does not exist, or `updated:` is absent or cannot be parsed, skip this step silently — no output, no error
 3. Calculate the number of days between the `updated:` date and today
-4. If days ≥ 7: append this single line to the wrapup output (after the Step 8 confirmation):
+4. If days ≥ 7: insert this line into the Step 8 output, before the `Good session!` sign-off:
    ```
    📊 MEMORY.md hasn't been updated in N days — consider running /recap
    ```
-   (where N is the actual number of days calculated)
+   (where N is the actual number of days calculated; use the same YYYY-MM-DD date established in Step 1 as "today")
 5. If days < 7: do nothing, no output

--- a/.claude/plugins/onebrain/skills/wrapup/SKILL.md
+++ b/.claude/plugins/onebrain/skills/wrapup/SKILL.md
@@ -142,28 +142,25 @@ If a genuinely useful long-term insight emerged this session : a clear behaviora
 
 ---
 
-## Step 8: Confirm
+## Step 8: Auto Recap Check
+
+Before confirming, silently check if a recap is overdue:
+
+1. Read `[agent_folder]/MEMORY.md` frontmatter and extract the `updated:` date field
+2. If `[agent_folder]/MEMORY.md` does not exist, or `updated:` is absent or cannot be parsed, set `recap_hint` to nil — no output, no error
+3. Calculate the number of days between the `updated:` date and today (use the same YYYY-MM-DD date established in Step 1)
+4. If days ≥ 7: set `recap_hint` to `📊 MEMORY.md hasn't been updated in N days — consider running /recap` (where N is the actual number of days)
+5. If days < 7: set `recap_hint` to nil
+
+---
+
+## Step 9: Confirm
 
 Say:
 > Session saved to `[logs_folder]/YYYY/MM/YYYY-MM-DD-session-NN.md`.
 >
 > [If action items]: I logged N action items : they'll appear in your Tasks view.
-> [If MEMORY.md updated]: I also added a learning to `[agent_folder]/MEMORY.md`.
+> [If MEMORY.md updated in Step 6]: I also added a learning to `[agent_folder]/MEMORY.md`.
+> [If recap_hint is set]: [recap_hint]
 >
 > Good session! See you next time.
-
----
-
-## Step 9: Auto Recap Check
-
-After the session log is written and Step 8 confirmation is sent, silently check if a recap is overdue:
-
-1. Read `[agent_folder]/MEMORY.md` frontmatter and extract the `updated:` date field
-2. If `[agent_folder]/MEMORY.md` does not exist, or `updated:` is absent or cannot be parsed, skip this step silently — no output, no error
-3. Calculate the number of days between the `updated:` date and today
-4. If days ≥ 7: insert this line into the Step 8 output, before the `Good session!` sign-off:
-   ```
-   📊 MEMORY.md hasn't been updated in N days — consider running /recap
-   ```
-   (where N is the actual number of days calculated; use the same YYYY-MM-DD date established in Step 1 as "today")
-5. If days < 7: do nothing, no output

--- a/.claude/plugins/onebrain/skills/wrapup/SKILL.md
+++ b/.claude/plugins/onebrain/skills/wrapup/SKILL.md
@@ -151,3 +151,19 @@ Say:
 > [If MEMORY.md updated]: I also added a learning to `[agent_folder]/MEMORY.md`.
 >
 > Good session! See you next time.
+
+---
+
+## Step 9: Auto Recap Check
+
+After the session log is written and Step 8 confirmation is sent, silently check if a recap is overdue:
+
+1. Read `[agent_folder]/MEMORY.md` frontmatter and extract the `updated:` date field
+2. If `[agent_folder]/MEMORY.md` does not exist, or `updated:` is absent or cannot be parsed, skip this step silently — no output, no error
+3. Calculate the number of days between the `updated:` date and today
+4. If days ≥ 7: append this single line to the wrapup output (after the Step 8 confirmation):
+   ```
+   📊 MEMORY.md hasn't been updated in N days — consider running /recap
+   ```
+   (where N is the actual number of days calculated)
+5. If days < 7: do nothing, no output

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,7 +116,7 @@ Skills are plain Markdown files. The AI reads them at runtime — no compilation
    - `run_in_background: true` — for fire-and-forget tasks (link suggestion, tagging). The skill proceeds immediately; the agent notifies the user when done.
    - `run_in_background: false` — for tasks whose results the skill needs before continuing (classification, analysis). Launch multiple in parallel when processing a batch.
 
-5. Register the agent in the **Background Agents** table in [INSTRUCTIONS.md](.claude/plugins/onebrain/INSTRUCTIONS.md) and in the table above.
+5. Register the agent in the **Agents** table in [INSTRUCTIONS.md](.claude/plugins/onebrain/INSTRUCTIONS.md) and in the table above. Note: both tables include a Mode column; keep them in sync.
 
 Agents are stateless — they receive all context in the prompt payload and do not retain memory between invocations. Keep them focused on a single task.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,10 +7,10 @@ Thanks for your interest in contributing. This document covers how the project i
 Good contributions include:
 
 - New slash commands (skills)
+- New background agents (focused autonomous tasks dispatched by skills)
 - Improvements to existing skills — clearer instructions, better prompts, edge case handling
 - Bug fixes in install scripts
 - README and documentation improvements
-- Support for additional AI agents
 
 ## Project Structure
 
@@ -28,7 +28,11 @@ Good contributions include:
 ├── hooks/
 │   └── hooks.json                       Hook configuration (session automation)
 └── agents/
-    └── knowledge-linker.md              Knowledge graph agent (used by /connect)
+    ├── knowledge-linker.md              Knowledge graph agent (used by /connect)
+    ├── link-suggester.md                Auto-add wikilinks after note creation (used by /learn)
+    ├── tag-suggester.md                 Auto-add tags from vault vocabulary (used by /capture, /reading-notes)
+    ├── inbox-classifier.md              Pre-classify inbox notes for /consolidate
+    └── task-extractor.md                Extract action items from braindumps (used by /braindump)
 ```
 
 Key files: [marketplace.json](.claude-plugin/marketplace.json) · [plugin.json](.claude/plugins/onebrain/.claude-plugin/plugin.json) · [INSTRUCTIONS.md](.claude/plugins/onebrain/INSTRUCTIONS.md) · [hooks.json](.claude/plugins/onebrain/hooks/hooks.json)
@@ -58,9 +62,37 @@ Skills are plain Markdown files. The AI reads them at runtime — no compilation
 - Prefer adding steps over removing them — removals can break workflows users depend on
 - Test manually: open a vault, invoke the command, follow it through
 
-## Adding a New Agent
+## Skills vs Agents — When to Use Which
 
-Agents are specialized subprocesses invoked by skills for focused, autonomous tasks. The existing example is [`knowledge-linker.md`](.claude/plugins/onebrain/agents/knowledge-linker.md), used by `/connect`.
+| | Skill | Agent |
+|--|-------|-------|
+| Invoked by | User (slash command or auto-route) | Another skill |
+| Runs | Inline, sequential | Background or parallel |
+| User interaction | Yes — can ask questions, confirm | No — autonomous, notifies only |
+| Scope | Multi-step workflow | Single focused task |
+| Reuse | One entry point | Can be dispatched by many skills |
+
+**Create an agent when all of these are true:**
+1. The task is self-contained and does not need user input mid-run
+2. It would block the main agent for more than one step if done inline
+3. It is either reusable across multiple skills, or benefits from parallel execution (e.g. classifying 10 inbox notes simultaneously)
+
+**Keep it in the skill when:**
+- The task is a single step that is already fast
+- It needs user confirmation before acting
+- It only makes sense in one skill's sequential flow
+
+**Existing agents** (for reference before adding a new one):
+
+| Agent | Dispatched by | Mode | Purpose |
+|-------|--------------|------|---------|
+| `knowledge-linker.md` | `/connect` | foreground | Find and add wikilinks across vault |
+| `link-suggester.md` | `/learn` | background | Auto-add up to 3 wikilinks to a new note |
+| `tag-suggester.md` | `/capture`, `/reading-notes` | background | Auto-add up to 3 tags from vault vocabulary |
+| `inbox-classifier.md` | `/consolidate` | foreground parallel | Pre-classify inbox notes for routing |
+| `task-extractor.md` | `/braindump` | background | Extract action items as formatted vault tasks |
+
+## Adding a New Agent
 
 1. Create `.claude/plugins/onebrain/agents/[agent-name].md`
 2. Add YAML frontmatter:
@@ -68,17 +100,25 @@ Agents are specialized subprocesses invoked by skills for focused, autonomous ta
    ```yaml
    ---
    name: Agent Display Name
-   description: One-line description — when this agent should be invoked
+   description: One-line description — what this agent does and when it runs
    color: blue
    ---
    ```
 
    Supported colors: `blue`, `green`, `red`, `yellow`, `purple`, `orange`.
 
-3. Write the agent's system prompt — its role, process, and output format
-4. Invoke the agent from a skill using the Agent tool, passing it the task context
+3. Write the agent prompt with these sections:
+   - **Input** — list every variable the agent receives
+   - **Process** — numbered steps; keep it to ≤7 steps
+   - **Constraints** — hard limits (max items, files it may not touch, exit conditions)
 
-Agents are stateless — they receive context from the invoking skill and return a result. Keep them focused on a single task.
+4. Dispatch the agent from the invoking skill using the Agent tool. Pass all required input as a structured prompt payload. Choose the dispatch mode:
+   - `run_in_background: true` — for fire-and-forget tasks (link suggestion, tagging). The skill proceeds immediately; the agent notifies the user when done.
+   - `run_in_background: false` — for tasks whose results the skill needs before continuing (classification, analysis). Launch multiple in parallel when processing a batch.
+
+5. Register the agent in the **Background Agents** table in [INSTRUCTIONS.md](.claude/plugins/onebrain/INSTRUCTIONS.md) and in the table above.
+
+Agents are stateless — they receive all context in the prompt payload and do not retain memory between invocations. Keep them focused on a single task.
 
 ## Adding a New Hook
 


### PR DESCRIPTION
## Summary

- **5 new agents**: `link-suggester`, `tag-suggester`, `inbox-classifier`, `task-extractor`, `knowledge-linker` — dispatched automatically by skills, never invoked directly by the user
- **Phase 2 sub-agent enhancements**: context pre-loader, stale note scanner, MEMORY.md overflow guard, orphan checkpoint auto-synthesis, `areas_folder` payload
- **Session-Start Briefing upgrades**: fallback defaults, stale project list, "Coming up (3 days)" section, MEMORY.md overflow warning
- **CONTRIBUTING.md**: Skill vs Agent decision guide with existing agents reference table and Mode column
- **Vault update support**: `/update` script syncs v1.9.0 → v1.9.3 cleanly

## Agent dispatch pattern (standardized)

All agents use a consistent one-line inline dispatch format:

> dispatch the **Agent Name** agent (`agents/agent-name.md`) as a [background/foreground] sub-agent (`run_in_background: X`, `mode: "bypassPermissions"`), passing `param1`, `param2`, .... Proceed to [next step] immediately.

## Skills updated

| Skill | Change |
|-------|--------|
| `/learn` | dispatches `link-suggester` (background) after writing note |
| `/capture` | dispatches `tag-suggester` (background) after note creation |
| `/reading-notes` | dispatches `tag-suggester` (background) after note creation |
| `/braindump` | dispatches `task-extractor` (background) after filing; template no longer includes inline task section |
| `/consolidate` | dispatches `inbox-classifier` (foreground parallel) per inbox note |
| `/connect` | dispatches `knowledge-linker` (foreground) via Step 2b when >20 notes |
| `/wrapup` | recap check (Step 8) now runs before confirmation (Step 9) |

## Agents

| Agent | Mode | Dispatched by | Purpose |
|-------|------|--------------|---------|
| `knowledge-linker` | foreground | `/connect` | Find and add wikilinks across vault |
| `link-suggester` | background | `/learn` | Auto-add up to 3 wikilinks to new notes |
| `tag-suggester` | background | `/capture`, `/reading-notes` | Auto-add up to 3 tags from vault vocabulary |
| `inbox-classifier` | foreground parallel | `/consolidate` | Pre-classify inbox notes for routing |
| `task-extractor` | background | `/braindump` | Extract action items as vault tasks |

## Files changed

- `.claude/plugins/onebrain/INSTRUCTIONS.md` — Phase 2 sub-agent, Session-Start Briefing, Agents table
- `.claude/plugins/onebrain/agents/` — 5 new agent files
- `.claude/plugins/onebrain/skills/learn/SKILL.md` — link-suggester dispatch
- `.claude/plugins/onebrain/skills/capture/SKILL.md` — tag-suggester dispatch
- `.claude/plugins/onebrain/skills/reading-notes/SKILL.md` — tag-suggester dispatch
- `.claude/plugins/onebrain/skills/braindump/SKILL.md` — task-extractor dispatch
- `.claude/plugins/onebrain/skills/consolidate/SKILL.md` — inbox-classifier dispatch
- `.claude/plugins/onebrain/skills/connect/SKILL.md` — knowledge-linker dispatch (Step 2b)
- `.claude/plugins/onebrain/skills/wrapup/SKILL.md` — recap check before confirmation
- `.claude/plugins/onebrain/.claude-plugin/plugin.json` — bumped to v1.9.3
- `CONTRIBUTING.md` — Skill vs Agent guide