### PR TITLE
fix(update): prevent spurious exit code 2 on self-replace

### DIFF
--- a/.claude/plugins/onebrain/.claude-plugin/plugin.json
+++ b/.claude/plugins/onebrain/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "onebrain",
-  "version": "1.9.4",
+  "version": "1.9.5",
   "description": "OneBrain — Where human and AI thinking become one. A powerful thinking partner powered by AI synergy.",
   "author": {
     "name": "OneBrain Contributors"

--- a/.claude/plugins/onebrain/skills/update/update.sh
+++ b/.claude/plugins/onebrain/skills/update/update.sh
@@ -6,8 +6,10 @@
 #   bash .claude/plugins/onebrain/skills/update/update.sh           # dry-run (compare only)
 #   bash .claude/plugins/onebrain/skills/update/update.sh --apply   # apply updates
 #
-# Note: wrapped in main() so bash reads the entire script before execution — prevents
-# misaligned reads if this file is replaced by its own --apply run.
+# Note: two-layer self-replacement guard:
+#   1. main() — bash parses the full function body before executing any of it
+#   2. exit $? at end — terminates the process immediately after main() returns,
+#      preventing bash from issuing a second read into the now-replaced file on disk.
 
 set -uo pipefail
 

--- a/.claude/plugins/onebrain/skills/update/update.sh
+++ b/.claude/plugins/onebrain/skills/update/update.sh
@@ -213,3 +213,4 @@ echo "status: ok"
 
 } # end main
 main "$@"
+exit $?  # terminate immediately after main — prevents bash from reading the replaced script file


### PR DESCRIPTION
## Summary

- Add `exit $?` after `main "$@"` so bash terminates immediately after main returns
- Without this, bash keeps the script's file descriptor open and seeks into the newly-replaced `update.sh` after apply, producing a syntax error (exit code 2) even though the update succeeded
- Bump v1.9.4 → v1.9.5

## Test plan

- [ ] Run `/update` with a version delta — apply should complete with exit code 0, no syntax error output