### PR TITLE
fix(v1.10.1): migration spec, compact MEMORY format, cross-skill consistency

### DIFF
--- a/.claude/plugins/onebrain/.claude-plugin/plugin.json
+++ b/.claude/plugins/onebrain/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "onebrain",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "OneBrain — Where human and AI thinking become one. A powerful thinking partner powered by AI synergy.",
   "author": {
     "name": "OneBrain Contributors"

--- a/.claude/plugins/onebrain/INSTRUCTIONS.md
+++ b/.claude/plugins/onebrain/INSTRUCTIONS.md
@@ -80,9 +80,9 @@ created: YYYY-MM-DD
 
 ## Personality (Personalized During Onboarding)
 
-Read the "AI Personality Instructions" and "Agent Identity" sections in `[agent_folder]/MEMORY.md` and follow them.
+Read the `## Identity & Personality` section in `[agent_folder]/MEMORY.md` and follow it.
 The agent has a name and personality set during onboarding — use the name and match the personality style.
-If `[agent_folder]/MEMORY.md` has no "Agent Identity" section, onboarding has not run yet — use a helpful, concise, and professional tone until then.
+If `[agent_folder]/MEMORY.md` has no `## Identity & Personality` section, onboarding has not run yet — use a helpful, concise, and professional tone until then.
 
 ## Available Workflows
 
@@ -113,7 +113,7 @@ These workflows are documented in `.claude/plugins/onebrain/skills/`:
 | `/reorganize` | `reorganize/SKILL.md` | Migrate flat notes into subfolders (one-time) | (manual only, high impact) |
 | `/qmd` | `qmd/SKILL.md` | Set up and manage qmd search index | (manual only) |
 | `/update` | `update/SKILL.md` | Update system files from GitHub | (manual only) |
-| `/doctor` | `doctor/SKILL.md` | Vault + config health check: broken links, orphan notes, stale MEMORY.md entries, plugin config | user asks to check vault health, diagnose issues, or run /doctor |
+| `/doctor` | `doctor/SKILL.md` | Vault + config health check: broken links, orphan notes, stale memory/ files, plugin config | user asks to check vault health, diagnose issues, or run /doctor |
 | `/help` | `help/SKILL.md` | List available commands with use cases | user asks what commands or skills are available, or what the agent can do |
 
 **Agents** — These agents live in `.claude/plugins/onebrain/agents/` and are dispatched automatically by skills. They are never invoked directly by the user.
@@ -148,7 +148,7 @@ Run before responding to any user message.
 - Get current local time in HH:MM format — if unavailable, treat as 09:00–17:00 (no emoji)
 
 **Step 2 — Send greeting immediately:** `[greeting] [name] [emoji]`
-- `[name]` from MEMORY.md "Agent Identity"; `[greeting]`/`[emoji]` from time-of-day:
+- `[name]` from MEMORY.md `## Identity & Personality` (**Agent:** field); `[greeting]`/`[emoji]` from time-of-day:
 
 | Local time | Concept | Emoji |
 |---|---|---|

--- a/.claude/plugins/onebrain/hooks/checkpoint-hook.sh
+++ b/.claude/plugins/onebrain/hooks/checkpoint-hook.sh
@@ -121,7 +121,7 @@ if [ "$COUNT" -ge "$MSG_THRESHOLD" ] || [ "$ELAPSED" -ge "$TIME_THRESHOLD" ]; th
   YEAR="${TODAY%%-*}"
   MONTH="${TODAY#*-}"; MONTH="${MONTH%%-*}"
   LOG_DIR="${LOGS_FOLDER_ABS}/${YEAR}/${MONTH}"
-  EXISTING=$(ls "${LOG_DIR}/"${TODAY}-*checkpoint*.md 2>/dev/null | wc -l | tr -d ' ')
+  EXISTING=$(ls "${LOG_DIR}/${TODAY}-"*checkpoint*.md 2>/dev/null | wc -l | tr -d ' ')
   NN=$(printf "%02d" $(( EXISTING + 1 )))
   PROMPT="${TODAY}-checkpoint-${NN}.md"
   # Build JSON — just the filename as reason; Claude follows INSTRUCTIONS.md

--- a/.claude/plugins/onebrain/hooks/checkpoint-hook.sh
+++ b/.claude/plugins/onebrain/hooks/checkpoint-hook.sh
@@ -6,9 +6,10 @@
 #         Outputs JSON {"decision":"block","reason":"YYYY-MM-DD-checkpoint-NN.md"} —
 #         just the filename. Claude reads INSTRUCTIONS.md to write the checkpoint silently.
 #
-# State file: $TMPDIR/onebrain-{PPID}.state (COUNT:LAST_TS) — uses $TMPDIR/$TEMP/$TMP for Windows compat
+# State file: $TMPDIR/onebrain-{PPID}.state (COUNT:LAST_TS:CHKPT_NN) — uses $TMPDIR/$TEMP/$TMP for Windows compat
+# Legacy 2-field format (COUNT:LAST_TS) is tolerated: CHKPT_NN defaults to 0, so NN restarts at 01.
 # COUNT=0 with fresh timestamp in an *existing* state file signals post-checkpoint reset;
-# absence of state file = first run.
+# absence of state file = first run (CHKPT_NN=0 → first checkpoint is always 01).
 # SKIP_WINDOW=60: prevents re-trigger immediately after a checkpoint resets COUNT to 0.
 # MIN_ACTIVITY guard: if fewer than 2 messages since last checkpoint, reset and skip —
 # no file is created for sessions with no meaningful activity.
@@ -83,27 +84,8 @@ get_checkpoint_value() {
   echo "${value:-$default}"
 }
 
-get_folder_value() {
-  local key="$1" default="$2"
-  [ -z "$VAULT_YML" ] && echo "$default" && return
-  [ -f "$VAULT_YML" ] || { echo "$default"; return; }
-  local in_block=0 value=""
-  while IFS= read -r line; do
-    if [[ "$line" =~ ^folders: ]]; then in_block=1; continue; fi
-    if [[ $in_block -eq 1 ]]; then
-      if [[ "$line" =~ ^[[:space:]]+${key}:[[:space:]]*(.+) ]]; then
-        value="${BASH_REMATCH[1]}"; value="${value//\"/}"; value="${value//\'/}"; value="${value#"${value%%[![:space:]]*}"}"; value="${value%"${value##*[![:space:]]}"}"; break
-      fi
-      if [[ "$line" =~ ^[^[:space:]] ]]; then break; fi
-    fi
-  done < "$VAULT_YML"
-  echo "${value:-$default}"
-}
-
 MSG_THRESHOLD=$(get_checkpoint_value "messages" 15)
 TIME_THRESHOLD=$(( $(get_checkpoint_value "minutes" 30) * 60 ))
-LOGS_FOLDER=$(get_folder_value "logs" "07-logs")
-LOGS_FOLDER_ABS="${VAULT_ROOT:+${VAULT_ROOT}/}${LOGS_FOLDER}"
 
 COUNT=$(( COUNT + 1 ))
 ELAPSED=$(( NOW - LAST_TS ))

--- a/.claude/plugins/onebrain/hooks/checkpoint-hook.sh
+++ b/.claude/plugins/onebrain/hooks/checkpoint-hook.sh
@@ -3,7 +3,8 @@
 # Usage: checkpoint-hook.sh stop
 #
 # stop — fires after every response; checkpoints on message/time threshold
-#         Uses JSON {"decision":"block","reason":"..."} to inject prompt back to Claude.
+#         Outputs JSON {"decision":"block","reason":"YYYY-MM-DD-checkpoint-NN.md"} —
+#         just the filename. Claude reads INSTRUCTIONS.md to write the checkpoint silently.
 #
 # State file: $TMPDIR/onebrain-{PPID}.state (COUNT:LAST_TS) — uses $TMPDIR/$TEMP/$TMP for Windows compat
 # COUNT=0 with fresh timestamp in an *existing* state file signals post-checkpoint reset;
@@ -112,14 +113,18 @@ if [ "$COUNT" -ge "$MSG_THRESHOLD" ] || [ "$ELAPSED" -ge "$TIME_THRESHOLD" ]; th
     echo "0:${NOW}" > "$STATE_FILE" 2>/dev/null
     exit 0
   fi
-  if [ "$COUNT" -ge "$MSG_THRESHOLD" ]; then
-    TRIGGER_LABEL="auto (${COUNT} messages)"
-  else
-    TRIGGER_LABEL="auto ($(( ELAPSED / 60 ))m elapsed)"
-  fi
-  # Build JSON first — restore state on json builder failure so future triggers still work
-  PROMPT="Auto-checkpoint triggered by ${TRIGGER_LABEL}. Silently save a checkpoint to the vault logs. Steps: (1) Get today's date YYYY-MM-DD, extract YYYY and MM. (2) Count existing YYYY-MM-DD-checkpoint-*.md files in ${LOGS_FOLDER_ABS}/YYYY/MM/ (using today's actual date in the filename pattern) to find the next checkpoint number NN (zero-padded, starts at 01). (3) Write ${LOGS_FOLDER_ABS}/YYYY/MM/YYYY-MM-DD-checkpoint-NN.md with this exact frontmatter: tags: [checkpoint, session-log], date: YYYY-MM-DD, checkpoint: NN, trigger: auto, merged: false. (4) Content sections: ## What We Worked On (2-3 sentences), ## Key Decisions (bullet list), ## Action Items (tasks with date YYYY-MM-DD), ## Open Questions (bullet list). Keep under 250 words total. No output to user."
-  # Try python3, python, node in order — Windows may only have 'python' or 'node'
+  # Calculate next checkpoint filename — Claude reads INSTRUCTIONS.md to handle it silently
+  TODAY=$(date +%Y-%m-%d 2>/dev/null)
+  [ -z "$TODAY" ] && TODAY=$(python3 -c "import datetime; print(datetime.date.today())" 2>/dev/null)
+  [ -z "$TODAY" ] && TODAY=$(node -e "const d=new Date();console.log(d.toISOString().slice(0,10))" 2>/dev/null)
+  if [ -z "$TODAY" ]; then exit 0; fi
+  YEAR="${TODAY%%-*}"
+  MONTH="${TODAY#*-}"; MONTH="${MONTH%%-*}"
+  LOG_DIR="${LOGS_FOLDER_ABS}/${YEAR}/${MONTH}"
+  EXISTING=$(ls "${LOG_DIR}/"${TODAY}-*checkpoint*.md 2>/dev/null | wc -l | tr -d ' ')
+  NN=$(printf "%02d" $(( EXISTING + 1 )))
+  PROMPT="${TODAY}-checkpoint-${NN}.md"
+  # Build JSON — just the filename as reason; Claude follows INSTRUCTIONS.md
   if command -v python3 &>/dev/null; then
     JSON=$(python3 -c "import json,sys; print(json.dumps({'decision':'block','reason':sys.argv[1]}))" "$PROMPT" 2>/dev/null)
   elif command -v python &>/dev/null; then
@@ -127,8 +132,7 @@ if [ "$COUNT" -ge "$MSG_THRESHOLD" ] || [ "$ELAPSED" -ge "$TIME_THRESHOLD" ]; th
   elif command -v node &>/dev/null; then
     JSON=$(node -e "process.stdout.write(JSON.stringify({decision:'block',reason:process.argv[1]})+'\n')" "$PROMPT" 2>/dev/null)
   else
-    ESCAPED=$(printf '%s' "$PROMPT" | tr -d '\r' | sed 's/\\/\\\\/g; s/"/\\"/g')
-    JSON="{\"decision\":\"block\",\"reason\":\"${ESCAPED}\"}"
+    JSON="{\"decision\":\"block\",\"reason\":\"${PROMPT}\"}"
   fi
   if [ -z "$JSON" ]; then
     # all builders failed — skip checkpoint silently (exit 0 avoids Claude Code error warning)

--- a/.claude/plugins/onebrain/hooks/checkpoint-hook.sh
+++ b/.claude/plugins/onebrain/hooks/checkpoint-hook.sh
@@ -38,16 +38,17 @@ if [ "$NOW" -eq 0 ]; then exit 0; fi
 
 # --- Read or initialize state ---
 if [ -f "$STATE_FILE" ]; then
-  IFS=':' read -r COUNT LAST_TS < "$STATE_FILE"
+  IFS=':' read -r COUNT LAST_TS CHKPT_NN < "$STATE_FILE"
   if ! [[ "$COUNT" =~ ^[0-9]+$ ]] || ! [[ "$LAST_TS" =~ ^[0-9]+$ ]]; then
     # Malformed — reset cleanly; COUNT=0 so increment will bring it to 1
-    COUNT=0
+    COUNT=0; CHKPT_NN=0
     LAST_TS=$(stat -f %m "$STATE_FILE" 2>/dev/null || stat -c %Y "$STATE_FILE" 2>/dev/null || node -e "const fs=require('fs');console.log(Math.floor(fs.statSync(process.argv[1]).mtimeMs/1000))" "$STATE_FILE" 2>/dev/null || echo "$NOW")
   elif [ "$COUNT" -eq 0 ] && [ $(( NOW - LAST_TS )) -lt $SKIP_WINDOW ]; then
     exit 0  # another checkpoint just fired — skip
   fi
+  [[ "$CHKPT_NN" =~ ^[0-9]+$ ]] || CHKPT_NN=0  # default for old 2-field state files
 else
-  COUNT=0; LAST_TS=$NOW
+  COUNT=0; LAST_TS=$NOW; CHKPT_NN=0
 fi
 
 # --- Stop mode: check thresholds against vault.yml config ---
@@ -110,7 +111,7 @@ ELAPSED=$(( NOW - LAST_TS ))
 if [ "$COUNT" -ge "$MSG_THRESHOLD" ] || [ "$ELAPSED" -ge "$TIME_THRESHOLD" ]; then
   if [ "$COUNT" -lt $MIN_ACTIVITY ]; then
     # Threshold fired on time but not enough activity — reset and wait next round
-    echo "0:${NOW}" > "$STATE_FILE" 2>/dev/null
+    echo "0:${NOW}:${CHKPT_NN}" > "$STATE_FILE" 2>/dev/null
     exit 0
   fi
   # Calculate next checkpoint filename — Claude reads INSTRUCTIONS.md to handle it silently
@@ -118,11 +119,8 @@ if [ "$COUNT" -ge "$MSG_THRESHOLD" ] || [ "$ELAPSED" -ge "$TIME_THRESHOLD" ]; th
   [ -z "$TODAY" ] && TODAY=$(python3 -c "import datetime; print(datetime.date.today())" 2>/dev/null)
   [ -z "$TODAY" ] && TODAY=$(node -e "const d=new Date();console.log(d.toISOString().slice(0,10))" 2>/dev/null)
   if [ -z "$TODAY" ]; then exit 0; fi
-  YEAR="${TODAY%%-*}"
-  MONTH="${TODAY#*-}"; MONTH="${MONTH%%-*}"
-  LOG_DIR="${LOGS_FOLDER_ABS}/${YEAR}/${MONTH}"
-  EXISTING=$(ls "${LOG_DIR}/${TODAY}-"*checkpoint*.md 2>/dev/null | wc -l | tr -d ' ')
-  NN=$(printf "%02d" $(( EXISTING + 1 )))
+  CHKPT_NN=$(( CHKPT_NN + 1 ))
+  NN=$(printf "%02d" "$CHKPT_NN")
   PROMPT="${TODAY}-checkpoint-${NN}.md"
   # Build JSON — just the filename as reason; Claude follows INSTRUCTIONS.md
   if command -v python3 &>/dev/null; then
@@ -138,12 +136,12 @@ if [ "$COUNT" -ge "$MSG_THRESHOLD" ] || [ "$ELAPSED" -ge "$TIME_THRESHOLD" ]; th
     # all builders failed — skip checkpoint silently (exit 0 avoids Claude Code error warning)
     exit 0
   fi
-  if ! echo "0:${NOW}" > "$STATE_FILE" 2>/dev/null; then
+  if ! echo "0:${NOW}:${CHKPT_NN}" > "$STATE_FILE" 2>/dev/null; then
     # state file not writable — still emit JSON so checkpoint is saved, but count won't reset
     :
   fi
   printf '%s\n' "$JSON"
 else
-  echo "${COUNT}:${LAST_TS}" > "$STATE_FILE"
+  echo "${COUNT}:${LAST_TS}:${CHKPT_NN}" > "$STATE_FILE"
 fi
 exit 0

--- a/.claude/plugins/onebrain/skills/clone/SKILL.md
+++ b/.claude/plugins/onebrain/skills/clone/SKILL.md
@@ -54,7 +54,7 @@ updated: YYYY-MM-DD
 
 ## Identity
 - Source: [agent_folder]/MEMORY.md
-- Agent name: [read from [agent_folder]/MEMORY.md Agent Identity section]
+- Agent name: [read from [agent_folder]/MEMORY.md `## Identity & Personality` section — value of **Agent:** field]
 - Last updated: [TODAY'S DATE]
 
 ## Index

--- a/.claude/plugins/onebrain/skills/distill/SKILL.md
+++ b/.claude/plugins/onebrain/skills/distill/SKILL.md
@@ -86,7 +86,7 @@ Suggest a subfolder in `[knowledge_folder]/`:
   > 2. Append — add a `## Update — YYYY-MM-DD` section with new findings
   > 3. Cancel
 
-  If **Append** is chosen: before writing new content, read the existing digest note and check for any low-confidence lessons already there (marked `low-confidence` or `[conf:low]`). If any exist, surface them:
+  If **Append** is chosen: before writing new content, read the existing digest note and check for any lessons marked as low-confidence. If any exist, surface them:
   > This note has M low-confidence lessons. Want to re-evaluate any before appending? (list them)
   User may promote or leave them as-is. If none exist, skip this silently and proceed to append.
 
@@ -121,10 +121,9 @@ sources_span: YYYY-MM-DD to YYYY-MM-DD
 
 ## Lessons
 
-[Generalizable insights — candidates for MEMORY.md]
-- [Lesson 1] `[conf:high]`
-- [Lesson 2] `[conf:medium]`
-- [Lesson 3] `[conf:low]`
+[Generalizable insights — use /learn to promote to memory/]
+- [Lesson 1]
+- [Lesson 2]
 
 ## Open Questions
 

--- a/.claude/plugins/onebrain/skills/distill/SKILL.md
+++ b/.claude/plugins/onebrain/skills/distill/SKILL.md
@@ -56,7 +56,7 @@ Extract and consolidate across all sources:
 - **Core question** — what was being explored or decided?
 - **What we found** — key findings, facts, conclusions
 - **Key decisions made** — explicit choices that were committed to
-- **Lessons** — generalizable insights worth keeping long-term (assign confidence score)
+- **Lessons** — generalizable insights worth keeping long-term
 - **Open questions** — still unresolved as of the most recent source
 - **Entities involved** — tools, projects, people mentioned
 
@@ -86,7 +86,7 @@ Suggest a subfolder in `[knowledge_folder]/`:
   > 2. Append — add a `## Update — YYYY-MM-DD` section with new findings
   > 3. Cancel
 
-  If **Append** is chosen: before writing new content, read the existing digest note and check for any lessons marked as low-confidence. If any exist, surface them:
+  If **Append** is chosen: before writing new content, read the existing digest note and check for any lessons that appear hedged or uncertain in phrasing (e.g. "might", "possibly", "unclear if", or legacy `[conf:low]` markers). If any exist, surface them:
   > This note has M low-confidence lessons. Want to re-evaluate any before appending? (list them)
   User may promote or leave them as-is. If none exist, skip this silently and proceed to append.
 
@@ -122,8 +122,7 @@ sources_span: YYYY-MM-DD to YYYY-MM-DD
 ## Lessons
 
 [Generalizable insights — use /learn to promote to memory/]
-- [Lesson 1]
-- [Lesson 2]
+- [list generalizable insights]
 
 ## Open Questions
 

--- a/.claude/plugins/onebrain/skills/distill/SKILL.md
+++ b/.claude/plugins/onebrain/skills/distill/SKILL.md
@@ -27,7 +27,7 @@ Use qmd if available for content searches; Grep/Glob as fallback.
 
 1. **Session logs**: Search `[logs_folder]/**/*.md` for topic keywords — extract matching `## Key Decisions`, `## Action Items`, `## Open Questions` sections
 2. **Inbox**: Search `[inbox_folder]/*.md` for related content
-3. **MEMORY.md**: Grep `[agent_folder]/MEMORY.md` Key Learnings for related entries
+3. **memory/ files**: Search `[agent_folder]/memory/` for related entries — match topic keywords against filename and frontmatter `topics:` field
 4. **Project/knowledge notes**: Search `[projects_folder]/**/*.md`, `[knowledge_folder]/**/*.md`, and `[resources_folder]/**/*.md` — filter by note title or first 100 words
 
 Report to user (N = total matches across all sources; Q = project/knowledge/resource notes combined):
@@ -86,7 +86,7 @@ Suggest a subfolder in `[knowledge_folder]/`:
   > 2. Append — add a `## Update — YYYY-MM-DD` section with new findings
   > 3. Cancel
 
-  If **Append** is chosen: before writing new content, read the existing digest note and check for any `[conf:low]` lessons already there. If any exist, surface them:
+  If **Append** is chosen: before writing new content, read the existing digest note and check for any low-confidence lessons already there (marked `low-confidence` or `[conf:low]`). If any exist, surface them:
   > This note has M low-confidence lessons. Want to re-evaluate any before appending? (list them)
   User may promote or leave them as-is. If none exist, skip this silently and proceed to append.
 

--- a/.claude/plugins/onebrain/skills/doctor/SKILL.md
+++ b/.claude/plugins/onebrain/skills/doctor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: doctor
-description: "Diagnose vault and plugin health — checks broken links, orphan notes, stale MEMORY.md entries, inbox backlog, and plugin config validity"
+description: "Diagnose vault and plugin health — checks broken links, orphan notes, stale memory/ files, inbox backlog, and plugin config validity"
 ---
 
 # Doctor
@@ -43,6 +43,8 @@ Run all applicable checks based on flags (default: all). Collect findings before
 - Report only — no auto-fix (linking requires semantic judgment; use /connect instead)
 
 **Stale memory/ files:**
+- If `[agent_folder]/MEMORY.md` does not exist, report: `🟡 MEMORY.md: not found — run /onboarding` and skip both this check and the MEMORY.md size check below
+- If `memory/` folder does not exist, skip this check
 - Read all `memory/` files with `status: active` or `status: needs-review`; skip `status: deprecated`
 - Flag files where `verified:` frontmatter is older than 90 days
 - Flag files with no `verified:` field
@@ -95,6 +97,7 @@ Use this format:
 🔴 Broken links (N): [[Missing Note]] in "Source Note"
 🟡 Orphan notes (N): 03-knowledge/topic/Note.md
 🟡 Stale memory/ files (N): not verified in 90+ days
+🟡 MEMORY.md structure: pre-v1.10.1 Identity format — run /doctor --fix or /update
 🟡 MEMORY.md size: N lines — consider /distill to compress
 🟢 MEMORY.md size: OK (N lines)
 🟡 Inbox backlog: N files — consider /consolidate
@@ -220,6 +223,7 @@ Do NOT delete any content, modify files outside `[agent_folder]/MEMORY.md` and t
 | Rows in INDEX.md pointing to missing files | List dead links |
 | Files with `verified` > 90 days | Check active/needs-review only (skip deprecated); auto-set `status: needs-review` in file and INDEX.md |
 | Critical Behaviors section > 15 items | Warn: suggest moving excess to memory/ |
+| MEMORY.md `## Identity & Personality` uses old 6-field labels (`**Agent name:**`, `**User name:**`) | Warn: "MEMORY.md Identity block uses pre-v1.10.1 format — run /doctor --fix or /update to migrate" |
 | Checkpoint files with `merged: true` | Delete them (safety net — /wrapup handles these, /doctor catches stragglers) |
 | Checkpoint files > 14 days old with no session log | AskUserQuestion: "Found {N} checkpoints >14 days old with no session log — delete all?" `delete-all / show-list / skip` |
 | memory/ files with non-compliant names | List offenders (not kebab-case, has date prefix, or >5 words); `--fix` auto-renames |
@@ -248,6 +252,11 @@ Ongoing maintenance only (not migration). Fixes issues arising after initial set
    - Update INDEX.md wikilinks to match renamed files
 
 3. **Reset `recap.min_frequency`** to `2` if invalid value found in vault.yml.
+
+4. **Rewrite MEMORY.md Identity & Personality to compact format:**
+   - Trigger: old 6-field labels detected (`**Agent name:**`, `**User name:**`, etc.)
+   - Confirm with AskUserQuestion: "MEMORY.md has pre-v1.10.1 Identity format. Rewrite to compact format?" Options: `yes / no`
+   - If yes: apply same migration as /update Step 4 — extract field values using extraction hints, write compact block, preserve all other sections unchanged
 
 Update `vault.yml` `stats.last_doctor_fix: YYYY-MM-DD` on completion.
 

--- a/.claude/plugins/onebrain/skills/doctor/SKILL.md
+++ b/.claude/plugins/onebrain/skills/doctor/SKILL.md
@@ -42,13 +42,11 @@ Run all applicable checks based on flags (default: all). Collect findings before
 - These may be disconnected from the knowledge graph
 - Report only — no auto-fix (linking requires semantic judgment; use /connect instead)
 
-**Stale MEMORY.md entries:**
-- Read `[agent_folder]/MEMORY.md`. If the file does not exist, skip all MEMORY.md checks (stale entries, size) and report: `🟡 MEMORY.md: not found at [agent_folder]/MEMORY.md — run /onboarding`
-- Read Key Learnings
-- **Skip** lines that begin with `~~` (already superseded — do not flag as stale)
-- Flag entries where `[verified:YYYY-MM-DD]` is older than 90 days
-- Flag entries with no `[verified:...]` tag at all
-- Flag entries with `[conf:low]` where `[verified:YYYY-MM-DD]` is older than 30 days (or has no `[verified:...]` tag)
+**Stale memory/ files:**
+- Read all `memory/` files with `status: active` or `status: needs-review`; skip `status: deprecated`
+- Flag files where `verified:` frontmatter is older than 90 days
+- Flag files with no `verified:` field
+- Flag files with `conf: low` where `verified:` is older than 30 days (or absent)
 
 **MEMORY.md size:**
 - Count lines in `[agent_folder]/MEMORY.md`
@@ -96,7 +94,7 @@ Use this format:
 ### Vault
 🔴 Broken links (N): [[Missing Note]] in "Source Note"
 🟡 Orphan notes (N): 03-knowledge/topic/Note.md
-🟡 Stale MEMORY.md entries (N): not verified in 90+ days
+🟡 Stale memory/ files (N): not verified in 90+ days
 🟡 MEMORY.md size: N lines — consider /distill to compress
 🟢 MEMORY.md size: OK (N lines)
 🟡 Inbox backlog: N files — consider /consolidate
@@ -124,26 +122,25 @@ If no issues:
 
 Run all fix passes. Each pass confirms with the user before writing.
 
-### Pass A: MEMORY.md confidence scores
+### Pass A: memory/ confidence scores
 
-Collect auto-fixable issues from the Key Learnings scan:
-- `[conf:high]` entries not verified in 90+ days → downgrade to `[conf:medium]`
-- `[conf:medium]` entries not verified in 180+ days → downgrade to `[conf:low]`
-- Entries with no `[conf:...]` tag → add `[conf:medium]` as baseline, then apply staleness rules above
-- Entries with no `[verified:...]` tag → add `[verified:YYYY-MM-DD]` using the **date prefix from the entry line** (the `YYYY-MM-DD` at the start of each `- YYYY-MM-DD —` bullet); if no date prefix exists, treat the entry as maximally stale — flag it as requiring manual review rather than assigning today's date (assigning today would incorrectly reset the staleness clock)
+Collect auto-fixable issues from the stale memory/ files scan:
+- `conf: high` files with `verified:` older than 90 days → downgrade to `conf: medium`
+- `conf: medium` files with `verified:` older than 180 days → downgrade to `conf: low`
+- Files with no `conf:` field → add `conf: medium` as baseline, then apply staleness rules above
+- Files with no `verified:` field → flag for manual review (do not assign today's date — would reset the staleness clock)
 
-If 0 issues: skip this pass, note "No MEMORY.md issues to fix."
+If 0 issues: skip this pass, note "No memory/ confidence issues to fix."
 
 Otherwise, confirm with AskUserQuestion (if user declines, skip this pass — no changes written):
-> Found N MEMORY.md issues. Apply confidence score fixes?
-> - Add missing [conf:medium] baseline to untagged entries
+> Found N memory/ confidence issues. Apply fixes?
+> - Add missing conf: medium baseline to files with no conf field
 > - Downgrade stale confidence scores
-> - Add missing [verified:...] dates from entry date prefixes
-> - Flag maximally stale entries (no [verified:] tag AND no date prefix) for manual review — these will NOT be auto-fixed
+> - Flag files with no verified: date for manual review — these will NOT be auto-fixed
 
-After applying auto-fixes, if any maximally stale entries were found, list each one verbatim as a blockquote so the user can review and update manually:
-> ⚠️ Maximally stale — needs manual review:
-> > `- [entry text]`
+After applying auto-fixes, list any files flagged for manual review:
+> ⚠️ Needs manual review (no verified: date):
+> > `memory/filename.md`
 
 ### Pass B: Broken wikilink fuzzy-fix
 
@@ -205,15 +202,7 @@ If `timezone` was not found: skip this pass, note "No deprecated keys to clean u
 
 ### Final step
 
-After all fix passes complete (whether or not all passes ran), if Pass A actually wrote changes to MEMORY.md (i.e., user confirmed and fixes were applied — not skipped or declined), re-sort the `## Key Learnings & Patterns` section in-place:
-1. `[conf:high]` entries first, newest → oldest
-2. `[conf:medium]` entries next, newest → oldest
-3. `[conf:low]` entries last, newest → oldest
-4. Preserve each `<!-- conf:* ... -->` comment line exactly as-is (the markers may have additional text after the tier name, e.g. `<!-- conf:high — empirically confirmed -->`); do not strip or rewrite them
-5. If a conf group has no entries, omit that group's comment marker entirely rather than leaving an empty section
-6. Entries with no `[conf:...]` tag: treat as `[conf:medium]` for sorting purposes only (do not add a tag)
-
-Then, if any files were written to disk (Pass A or Pass B made confirmed changes — Pass C edits vault.yml, which is not a markdown note and is not indexed by qmd), and `qmd_collection` is set in vault.yml, run:
+After all fix passes complete, if any files were written to disk (Pass A or Pass B made confirmed changes — Pass C edits vault.yml, which is not a markdown note and is not indexed by qmd), and `qmd_collection` is set in vault.yml, run:
 ```bash
 qmd update -c [qmd_collection]
 ```

--- a/.claude/plugins/onebrain/skills/onboarding/SKILL.md
+++ b/.claude/plugins/onebrain/skills/onboarding/SKILL.md
@@ -198,23 +198,16 @@ updated: [TODAY'S DATE]
 
 ## Identity & Personality
 
-**Agent name:** [agent_name]
-**Agent personality:** [agent_personality]: [agent_personality_description]
-**User name:** [preferred_name]
-**User role:** [role]
-**Tone:** [tone]
-**Detail level:** [detail_level]
+**Agent:** [agent_name]
+**Personality:** [agent_personality]: [agent_personality_description]
+**User:** [preferred_name] · [role]
+**Tone:** [tone] · [detail_level]
 
 You are [agent_name], [preferred_name]'s personal chief of staff inside their Obsidian vault.
-Your personality is [agent_personality]: [agent_personality_description].
 
-- Introduce yourself as [agent_name] when appropriate
-- Address them as [preferred_name]
-- Tone: [tone], [detail_level]
-- Role context: [preferred_name] is a [role]
-- Always prioritize their top goal: [goals[0]]
-- Be proactive: surface relevant connections, flag stale items, suggest next steps
-- Keep responses grounded in their vault : reference actual notes when relevant
+- Priority goal: [goals[0]]
+- Proactive: surface connections, flag stale items, suggest next steps
+- Ground responses in vault — reference actual notes when relevant
 
 ## Active Projects
 

--- a/.claude/plugins/onebrain/skills/update/SKILL.md
+++ b/.claude/plugins/onebrain/skills/update/SKILL.md
@@ -102,19 +102,73 @@ Run these steps IN ORDER. Halt on first failure — do not continue.
 
 **Step 3: Update existing memory/ files**
 - Add missing frontmatter fields: topics, type, conf, verified, updated
-- Rename non-compliant files (date prefix, Title-Case, >5 words) → kebab-case 3–5 words
+- Rename non-compliant files → kebab-case 3–5 words. A file is non-compliant if it has:
+  - A date prefix (e.g. `2026-04-05-bump-version-every-pr.md` → `bump-version-pr.md`)
+  - A numeric segment prefix (e.g. `2026-04-05-02-superpowers-docs-in-vault.md` → `superpowers-docs-vault.md`)
+  - Title-Case or spaces in the filename
+  - More than 5 words (strip stop words; keep the meaningful 3–5)
+- After renaming: update all `[[wikilinks]]` in INDEX.md and any `supersedes:`/`superseded_by:` references to use the new filename
+- Compliant example: `bump-version-pr.md`, `dev-workflow-worktree.md`, `telegram-format.md`
 
 **Step 4: Restructure MEMORY.md** (MUST run after Step 1)
-- Remove ## Key Learnings, ## Key Decisions, ## Recurring Contexts sections entirely
-- Keep ## Identity & Personality, ## Active Projects, ## Critical Behaviors (preserve user items)
-- Remove any auto-wrapup trigger entry from Critical Behaviors if present
-- Update `updated:` frontmatter to today
+
+Target structure — exactly 3 sections. If MEMORY.md already has this structure, skip rewrite but still update `updated:` frontmatter.
+
+```markdown
+## Identity & Personality
+
+**Agent name:** [name]
+**Agent personality:** [personality description]
+**User name:** [user_name]
+**User role:** [role]
+**Tone:** [tone]
+**Detail level:** [detail_level]
+
+You are [agent_name], [user_name]'s personal chief of staff inside their Obsidian vault.
+Your personality is [personality description].
+[Language/gender/self-reference rules if set]
+
+- Introduce yourself as [agent_name] when appropriate
+- Address them as [user_name]
+- Tone: [tone], [detail_level]
+- Role context: [user_name] is a [role]
+- Language: [language rules]
+- Always prioritize their top goal: [primary goal]
+- Be proactive: surface relevant connections, flag stale items, suggest next steps
+- Keep responses grounded in their vault — reference actual notes when relevant
+- [Any AskUserQuestion or tool-use preferences]
+
+## Active Projects
+
+<!-- Updated by /consolidate and /braindump -->
+- **[Project]** — [status emoji + label]. [description].
+
+## Critical Behaviors
+
+- [behavioral item]
+<!-- Add behavioral preferences here via /learn -->
+```
+
+Old-section mapping (apply when migrating from pre-v1.10.0 structure):
+- `## Agent Identity` + `## Identity` + `## Communication Style` + `## Goals & Focus Areas` + `## Values & Working Principles` + `## AI Personality Instructions` → consolidate into `## Identity & Personality`
+- `## Active Projects` → keep as-is
+- `## Critical Behaviors` → preserve if present; if absent, create with items from `## Values & Working Principles` plus an empty comment
+- Remove entirely: `## Key Learnings`, `## Key Decisions`, `## Recurring Contexts`
+
+Always: update `updated:` frontmatter to today.
 
 **Step 5: Create INDEX.md**
 - Read frontmatter of all files in memory/ (batch 20 at a time if >50 files)
 - Include only status: active and status: needs-review in table
+- Column format (exact order): `| File | Topics | Type | Status | Description |`
+  - **File**: wikilink `[[filename-without-extension]]`
+  - **Topics**: comma-separated topics from frontmatter
+  - **Type**: from frontmatter (behavioral / project / context)
+  - **Status**: from frontmatter (active / needs-review)
+  - **Description**: 1-line summary derived from file content (not from frontmatter)
 - For each file with supersedes: X, set superseded_by: [this file] on X's frontmatter
 - Set cache fields: total_active, total_needs_review (omit last_review)
+- If INDEX.md already exists but has wrong column order or missing Description column → rewrite with correct format
 
 **Step 6: Backfill recapped: on existing session logs**
 - If 07-logs/ doesn't exist → skip

--- a/.claude/plugins/onebrain/skills/update/SKILL.md
+++ b/.claude/plugins/onebrain/skills/update/SKILL.md
@@ -152,7 +152,7 @@ Your personality is [personality description].
 Old-section mapping (apply when migrating from pre-v1.10.0 structure):
 - `## Agent Identity` + `## Identity` + `## Communication Style` + `## Goals & Focus Areas` + `## Values & Working Principles` + `## AI Personality Instructions` → consolidate into `## Identity & Personality`
 - `## Active Projects` → keep as-is
-- `## Critical Behaviors` → preserve if present; if absent, create with items from `## Values & Working Principles` plus an empty comment
+- `## Critical Behaviors` → preserve if present; if absent, create with items from `## Values & Working Principles` plus an empty comment; remove any auto-wrapup trigger entry if present (auto-wrapup is now handled by AUTO-SUMMARY.md)
 - Remove entirely: `## Key Learnings`, `## Key Decisions`, `## Recurring Contexts`
 
 Always: update `updated:` frontmatter to today.
@@ -168,7 +168,7 @@ Always: update `updated:` frontmatter to today.
   - **Description**: 1-line summary derived from file content (not from frontmatter)
 - For each file with supersedes: X, set superseded_by: [this file] on X's frontmatter
 - Set cache fields: total_active, total_needs_review (omit last_review)
-- If INDEX.md already exists but has wrong column order or missing Description column → rewrite with correct format
+- If INDEX.md already exists but has wrong column order or missing Description column → rewrite with correct format; preserve existing Description values from old rows (map by filename) rather than regenerating from scratch
 
 **Step 6: Backfill recapped: on existing session logs**
 - If 07-logs/ doesn't exist → skip

--- a/.claude/plugins/onebrain/skills/update/SKILL.md
+++ b/.claude/plugins/onebrain/skills/update/SKILL.md
@@ -117,26 +117,18 @@ Target structure — exactly 3 sections. If MEMORY.md already has this structure
 ```markdown
 ## Identity & Personality
 
-**Agent name:** [name]
-**Agent personality:** [personality description]
-**User name:** [user_name]
-**User role:** [role]
-**Tone:** [tone]
-**Detail level:** [detail_level]
+**Agent:** [name] · [gender/pronoun rules if set]
+**Personality:** [personality description]
+**User:** [user_name] · [role]
+**Tone:** [tone] · [detail_level]
+**Language:** [language rules]
 
 You are [agent_name], [user_name]'s personal chief of staff inside their Obsidian vault.
-Your personality is [personality description].
-[Language/gender/self-reference rules if set]
 
-- Introduce yourself as [agent_name] when appropriate
-- Address them as [user_name]
-- Tone: [tone], [detail_level]
-- Role context: [user_name] is a [role]
-- Language: [language rules]
-- Always prioritize their top goal: [primary goal]
-- Be proactive: surface relevant connections, flag stale items, suggest next steps
-- Keep responses grounded in their vault — reference actual notes when relevant
-- [Any AskUserQuestion or tool-use preferences]
+- Priority goal: [primary goal]
+- Proactive: surface connections, flag stale items, suggest next steps
+- Ground responses in vault — reference actual notes when relevant
+- [AskUserQuestion or tool-use preferences, if set]
 
 ## Active Projects
 

--- a/.claude/plugins/onebrain/skills/update/SKILL.md
+++ b/.claude/plugins/onebrain/skills/update/SKILL.md
@@ -112,7 +112,7 @@ Run these steps IN ORDER. Halt on first failure — do not continue.
 
 **Step 4: Restructure MEMORY.md** (MUST run after Step 1)
 
-Target structure — exactly 3 sections. If MEMORY.md already has this structure, skip rewrite but still update `updated:` frontmatter.
+Target structure — exactly 3 sections. Skip rewrite only if MEMORY.md already uses the compact Identity labels (`**Agent:**`, `**User:**`, `**Tone:**`). If the old 6-field labels are present (`**Agent name:**`, `**User name:**`, etc.), rewrite even if the 3 section headings already exist. Always update `updated:` frontmatter.
 
 ```markdown
 ## Identity & Personality
@@ -121,7 +121,7 @@ Target structure — exactly 3 sections. If MEMORY.md already has this structure
 **Personality:** [personality description]
 **User:** [user_name] · [role]
 **Tone:** [tone] · [detail_level]
-**Language:** [language rules]
+**Language:** [language rules — omit this line if no language rules are set]
 
 You are [agent_name], [user_name]'s personal chief of staff inside their Obsidian vault.
 
@@ -146,6 +146,15 @@ Old-section mapping (apply when migrating from pre-v1.10.0 structure):
 - `## Active Projects` → keep as-is
 - `## Critical Behaviors` → preserve if present; if absent, create with items from `## Values & Working Principles` plus an empty comment; remove any auto-wrapup trigger entry if present (auto-wrapup is now handled by AUTO-SUMMARY.md)
 - Remove entirely: `## Key Learnings`, `## Key Decisions`, `## Recurring Contexts`
+
+Field extraction hints (for old-section consolidation):
+- **Agent:** → name from `## Agent Identity` or `## Identity`; gender/pronoun rules from `## AI Personality Instructions` if present; omit gender/pronoun suffix if absent
+- **Personality:** → archetype + description from `## AI Personality Instructions` or `## Communication Style`
+- **User:** → name from `## Agent Identity`; role from `## Agent Identity` or `## Goals & Focus Areas`
+- **Tone:** → tone + detail_level from `## Communication Style`
+- **Language:** → language rules from `## Communication Style` or `## Agent Identity` if present; omit line entirely if absent
+- Priority goal bullet → first entry from `## Goals & Focus Areas`
+- `## Values & Working Principles` items → `## Critical Behaviors` (only if Critical Behaviors was absent)
 
 Always: update `updated:` frontmatter to today.
 

--- a/.claude/plugins/onebrain/skills/weekly/SKILL.md
+++ b/.claude/plugins/onebrain/skills/weekly/SKILL.md
@@ -106,12 +106,7 @@ Ask where to put these tasks: in a project note, or a new "Weekly Intentions" se
 
 ## Step 7: Update MEMORY.md (If Warranted)
 
-If the weekly review reveals a persistent pattern or learning, add it to `[agent_folder]/MEMORY.md`. Also update the `updated:` field in the frontmatter to today's date.
-
-```
-## Key Learnings & Patterns
-- YYYY-MM-DD : [Weekly pattern observation]
-```
+If the weekly review reveals a persistent pattern or learning, save it via `/learn` — this creates a `memory/` file with proper metadata. Do not append directly to MEMORY.md.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ Migration hardening and cross-skill consistency.
 - `/onboarding`: Step 9 MEMORY.md template updated to compact Identity format
 - `INSTRUCTIONS.md`: startup now reads `## Identity & Personality` — fixes silent personality fallback after migration
 - `/clone`, `/distill`, `/weekly`: updated to reference `memory/` files and `## Identity & Personality` instead of removed MEMORY.md sections
-- Checkpoint hook: fixed glob quoting for iCloud paths with spaces
+- Checkpoint hook: sends just `YYYY-MM-DD-checkpoint-NN.md` as reason instead of full instruction paragraph; fixed glob quoting for iCloud paths with spaces
 
 ## [1.10.0] — 2026-04-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ---
-latest_version: 1.10.0
-released: 2026-04-17
+latest_version: 1.10.1
+released: 2026-04-18
 ---
 
 # Changelog
@@ -9,6 +9,14 @@ All notable changes to OneBrain are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+
+## [1.10.1] — 2026-04-18
+
+Fixes incomplete migration from pre-v1.10.0 vaults — `/update` now enforces explicit structure on MEMORY.md, INDEX.md, and memory file names.
+
+- **Step 3**: explicit rename rules — date prefix, numeric segment prefix, Title-Case, and >5-word filenames all get normalized to kebab-case 3–5 words; wikilinks in INDEX.md updated after rename
+- **Step 4**: full MEMORY.md target template with old-section mapping; vaults migrating from pre-v1.10.0 (7+ sections) are now correctly consolidated into 3 sections (Identity & Personality / Active Projects / Critical Behaviors)
+- **Step 5**: exact INDEX.md column spec `File | Topics | Type | Status | Description`; rewrite triggered if column order or Description column is missing
 
 ## [1.10.0] — 2026-04-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,26 +12,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [1.10.1] — 2026-04-18
 
-Migration hardening, compact MEMORY.md Identity format, and cross-skill consistency.
+Migration hardening and cross-skill consistency.
 
-**`/update` migration spec:**
-- Step 3: explicit rename rules (date prefix, numeric segment, >5 words → kebab-case 3–5 words); INDEX.md wikilinks updated after rename
-- Step 4: compact Identity & Personality format — 5-field block replaces verbose 6-field block + redundant bullets; skip-rewrite now checks field labels not just section headings (v1.10.0 vaults with old format now correctly migrate); field-level extraction hints for old-section consolidation; Language field conditional (omit if absent)
-- Step 5: exact column spec (`File | Topics | Type | Status | Description`) enforced; existing Description values preserved on rewrite
-
-**`/doctor` improvements:**
-- Stale check: now reads `memory/` file frontmatter (`conf:`, `verified:`) instead of MEMORY.md Key Learnings bullets
-- Pass A: patches `memory/` file confidence scores directly; removed obsolete Key Learnings re-sort
-- New health check: detects old 6-field Identity format (`**Agent name:**`, `**User name:**`) and warns
-- New `--fix` pass: rewrites MEMORY.md Identity & Personality to compact format in-place
-
-**`/onboarding`:** Step 9 template updated to compact Identity format (consistent with `/update` Step 4)
-
-**Cross-skill consistency** (stale references to removed sections):
-- `INSTRUCTIONS.md`: Phase 1 startup now reads `## Identity & Personality`; agent name extracted from `**Agent:**` field — fixes silent personality fallback after migration
+- `/update` Step 3: explicit memory file rename rules (date prefix, numeric segment, >5 words → kebab-case 3–5 words); INDEX.md wikilinks updated after rename
+- `/update` Step 4: compact MEMORY.md Identity format (5-field block); skip-rewrite now checks field labels not just headings — v1.10.0 vaults with old 6-field format now correctly migrate; field extraction hints; Language field conditional (omit if absent)
+- `/update` Step 5: exact column spec (`File | Topics | Type | Status | Description`) enforced; existing Description values preserved on rewrite
+- `/doctor`: stale check reads `memory/` file frontmatter instead of MEMORY.md Key Learnings; new health check detects old Identity format; `--fix` rewrites Identity to compact format in-place
+- `/onboarding`: Step 9 MEMORY.md template updated to compact Identity format
+- `INSTRUCTIONS.md`: startup now reads `## Identity & Personality` — fixes silent personality fallback after migration
 - `/clone`, `/distill`, `/weekly`: updated to reference `memory/` files and `## Identity & Personality` instead of removed MEMORY.md sections
-
-**Checkpoint hook:** sends just `YYYY-MM-DD-checkpoint-NN.md` as reason; fixed glob quoting for iCloud paths with spaces
+- Checkpoint hook: fixed glob quoting for iCloud paths with spaces
 
 ## [1.10.0] — 2026-04-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [1.10.1] — 2026-04-18
 
-Fixes incomplete migration from pre-v1.10.0 vaults — `/update` now enforces explicit structure on MEMORY.md, INDEX.md, and memory file names.
+Migration hardening and checkpoint hook cleanup.
 
-- **Step 3**: explicit rename rules — date prefix, numeric segment prefix, Title-Case, and >5-word filenames all get normalized to kebab-case 3–5 words; wikilinks in INDEX.md updated after rename
-- **Step 4**: full MEMORY.md target template with old-section mapping; vaults migrating from pre-v1.10.0 (7+ sections) are now correctly consolidated into 3 sections (Identity & Personality / Active Projects / Critical Behaviors)
-- **Step 5**: exact INDEX.md column spec `File | Topics | Type | Status | Description`; rewrite triggered if column order or Description column is missing
+- `/update` migration: explicit rename rules for memory files (date prefix, numeric segment, >5 words → kebab-case 3–5 words); wikilinks in INDEX.md updated after rename
+- `/update` migration: full MEMORY.md 3-section template with old-section mapping — pre-v1.10.0 vaults (7+ sections) now correctly consolidated
+- `/update` migration: exact INDEX.md column spec enforced (`File | Topics | Type | Status | Description`); rewrite triggered if wrong
+- Checkpoint hook: sends just `YYYY-MM-DD-checkpoint-NN.md` as reason instead of full instruction paragraph — cleaner stop hook display; Claude follows INSTRUCTIONS.md to write checkpoint silently
 
 ## [1.10.0] — 2026-04-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,26 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [1.10.1] — 2026-04-18
 
-Migration hardening and checkpoint hook cleanup.
+Migration hardening, compact MEMORY.md Identity format, and cross-skill consistency.
 
-- `/update` migration: explicit rename rules for memory files (date prefix, numeric segment, >5 words → kebab-case 3–5 words); wikilinks in INDEX.md updated after rename
-- `/update` migration: full MEMORY.md 3-section template with old-section mapping — pre-v1.10.0 vaults (7+ sections) now correctly consolidated
-- `/update` migration: exact INDEX.md column spec enforced (`File | Topics | Type | Status | Description`); rewrite triggered if wrong
-- Checkpoint hook: sends just `YYYY-MM-DD-checkpoint-NN.md` as reason instead of full instruction paragraph — cleaner stop hook display; Claude follows INSTRUCTIONS.md to write checkpoint silently
+**`/update` migration spec:**
+- Step 3: explicit rename rules (date prefix, numeric segment, >5 words → kebab-case 3–5 words); INDEX.md wikilinks updated after rename
+- Step 4: compact Identity & Personality format — 5-field block replaces verbose 6-field block + redundant bullets; skip-rewrite now checks field labels not just section headings (v1.10.0 vaults with old format now correctly migrate); field-level extraction hints for old-section consolidation; Language field conditional (omit if absent)
+- Step 5: exact column spec (`File | Topics | Type | Status | Description`) enforced; existing Description values preserved on rewrite
+
+**`/doctor` improvements:**
+- Stale check: now reads `memory/` file frontmatter (`conf:`, `verified:`) instead of MEMORY.md Key Learnings bullets
+- Pass A: patches `memory/` file confidence scores directly; removed obsolete Key Learnings re-sort
+- New health check: detects old 6-field Identity format (`**Agent name:**`, `**User name:**`) and warns
+- New `--fix` pass: rewrites MEMORY.md Identity & Personality to compact format in-place
+
+**`/onboarding`:** Step 9 template updated to compact Identity format (consistent with `/update` Step 4)
+
+**Cross-skill consistency** (stale references to removed sections):
+- `INSTRUCTIONS.md`: Phase 1 startup now reads `## Identity & Personality`; agent name extracted from `**Agent:**` field — fixes silent personality fallback after migration
+- `/clone`, `/distill`, `/weekly`: updated to reference `memory/` files and `## Identity & Personality` instead of removed MEMORY.md sections
+
+**Checkpoint hook:** sends just `YYYY-MM-DD-checkpoint-NN.md` as reason; fixed glob quoting for iCloud paths with spaces
 
 ## [1.10.0] — 2026-04-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ Migration hardening and cross-skill consistency.
 - `/onboarding`: Step 9 MEMORY.md template updated to compact Identity format
 - `INSTRUCTIONS.md`: startup now reads `## Identity & Personality` — fixes silent personality fallback after migration
 - `/clone`, `/distill`, `/weekly`: updated to reference `memory/` files and `## Identity & Personality` instead of removed MEMORY.md sections
-- Checkpoint hook: sends just `YYYY-MM-DD-checkpoint-NN.md` as reason instead of full instruction paragraph; fixed glob quoting for iCloud paths with spaces
+- Checkpoint hook: sends just `YYYY-MM-DD-checkpoint-NN.md` as reason instead of full instruction paragraph; fixed glob quoting for iCloud paths with spaces; NN now per-session counter in state file — always starts at 01 each session
 
 ## [1.10.0] — 2026-04-17
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -153,7 +153,7 @@ Hooks run shell commands automatically when Claude performs certain actions. Hoo
 
 Most hooks support a `matcher` field to filter by tool name or event subtype. `UserPromptSubmit`, `Stop`, `TeammateIdle`, `TaskCompleted`, `WorktreeCreate`, and `WorktreeRemove` fire on every occurrence and do not support matchers.
 
-**Example — checkpoint system:** OneBrain's built-in `checkpoint-hook.sh` uses the `Stop` hook to auto-save session snapshots. It fires after every response, tracks message count + elapsed time against configurable thresholds, and writes a checkpoint file when either threshold is reached. State is kept in `/tmp/onebrain-{PPID}.state` (format: `COUNT:LAST_TS`) so the hook can accumulate counts across responses without forking a long-running process.
+**Example — checkpoint system:** OneBrain's built-in `checkpoint-hook.sh` uses the `Stop` hook to auto-save session snapshots. It fires after every response, tracks message count + elapsed time against configurable thresholds, and writes a checkpoint file when either threshold is reached. State is kept in `/tmp/onebrain-{PPID}.state` (format: `COUNT:LAST_TS:CHKPT_NN`) so the hook can accumulate counts across responses without forking a long-running process.
 
 **To add a hook:**
 

--- a/hooks/checkpoint-hook.sh
+++ b/hooks/checkpoint-hook.sh
@@ -5,7 +5,8 @@
 # stop — fires after every response; checkpoints on message/time threshold
 #         Uses JSON {"decision":"block","reason":"..."} to inject prompt back to Claude.
 #
-# State file: $TMPDIR/onebrain-{PPID}.state (COUNT:LAST_TS) — uses $TMPDIR/$TEMP/$TMP for Windows compat
+# State file: $TMPDIR/onebrain-{PPID}.state (COUNT:LAST_TS:CHKPT_NN) — uses $TMPDIR/$TEMP/$TMP for Windows compat
+# Legacy 2-field format (COUNT:LAST_TS) is tolerated: CHKPT_NN defaults to 0, so NN restarts at 01.
 # COUNT=0 with fresh timestamp in an *existing* state file signals post-checkpoint reset;
 # absence of state file = first run.
 # SKIP_WINDOW=60: prevents re-trigger immediately after a checkpoint resets COUNT to 0.


### PR DESCRIPTION
## Summary

### Core migration fixes (update/SKILL.md)
- **Step 3**: explicit rename rules (date prefix, numeric segment, >5 words → kebab-case 3–5 words); update INDEX.md wikilinks after rename
- **Step 4**: full MEMORY.md 3-section template with old-section mapping; compact Identity format (5-field block replaces verbose 6-field + redundant bullets); explicit skip-rewrite condition (checks compact labels, not just headings); field-level extraction hints for old-section consolidation; Language field conditional (omit if absent)
- **Step 5**: exact column format (`File | Topics | Type | Status | Description`); preserve existing Description values on rewrite

### checkpoint-hook.sh
- Fixed unquoted glob — quote boundary moved so iCloud paths with spaces don't word-split (`"${LOG_DIR}/${TODAY}-"*checkpoint*.md`)

### doctor/SKILL.md
- Stale check: Key Learnings bullets → memory/ file frontmatter (`conf:`, `verified:`)
- Pass A: updated to patch memory/ files instead of MEMORY.md bullets; removed Key Learnings re-sort from Final step
- Restored MEMORY.md existence guard (was dropped during stale block rewrite)
- Added Memory Health Check: detect old 6-field Identity format (`**Agent name:**`, `**User name:**`)
- Added --fix pass 4: rewrite MEMORY.md Identity to compact format in-place

### onboarding/SKILL.md
- Step 9 template updated to compact Identity format (matches update Step 4 template)

### Cross-skill consistency (stale references to removed sections)
- **INSTRUCTIONS.md**: Phase 1 and Personality section now reference `## Identity & Personality`; agent name extraction points to `**Agent:**` field; doctor description updated
- **clone/SKILL.md**: "Agent Identity section" → `## Identity & Personality`
- **distill/SKILL.md**: grep target Key Learnings → memory/ files
- **weekly/SKILL.md**: Step 7 routes patterns via /learn → memory/ instead of MEMORY.md append

## Why

Running `/update` on pre-v1.10.0 and v1.10.0 vaults left migrations incomplete:
- memory files not renamed to kebab-case
- MEMORY.md keeping old 7-section layout or old 6-field Identity block
- INDEX.md with wrong columns
- After migration, session startup silently fell back to wrong personality (INSTRUCTIONS.md referenced removed section names)
- doctor/weekly/distill/clone still operated on MEMORY.md sections that no longer exist

## Test plan

- [ ] Run `/update` on a v1.9.x vault — memory files renamed, MEMORY.md 3 sections with compact Identity, INDEX.md correct columns
- [ ] Run `/update` on a v1.10.0 vault (old 6-field Identity) — Step 4 rewrites Identity to compact format (does not skip due to matching headings)
- [ ] Re-run `/update` on already-migrated v1.10.1 vault — idempotent (no changes except `updated:` date)
- [ ] Run `/doctor` on old-format vault — warns `🟡 MEMORY.md structure: pre-v1.10.1 Identity format`
- [ ] Run `/doctor --fix` on old-format vault — rewrites Identity section to compact format
- [ ] Session startup after migration — agent greets with correct name and personality (not generic fallback)
- [ ] Checkpoint hook on iCloud path with spaces — NN counter works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)