### PR TITLE
feat: terminal output formatting for all OneBrain skills (v1.10.5)

### DIFF
--- a/.claude/plugins/onebrain/.claude-plugin/plugin.json
+++ b/.claude/plugins/onebrain/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "onebrain",
-  "version": "1.10.4",
+  "version": "1.10.5",
   "description": "OneBrain — Where human and AI thinking become one. A powerful thinking partner powered by AI synergy.",
   "author": {
     "name": "OneBrain Contributors"

--- a/.claude/plugins/onebrain/INSTRUCTIONS.md
+++ b/.claude/plugins/onebrain/INSTRUCTIONS.md
@@ -151,9 +151,10 @@ Run before responding to any user message.
 
 Format — use plain text only, no markdown syntax:
 ```
-────────────────────────────────────
+────────────────────────────────
 [emoji] [greeting] [user]
 Ddd · DD Mon YYYY · HH:MM
+────────────────────────────────
 ```
 
 - `[user]` = user name from MEMORY.md (**User:** field)
@@ -190,8 +191,8 @@ Otherwise, append after the greeting:
 📋 [N] checkpoints — /wrapup?         ← omit if orphan_count = 0
 
 Pending tasks:
-- [ ] task description 📅 YYYY-MM-DD (overdue)
-- [ ] task description 📅 YYYY-MM-DD
+⬜ task description 📅 YYYY-MM-DD (overdue)
+⬜ task description 📅 YYYY-MM-DD
 (+N more — /daily for full list)      ← show only if tasks exceed 5
 ```
 

--- a/.claude/plugins/onebrain/skills/bookmark/SKILL.md
+++ b/.claude/plugins/onebrain/skills/bookmark/SKILL.md
@@ -84,7 +84,7 @@ Append under the correct `##` / `###` section (alphabetical order). Create missi
 ## Step 6: Confirm
 
 Say in one line:
-> Saved to **Bookmarks.md** under `## [Category]`. [If subcategory: `/ ### [Subcategory]`]
+🔖 Saved to `Bookmarks.md` under {Category}. [If subcategory: / {Subcategory}]
 
 ---
 
@@ -97,4 +97,4 @@ If the user asks to move or recategorize a bookmark:
 3. Remove from current section; append to target section (create `##` / `###` as needed)
 4. Refresh `updated` in frontmatter
 5. Confirm in one line:
-   > Moved **[Name]** from `## [Old]` → `## [New]`. [If subcategory: `/ ### [Sub]`]
+   🔖 Moved {Name} from {Old} → {New}. [If subcategory: / {Sub}]

--- a/.claude/plugins/onebrain/skills/bookmark/SKILL.md
+++ b/.claude/plugins/onebrain/skills/bookmark/SKILL.md
@@ -84,7 +84,7 @@ Append under the correct `##` / `###` section (alphabetical order). Create missi
 ## Step 6: Confirm
 
 Say in one line:
-🔖 Saved to `Bookmarks.md` under {Category}. [If subcategory: / {Subcategory}]
+🔖 Saved to `Bookmarks.md` under `## {Category}`. [If subcategory: `/ ### {Subcategory}`]
 
 ---
 
@@ -97,4 +97,4 @@ If the user asks to move or recategorize a bookmark:
 3. Remove from current section; append to target section (create `##` / `###` as needed)
 4. Refresh `updated` in frontmatter
 5. Confirm in one line:
-   🔖 Moved {Name} from {Old} → {New}. [If subcategory: / {Sub}]
+   🔖 Moved {Name} from `## {Old}` → `## {New}`. [If subcategory: `/ ### {Sub}`]

--- a/.claude/plugins/onebrain/skills/braindump/SKILL.md
+++ b/.claude/plugins/onebrain/skills/braindump/SKILL.md
@@ -88,4 +88,4 @@ After writing, dispatch the **Task Extractor** agent (`agents/task-extractor.md`
 ## Step 6: Confirm
 
 Say in one line:
-> Filed to `[inbox_folder]/YYYY-MM-DD-braindump.md`. [If project link: Added note to "Project".]
+💭 Filed to `[inbox_folder]/YYYY-MM-DD-braindump.md`. [If project link: Added note to "Project Name".]

--- a/.claude/plugins/onebrain/skills/capture/SKILL.md
+++ b/.claude/plugins/onebrain/skills/capture/SKILL.md
@@ -107,4 +107,4 @@ After writing, dispatch the **Tag Suggester** agent (`agents/tag-suggester.md`) 
 ## Step 6: Confirm
 
 Say in one line:
-> Captured to `[file path]`.
+📝 Captured to `[file path]`.

--- a/.claude/plugins/onebrain/skills/clone/SKILL.md
+++ b/.claude/plugins/onebrain/skills/clone/SKILL.md
@@ -69,15 +69,17 @@ updated: YYYY-MM-DD
 ## Step 2: Display Clone Summary
 
 Show the user what will be cloned:
-> **Ready to clone:**
-> - `[agent_folder]/MEMORY.md` : identity and personality
-> - `[agent_folder]/INDEX.md` : memory index
-> - `[agent_folder]/CLONE.md` : this manifest
-> - `[agent_folder]/memory/` : N files
-> - `vault.yml` : vault configuration
-> - `.claude/plugins/onebrain/` : OneBrain plugin
->
-> **Not cloned:** your notes, projects, areas, knowledge, resources, archive, logs.
+──────────────────────────────────────────────────────────────
+📦 Ready to Clone
+──────────────────────────────────────────────────────────────
+✅  `[agent_folder]/MEMORY.md`      identity and personality
+✅  `[agent_folder]/INDEX.md`       memory index
+✅  `[agent_folder]/CLONE.md`       this manifest
+✅  `[agent_folder]/memory/`        {N} files
+✅  `vault.yml`                     vault configuration
+✅  `.claude/plugins/onebrain/`     OneBrain plugin
+
+❌  notes, projects, areas, knowledge, resources, archive, logs
 
 ---
 
@@ -103,10 +105,10 @@ If the user chose option 1:
    - `.claude/plugins/onebrain/` to `[output_folder]/.claude/plugins/onebrain/`
    - If archive included: `[archive_folder]/[agent_folder]/memory/` to `[output_folder]/[archive_folder]/[agent_folder]/memory/`
 5. Confirm:
-   > Your agent context is ready at `[output_folder]/`.
-   > Copy its contents to your new vault root to restore context.
-   > **Prerequisite:** Your new vault must have OneBrain installed before importing.
-   > To import: place `[agent_folder]/` at the vault root : MEMORY.md is inside.
+   ✅ Agent context ready at `{output_folder}/`.
+   Copy its contents to your new vault root to restore context.
+   Prerequisite: new vault must have OneBrain installed before importing.
+   → To import: place `[agent_folder]/` at the vault root — MEMORY.md is inside.
 
 ---
 

--- a/.claude/plugins/onebrain/skills/connect/SKILL.md
+++ b/.claude/plugins/onebrain/skills/connect/SKILL.md
@@ -59,11 +59,19 @@ Look for:
 Group suggestions by note. For each suggestion, show:
 
 ```
-## Note A → Note B
-Type: Conceptual overlap
-Reason: Both discuss [shared concept]
-Suggested addition to "Note A":
-  Near "...existing text..." → add "Note B"
+──────────────────────────────────────────────────────────────
+🔗 Connect — {N} suggestions found
+──────────────────────────────────────────────────────────────
+[{n}/{N}] `{Note A}` → `{Note B}`
+  Type: {connection type}
+  Reason: {reason}
+  Add to `{Note A}`:
+    Near "...{nearby text}..." → add [[{Note B}]]
+```
+
+No suggestions:
+```
+✅ No connections found — notes are already well-linked.
 ```
 
 Maximum 10 suggestions. Ask user to approve each batch before implementing.
@@ -78,7 +86,7 @@ For each approved suggestion:
 - Add the wikilink inline or in a "## Related" section at the bottom
 
 After implementing:
-> Added "Note B" link to "Note A".
+✅ Added [[{Note B}]] link to `{Note A}`.
 
 ---
 

--- a/.claude/plugins/onebrain/skills/connect/SKILL.md
+++ b/.claude/plugins/onebrain/skills/connect/SKILL.md
@@ -12,10 +12,15 @@ Find meaningful connections between your notes and suggest wikilinks to build a 
 ## Step 1: Scope
 
 Ask (or infer from context):
-> Do you want to find connections:
-> - For a **specific note** (name it)
-> - Across your entire **knowledge base** (`[projects_folder]/**/*.md`, `[areas_folder]/**/*.md`, `[knowledge_folder]/**/*.md`, `[resources_folder]/**/*.md`)
-> - For **recently added notes** (last 7 days)
+
+AskUserQuestion:
+- question: "What scope do you want to search for connections?"
+- header: "Connect Scope"
+- multiSelect: false
+- options:
+  - label: "specific note", description: "Find connections for a specific note (you'll name it)"
+  - label: "entire knowledge base", description: "Scan all projects, areas, knowledge, and resources"
+  - label: "recently added", description: "Notes added in the last 7 days"
 
 ---
 
@@ -75,6 +80,9 @@ No suggestions:
 ```
 
 Maximum 10 suggestions. Ask user to approve each batch before implementing.
+
+If more than 10 suggestions found, show first 10 and add:
+  (showing 10 of {M} — run /connect again to see more)
 
 ---
 

--- a/.claude/plugins/onebrain/skills/consolidate/SKILL.md
+++ b/.claude/plugins/onebrain/skills/consolidate/SKILL.md
@@ -16,10 +16,11 @@ List all files in `[inbox_folder]/` (excluding .gitkeep). For each file:
 - Note the date and main topics
 
 Report:
-> You have N items in your inbox:
-> 1. `2026-03-20-braindump.md` : ideas about [topic], 2 tasks
-> 2. `2026-03-19-capture.md` : note about [topic]
-> ...
+──────────────────────────────────────────────────────────────
+📥 Consolidate — {N} inbox items
+──────────────────────────────────────────────────────────────
+  1. `{filename}` — {brief description}, {N tasks} tasks
+  2. `{filename}` — {brief description}
 
 ---
 
@@ -67,7 +68,19 @@ Classify the item and route it to the appropriate folder:
 - **Ongoing responsibility (something you maintain over time, not a one-time insight)** → `[areas_folder]/` : examples: health tracking, finances, career development, relationships
 
 Confirm routing with the user for the first 3 items. After that, proceed autonomously : or if the user says 'stop and confirm', return to confirmation mode for the next item.
-> `[filename]`: This looks like [classification] : I'd route it to `[destination-folder]/`. Does that work, or would you prefer a different folder?
+
+[{n}/{N}] `{filename}` looks like {classification}
+  Route to `{folder}/{subfolder}/`?
+
+Then AskUserQuestion:
+- question: "How should I file this note?"
+- header: "Route [{n}/{N}]"
+- multiSelect: false
+- options:
+  - label: "confirm", description: "File as suggested"
+  - label: "different folder", description: "Choose a different destination"
+  - label: "merge", description: "Merge into an existing note instead"
+  - label: "skip", description: "Leave in inbox for now"
 
 Also show merge options if relevant:
 > I'd merge this into "Existing Note" : it adds context about [topic].
@@ -114,10 +127,20 @@ Ask preference once: "After processing, should I archive originals or delete the
 ## Step 6: Summary
 
 Report:
-> Inbox processed:
-> - Merged N items into existing notes
-> - Created N new knowledge notes: "Note A", "Note B"
-> - Archived N originals
-> - N tasks remain open across your vault
->
-> Your inbox is [clear / down to N items].
+──────────────────────────────────────────────────────────────
+📥 Inbox Processed — {N} notes
+──────────────────────────────────────────────────────────────
+Moved:
+  `{filename}`  →  {folder}/{subfolder}
+
+Kept in inbox ({M}):
+  `{filename}` — {reason}
+(omit "Kept in inbox" block if all items moved)
+
+{P} tasks remain open across your vault.
+(omit if no open tasks)
+──────────────────────────────────────────────────────────────
+{N} moved, {M} kept. Inbox {clear / down to M items}.
+
+Empty state:
+✅ Inbox is empty — nothing to process.

--- a/.claude/plugins/onebrain/skills/consolidate/SKILL.md
+++ b/.claude/plugins/onebrain/skills/consolidate/SKILL.md
@@ -26,14 +26,15 @@ Report:
 
 ## Step 2: Let User Choose Scope
 
-Ask:
-> Do you want to:
-> - Process **all** inbox items
-> - Process items from the **last N days**
-> - Process a **specific file** (name it)
-> - Just **review** without moving anything
-
-Wait for response.
+AskUserQuestion:
+- question: "Which items do you want to process?"
+- header: "Consolidate Scope"
+- multiSelect: false
+- options:
+  - label: "all", description: "Process all inbox items"
+  - label: "last N days", description: "Process items from the last N days (specify N)"
+  - label: "specific file", description: "Process a specific file (name it)"
+  - label: "just review", description: "Review without moving anything"
 
 ---
 

--- a/.claude/plugins/onebrain/skills/daily/SKILL.md
+++ b/.claude/plugins/onebrain/skills/daily/SKILL.md
@@ -41,21 +41,31 @@ If normal mode: Glob `[logs_folder]/**/*.md`. Find the most recent session log (
 ### Display the Briefing
 
 ```
-## Daily Briefing · Ddd DD Mon YYYY [morning / afternoon / evening] · inbox N
-
-**Last session (DD Mon):** [1–2 sentence recap of topics + open items]
+──────────────────────────────────────────────────────────────
+📅 Daily Briefing · Ddd DD Mon YYYY {period} · inbox N
+──────────────────────────────────────────────────────────────
+Last session (Ddd DD Mon): [1–2 sentence recap of topics + open items]
 (morning mode only — skip if no prior session found)
 
-**Tasks due today:**
-- [ ] Task description 📅 YYYY-MM-DD (from "Note Name")
-- [ ] Overdue task 📅 YYYY-MM-DD (overdue - from "Note Name")
+Tasks due today:
+  ⬜ Task description 📅 YYYY-MM-DD (from "Note Name")
+  ⬜ Overdue task 📅 YYYY-MM-DD (overdue - from "Note Name")
+  (+N more — /daily for full list)
 
-**Open from last session:**
-- [ ] Action item text
+Open from last session:
+  ⬜ Action item text
 ```
 
-- `Ddd` is the abbreviated day of week (Mon, Tue, Wed, Thu, Fri, Sat, Sun)
+Rules:
+- `{period}` = morning / afternoon / evening
 - Omit `· inbox N` if inbox count is 0
+- Omit `(+N more)` line if 5 or fewer tasks
+- Omit "Last session" block if not morning mode or no prior session exists
 
 If both task sources are empty:
-> No tasks or open items for today.
+```
+──────────────────────────────────────────────────────────────
+📅 Daily Briefing · Ddd DD Mon YYYY {period}
+──────────────────────────────────────────────────────────────
+✅ Nothing on your plate today — clear!
+```

--- a/.claude/plugins/onebrain/skills/distill/SKILL.md
+++ b/.claude/plugins/onebrain/skills/distill/SKILL.md
@@ -31,10 +31,10 @@ Use qmd if available for content searches; Grep/Glob as fallback.
 4. **Project/knowledge notes**: Search `[projects_folder]/**/*.md`, `[knowledge_folder]/**/*.md`, and `[resources_folder]/**/*.md` — filter by note title or first 100 words
 
 Report to user (N = total matches across all sources; Q = project/knowledge/resource notes combined):
-> Found N sources: M session logs, P inbox notes, Q knowledge notes
+Found {N} sources: {M} session logs, {P} inbox notes, {Q} knowledge notes
 
 **If N = 0:** Stop and inform the user:
-> No notes found matching '[topic]'. Try a broader keyword or check the topic name.
+🔴 No notes found matching '{topic}'. Try a broader keyword or check the topic name.
 
 Exit — do not proceed to Step 3.
 
@@ -135,11 +135,13 @@ sources_span: YYYY-MM-DD to YYYY-MM-DD
 
 ---
 
-Report:
-> Distilled into `[path]`.
+Say:
+──────────────────────────────────────────────────────────────
+🧪 Distilled
+──────────────────────────────────────────────────────────────
+`{knowledge_folder}/{subfolder}/{Title}.md`
 
-If you want any lesson to persist in long-term memory, promote it manually:
-> To promote a lesson: `/learn [lesson text]`
+→ To promote a lesson to long-term memory: /learn [lesson text]
 
 ---
 

--- a/.claude/plugins/onebrain/skills/doctor/SKILL.md
+++ b/.claude/plugins/onebrain/skills/doctor/SKILL.md
@@ -104,35 +104,37 @@ Run all applicable checks based on flags (default: all). Collect findings before
 Use this format:
 
 ```
-## OneBrain Doctor · YYYY-MM-DD
+──────────────────────────────────────────────────────────────
+🏥 OneBrain Doctor · YYYY-MM-DD
+──────────────────────────────────────────────────────────────
+📁 Vault
+  🔴 Broken links (N): [[Missing Note]] in "Source Note"
+  🟡 Orphan notes (N): 03-knowledge/topic/Note.md
+  🟡 Inbox backlog: N files — consider /consolidate
+  🟢 Checkpoints: all merged
 
-### Vault
-🔴 Broken links (N): [[Missing Note]] in "Source Note"
-🟡 Orphan notes (N): 03-knowledge/topic/Note.md
-🟡 Stale memory/ files (N): not verified in 90+ days
-🟡 MEMORY.md structure: pre-v1.10.1 Identity format — run /doctor --fix or /update
-🟡 MEMORY.md size: N lines — consider /distill to compress
-🟢 MEMORY.md size: OK (N lines)
-🟡 Inbox backlog: N files — consider /consolidate
-🟢 Checkpoints: all merged
+⚙️ Config
+  🟢 vault.yml: OK
+  🟢 plugin.json: OK (vX.X.X)
+  🔴 qmd_collection: missing — qmd search will not work
+  🟡 vault.yml: `timezone` key found — no longer used, safe to remove
+  🔴 OneBrain hooks: Stop missing or wrong — run /update to register
+  🔴 OneBrain hooks: PreCompact missing or wrong — run /update to register
+  🔴 OneBrain hooks: PostCompact missing or wrong — run /update to register
+  🟢 OneBrain hooks: all 3 registered correctly
+  🔴 qmd: binary not installed — run /qmd setup
+  🔴 qmd: hooks.json missing — run /update to restore
+  🔴 qmd: PostToolUse hook missing or wrong — run /update to restore
+  🟢 qmd: PostToolUse hook registered correctly
 
-### Config
-🟢 vault.yml: OK
-🟢 plugin.json: OK (vX.X.X)
-🔴 qmd_collection: missing — qmd search will not work
-🟡 vault.yml: `timezone` key found — no longer used, safe to remove
-🔴 OneBrain hooks: Stop missing or wrong — run /update to register
-🔴 OneBrain hooks: PreCompact missing or wrong — run /update to register
-🔴 OneBrain hooks: PostCompact missing or wrong — run /update to register
-🟢 OneBrain hooks: all 3 registered correctly
-🔴 qmd: binary not installed — run /qmd setup
-🔴 qmd: hooks.json missing — run /update to restore
-🔴 qmd: PostToolUse hook missing or wrong — run /update to restore
-🟢 qmd: PostToolUse hook registered correctly
-
----
-N issues found (M critical 🔴, P warnings 🟡)
-Run /doctor --fix to repair broken wikilinks and stale memory entries.
+🧠 Memory
+  🟡 Stale memory/ files (N): not verified in 90+ days
+  🟡 MEMORY.md structure: pre-v1.10.1 Identity format — run /doctor --fix or /update
+  🟡 MEMORY.md size: N lines — consider /distill to compress
+  🟢 MEMORY.md size: OK (N lines)
+──────────────────────────────────────────────────────────────
+🔴 N issues found (M critical 🔴, P warnings 🟡)
+Run `/doctor --fix` to repair.
 ```
 
 If no issues:

--- a/.claude/plugins/onebrain/skills/doctor/SKILL.md
+++ b/.claude/plugins/onebrain/skills/doctor/SKILL.md
@@ -214,8 +214,9 @@ For each unique broken link name:
 4. **Never auto-replace without user confirmation.** Every substitution requires an explicit yes or number.
 
 After Pass B, report:
-> Fixed N broken links across M files. P links could not be matched automatically — fix manually.
-> Modified files: [list of file paths that were changed]
+✅ Fixed {N} broken links across {M} files.
+🟡 {N} links could not be auto-matched — manual review needed.
+Modified files: [list of file paths that were changed]
 
 ### Pass C: Deprecated vault.yml keys
 

--- a/.claude/plugins/onebrain/skills/help/SKILL.md
+++ b/.claude/plugins/onebrain/skills/help/SKILL.md
@@ -16,49 +16,58 @@ When this skill is invoked, present all available OneBrain commands to the user.
    - If project plugin: read from `.claude/plugins/onebrain/.claude-plugin/plugin.json`
    - If global plugin: use Glob on `~/.claude/plugins/cache/onebrain/onebrain/*/.claude-plugin/plugin.json` to find all cached versions. If multiple matches are returned, use the one with the highest version number (compare the version directory name as semver). If no matches are found, skip the version display.
 3. Display as the first line of your response:
-   - If project plugin: **OneBrain v{version}** (project plugin)
-   - If global plugin: **OneBrain v{version}** (global plugin)
-   - If version could not be determined: **OneBrain**
+   - If project plugin: OneBrain v{version} (project plugin)
+   - If global plugin: OneBrain v{version} (global plugin)
+   - If version could not be determined: OneBrain
 
-## Step 1: Present the Command Table
+## Step 1: Present the Command List
 
-Display a formatted table with all available commands:
+Display a grouped plain text output:
 
-| Command | What it does | When to use it |
-|---------|-------------|----------------|
-| `/onboarding` | First-run setup : personalizes your agent, vault structure, and preferences | Use once when setting up a new vault |
-| `/braindump` | Capture a stream of raw thoughts, ideas, and tasks | When your head is full and you need to offload everything |
-| `/capture` | Quick note capture with automatic wikilink suggestions | When you want to save a single idea, reference, or thought |
-| `/bookmark` | Save a URL with AI-generated name, description, and category to Bookmarks.md | When you want to quickly park a link for later without full processing |
-| `/consolidate` | Review and merge inbox items into your knowledge base | When your inbox is getting full and needs processing |
-| `/connect` | Find connections between notes and suggest wikilinks | When you want to strengthen the web of ideas in your vault |
-| `/research` | Web research on a topic → structured knowledge note | When you want to learn about something and save it |
-| `/summarize` | Fetch a URL and create a structured summary note | When you want to deeply process an article or page into a permanent vault note |
-| `/import` | Import local files (PDF, Word, Excel, images, video, scripts) into vault notes | When you have files on disk you want distilled into your knowledge base |
-| `/reading-notes` | Book or article → structured progressive summary | When finishing a book or long article and want to capture it |
-| `/tasks` | Open live task dashboard in Obsidian : creates/updates `TASKS.md` with live query sections | When you want an overview of what needs doing |
-| `/moc` | Create or refresh vault portal (MOC.md) : a Map of Content with live queries, AI summary, and your pinned links | When you want a bird's-eye view of your entire vault |
-| `/weekly` | Weekly reflection : review sessions, patterns, intentions | At the end of each week for review and planning |
-| `/daily` | Two-phase daily briefing : surfaces tasks and last session context, then saves your stated focus as a daily note | Every morning (or any time you want to reset your focus for the day) |
-| `/recap` | Batch-promotes recurring insights from session logs into `memory/` files — does NOT write to MEMORY.md; applies frequency filter so only insights appearing in multiple sessions are kept | Periodically, when you want to distill recent sessions into long-term memory |
-| `/memory-review` | Interactive review of all memory/ files — keep, update, deprecate, or delete entries one by one | When you want to prune stale or inaccurate agent memory |
-| `/wrapup` | Save a session summary to your session log | At the end of a work session to capture what you did |
-| `/learn` | Teach the agent something : facts about your world or behavioral preferences | When you want the agent to remember something across all future sessions |
-| `/clone` | Package your agent context (agent folder including MEMORY.md) for vault transfer | When moving to a new vault and want to preserve your agent's memory |
-| `/reorganize` | Migrate existing flat notes into subfolders : one-time migration | After upgrading to a version with subfolder organization |
-| `/qmd` | Set up and manage qmd search index (setup, embed, status, reindex, uninstall) | When you want faster vault search or need to manage the search index |
-| `/distill` | Aggregate notes from multiple sessions on a topic into a structured knowledge note | When you want to compress a completed research thread or recurring theme into permanent knowledge |
-| `/doctor` | Diagnose vault and plugin health (broken links, orphan notes, stale memory, inbox backlog) | When something feels off, or as periodic vault maintenance |
-| `/update` | Update OneBrain system files from GitHub | When a new version is available |
-| `/help` | List all available commands | You're already here! |
+```
+──────────────────────────────────────────────────────────────
+📖 OneBrain Commands — v{version}
+──────────────────────────────────────────────────────────────
+Capture & Organize
+  /capture        Quick note capture with wikilinks
+  /braindump      Dump raw thoughts, ideas, tasks
+  /bookmark       Save a URL to Bookmarks.md
+  /consolidate    Process inbox into knowledge base
+
+Research & Recall
+  /research       Web research → structured knowledge note
+  /summarize      URL → deep summary note
+  /reading-notes  Book or article → structured notes
+  /connect        Find connections between notes
+
+Review & Reflect
+  /daily          Daily briefing — tasks + last session
+  /weekly         Weekly reflection and planning
+  /recap          Promote session insights to memory
+  /distill        Compress a research thread into knowledge
+
+System
+  /tasks          Open live task dashboard
+  /moc            Refresh vault portal (MOC.md)
+  /doctor         Vault health check
+  /update         Update OneBrain to latest version
+  /learn          Teach the agent something to remember
+  /wrapup         Save session summary to log
+  /memory-review  Interactive memory pruning
+  /clone          Package agent context for vault transfer
+  /reorganize     Migrate flat notes into subfolders
+  /qmd            Manage search index
+  /onboarding     First-run vault setup
+  /help           Show this list
+──────────────────────────────────────────────────────────────
+/help [command] for details on any command
+```
 
 ## Step 2: Add a Usage Note
 
-After the table, add:
+After the command list, add:
 
----
-
-**Tips:**
-- Commands use the `/` prefix : for example, `/braindump`, `/tasks`, `/research`
-- You can also describe what you want in plain language: "I want to dump some thoughts" or "show me my tasks"
-- New to OneBrain? Start with `/onboarding` to set up your vault and personalize your AI assistant
+Tips:
+  • Commands use the `/` prefix — for example, `/braindump`, `/tasks`, `/research`
+  • You can also describe what you want in plain language
+  • New to OneBrain? Start with `/onboarding`

--- a/.claude/plugins/onebrain/skills/import/SKILL.md
+++ b/.claude/plugins/onebrain/skills/import/SKILL.md
@@ -48,7 +48,7 @@ Parse arguments:
    > Import inbox not found at `[inbox path]`. Run `/onboarding` to set up your vault, or use `/import /path/to/file` to import a specific file.
    Then stop.
 4. If inbox is empty, report:
-   > Inbox is empty (`[inbox path]`). Add files there and run `/import` again, or run `/import /path/to/file`.
+   🔴 Inbox is empty (`[inbox path]`). Add files or use `/import /path/to/file`.
    Then stop.
 
 ### Step 2: Group and display (batch mode only)
@@ -96,33 +96,33 @@ Each subagent runs the appropriate handler section from this skill (see below).
 After all subagents complete, show a summary:
 
 ```
-Import complete : 4 notes created:
+──────────────────────────────────────────────────────────────
+📂 Import Complete — {N} notes
+──────────────────────────────────────────────────────────────
+  `[resources_folder]/research/report.md`         (from report.pdf)
+  `[resources_folder]/finance/budget-summary.md`  (from budget.xlsx)
+  `[resources_folder]/media/hero-image.md`        (from hero-image.png)
+  `[resources_folder]/scripts/cleanup.md`         (from cleanup.sh)
 
-  [resources_folder]/research/report.md         (from report.pdf)
-  [resources_folder]/finance/budget-summary.md  (from budget.xlsx)
-  [resources_folder]/media/hero-image.md        (from hero-image.png)
-  [resources_folder]/scripts/cleanup.md         (from cleanup.sh)
-
-4 files removed from inbox.
+{N} files removed from inbox.
 ```
 
 If any subagent failed:
 ```
-⚠ 1 file failed:
-  deck.pptx : markitdown not installed. File left in inbox. Install with: pipx install markitdown
+⚠️ {N} file(s) failed:
+  `{filename}` — {reason}
 ```
 
 If any files were skipped due to unsupported type:
 ```
-⏭ 2 files skipped (unsupported : left in inbox):
-  unknown.xyz
-  notes.txt
+⏭ {N} file(s) skipped (unsupported — left in inbox):
+  `{filename}`
 ```
 
 If a note was created but the inbox delete failed (partial success):
 ```
-⚠ 1 partial success:
-  report.pdf : note created at [resources_folder]/research/report.md, but inbox file could not be deleted. Delete manually.
+⚠️ {N} partial success:
+  `{filename}` — note created at `{vault path}`, but inbox file could not be deleted. Delete manually.
 ```
 
 ### Supported File Types

--- a/.claude/plugins/onebrain/skills/learn/SKILL.md
+++ b/.claude/plugins/onebrain/skills/learn/SKILL.md
@@ -32,9 +32,14 @@ Options: `active-projects / memory-file`
 Before writing a new file, grep `memory/` for files with overlapping topics or similar content.
 Scan ONLY files with `status: active` or `status: needs-review` — skip deprecated files.
 
-If a potential conflict is found, show via AskUserQuestion:
-- question: "Possible conflict with `memory/{filename}.md`\n  New: \"{new fact}\"\n  Existing: \"{existing fact}\"\n\n  How should I handle this?"
-- header: "⚠️ Conflict"
+If a potential conflict is found, show this display block first:
+⚠️ Possible conflict with `memory/{filename}.md`
+  New: "{new fact}"
+  Existing: "{existing fact}"
+
+Then AskUserQuestion:
+- question: "How should I handle this conflict?"
+- header: "Conflict"
 - multiSelect: false
 - options:
   - label: "update", description: "Merge new fact into existing file (old content still partially correct)"

--- a/.claude/plugins/onebrain/skills/learn/SKILL.md
+++ b/.claude/plugins/onebrain/skills/learn/SKILL.md
@@ -33,16 +33,13 @@ Before writing a new file, grep `memory/` for files with overlapping topics or s
 Scan ONLY files with `status: active` or `status: needs-review` — skip deprecated files.
 
 If a potential conflict is found, show via AskUserQuestion:
-
-⚠️ Possible conflict: memory/onebrain-development.md
-   "Source repo path, /update workflow"
-
-   New fact: "repo moved to ~/projects/onebrain-v2"
-   Existing: "repo at ~/projects/onebrain"
-
-   1) update   — edit existing file (old content still partially correct)
-   2) supersede — create new file, deprecate old (old content fully outdated)
-   3) separate  — create new file separately (no conflict, keep both)
+- question: "Possible conflict with `memory/{filename}.md`\n  New: \"{new fact}\"\n  Existing: \"{existing fact}\"\n\n  How should I handle this?"
+- header: "⚠️ Conflict"
+- multiSelect: false
+- options:
+  - label: "update", description: "Merge new fact into existing file (old content still partially correct)"
+  - label: "supersede", description: "Create new file, deprecate old (old content fully outdated)"
+  - label: "separate", description: "Create new file separately (no conflict, keep both)"
 
 **update** → read existing file, merge new fact in-place, bump `verified` to today.
 No new file created, INDEX.md unchanged.
@@ -98,3 +95,8 @@ Example: `dev-workflow.md` exists → try `dev-workflow-02.md` → `dev-workflow
 
 6. If `supersede` was chosen: additionally set `supersedes: old-file.md` in new file's
    frontmatter and `superseded_by: new-file.md` in old file's frontmatter.
+
+## Confirmation
+
+After writing or updating the file, say in one line:
+🧠 Learned: {brief description of what was saved or updated}.

--- a/.claude/plugins/onebrain/skills/memory-review/SKILL.md
+++ b/.claude/plugins/onebrain/skills/memory-review/SKILL.md
@@ -26,12 +26,28 @@ If memory/ is empty or has no active/needs-review entries → display
 
 ## Display Per Entry
 
-Show each entry in this format:
+Header before first entry:
+──────────────────────────────────────────────────────────────
+🔬 Memory Review — {N} files to review
+──────────────────────────────────────────────────────────────
 
-[1/8] dev | active | conf:high | verified 45 days ago
-      dev-workflow-superpowers
-      "Superpowers flow + worktree + 3 review rounds"
-      → keep / update / needs-review / deprecate / delete / skip / stop
+Per-entry format:
+[{n}/{N}] {topics} | {status} | conf:{level} | verified {X} days ago
+      `{filename}.md`
+      "{1-line description}"
+
+Then AskUserQuestion:
+- question: "What would you like to do with this entry?"
+- header: "Memory Review [{n}/{N}]"
+- multiSelect: false
+- options:
+  - label: "keep", description: "Bump verified date to today, no other changes"
+  - label: "update", description: "Edit confidence, type, or description"
+  - label: "needs-review", description: "Flag for later review"
+  - label: "deprecate", description: "Mark as deprecated (keeps file, removes from active index)"
+  - label: "delete", description: "Move to archive and remove from index"
+  - label: "skip", description: "Move to next entry, no changes"
+  - label: "stop", description: "Exit review, leave remaining entries unchanged"
 
 ## Option Behaviors
 
@@ -75,6 +91,11 @@ Every skill that modifies INDEX.md must update these frontmatter cache fields:
 
 On /memory-review completion: update `vault.yml` `stats.last_memory_review: YYYY-MM-DD`.
 Update regardless of whether any changes were made — the field tracks when the user last reviewed, not when they last changed something. Only skip the update if the user invoked **stop** before processing any entries.
+
+## Completion
+
+After the review session ends:
+✅ Memory review complete — kept {N}, updated {M}, deprecated {P}, deleted {Q}.
 
 ## Edge Cases
 

--- a/.claude/plugins/onebrain/skills/memory-review/SKILL.md
+++ b/.claude/plugins/onebrain/skills/memory-review/SKILL.md
@@ -97,6 +97,8 @@ Update regardless of whether any changes were made — the field tracks when the
 After the review session ends:
 ✅ Memory review complete — kept {N}, updated {M}, deprecated {P}, deleted {Q}.
 
+Note: If more than 40 entries, review shows all entries sequentially (no truncation needed — user controls pace via skip/stop).
+
 ## Edge Cases
 
 - If entry's row is missing from INDEX.md but file exists in memory/ (out of sync) →

--- a/.claude/plugins/onebrain/skills/moc/SKILL.md
+++ b/.claude/plugins/onebrain/skills/moc/SKILL.md
@@ -187,6 +187,6 @@ Run via Bash (fails silently if Obsidian is not installed):
 open "obsidian://open?path=$(cd "${CLAUDE_PROJECT_DIR:-.}" && pwd)/MOC.md" 2>/dev/null || true
 ```
 
-Then say in one line:
+Then say:
 🗺️ MOC.md updated.
 → Opening in Obsidian...

--- a/.claude/plugins/onebrain/skills/moc/SKILL.md
+++ b/.claude/plugins/onebrain/skills/moc/SKILL.md
@@ -180,6 +180,13 @@ PINNED_CONTENT
 
 ---
 
-## Step 5: Confirm
+## Step 5: Open in Obsidian and confirm
 
-`MOC.md updated.`
+Run via Bash (fails silently if Obsidian is not installed):
+```bash
+open "obsidian://open?path=$(cd "${CLAUDE_PROJECT_DIR:-.}" && pwd)/MOC.md" 2>/dev/null || true
+```
+
+Then say in one line:
+🗺️ MOC.md updated.
+→ Opening in Obsidian...

--- a/.claude/plugins/onebrain/skills/onboarding/SKILL.md
+++ b/.claude/plugins/onebrain/skills/onboarding/SKILL.md
@@ -47,11 +47,13 @@ For steps that present a fixed set of choices (personality archetype, communicat
 
 Say:
 
-> Welcome to OneBrain : where human and AI thinking become one.
->
-> I'm going to ask you a few quick questions to personalize your vault. This takes about 2 minutes, and you can always update your settings later by editing `[agent_folder]/MEMORY.md` directly.
->
-> Let's start!
+👋 Welcome to OneBrain — where human and AI thinking become one.
+
+I'm going to ask you a few quick questions to personalize your vault.
+This takes about 2 minutes. You can update settings later by editing
+`[agent_folder]/MEMORY.md` directly.
+
+Let's start!
 
 ---
 
@@ -332,31 +334,17 @@ If user selects "Skip for now": continue to Step 12.
 
 Say:
 
-> You're all set, [preferred_name]! I'm [agent_name] and I'm ready to help. Here's what's set up:
->
-> - Your identity and personality are saved in `05-agent/MEMORY.md`
-> - Your vault is set up with these folders:
->   - `00-inbox/` : raw captures (process regularly); `imports/` subfolder for `/import` staging
->   - `01-projects/` : active projects with tasks
->   - `02-areas/` : ongoing responsibilities (health, finances, career...)
->   - `03-knowledge/` : your own synthesized thinking
->   - `04-resources/` : external info, research output, reference
->   - `05-agent/` : AI context and memory
->   - `06-archive/` : completed and archived items
->   - `07-logs/` : session logs
->
-> [If qmd was set up in Step 11b:] qmd search index active (collection: `<name>`) : the agent will use qmd automatically
->
-> **First things to try:**
-> - `/braindump` : dump anything on your mind right now
-> - `/capture` : add a quick note or idea
-> - `/research [topic]` : research something and save it to your vault
->
-> **How notes are organized:** Project and area notes go into kebab-case subfolders (e.g. `01-projects/work/Website Redesign.md`). I'll suggest a subfolder whenever you create a note : just confirm or adjust. Research and summary output goes to `04-resources/` : use `/consolidate` to turn it into your own thinking in `03-knowledge/`. Use `/learn` to teach me things about your world (domain, tools, terminology) and I'll save them to `05-agent/`. Session logs go into `07-logs/YYYY/MM/` and archive items go into `06-archive/YYYY/MM/`.
->
-> When you're done working, run `/wrapup` to save a session summary.
->
-> What would you like to do first?
+──────────────────────────────────────────────────────────────
+👋 Onboarding Complete
+──────────────────────────────────────────────────────────────
+  `[agent_folder]/MEMORY.md`   identity and personality saved
+  `vault.yml`                  vault configuration saved
+  Folders created:             {list of folders created}
+  Plugin hooks:                registered ✅
+  [If qmd set up:] qmd search: `{collection-name}` ✅
+
+→ Run /daily to see your first briefing.
+→ Run /help to see all available commands.
 
 ---
 
@@ -521,18 +509,15 @@ Identical to Step 11b in Path A. Ask the user whether to set up qmd, and if yes,
 ## Path B : Step 13: Completion message
 
 Say:
-> You're all set, [preferred_name]! I'm [agent_name] and I'm ready to help.
->
-> OneBrain is now bundled inside your vault:
-> - Plugin files copied to `.claude/plugins/onebrain/`
-> - [If Step 9 appended: "OneBrain instructions added to `CLAUDE.md`"] [If Step 9 created: "`CLAUDE.md` created with OneBrain instructions"] [If Step 9 skipped: "OneBrain instructions already present in `CLAUDE.md`"]
-> - [If Step 10 wrote: "Your identity saved in `[agent_folder]/MEMORY.md`"] [If Step 10 kept: "Existing identity in `[agent_folder]/MEMORY.md` preserved"]
-> - Vault folders created (existing folders untouched)
->
-> Use `/update` to keep OneBrain current : it works the same as a fresh vault install.
->
-> The global plugin install is no longer needed for this vault. You can remove it with `/plugin uninstall onebrain@onebrain` if you like, but it's safe to leave as-is.
->
-> [If qmd was set up in Step 12b:] qmd search index active (collection: `<name>`)
->
-> What would you like to do first?
+
+──────────────────────────────────────────────────────────────
+👋 Onboarding Complete
+──────────────────────────────────────────────────────────────
+  `[agent_folder]/MEMORY.md`   identity and personality saved
+  `vault.yml`                  vault configuration saved
+  Folders created:             {list of folders created}
+  Plugin hooks:                registered ✅
+  [If qmd set up:] qmd search: `{collection-name}` ✅
+
+→ Run /daily to see your first briefing.
+→ Run /help to see all available commands.

--- a/.claude/plugins/onebrain/skills/qmd/SKILL.md
+++ b/.claude/plugins/onebrain/skills/qmd/SKILL.md
@@ -113,13 +113,17 @@ Report progress. If it fails, show the error : the collection is created but not
 ### Step 9: Confirm completion
 
 Say:
-> qmd is set up! Collection `<collection-name>` is indexed and ready.
->
-> - The agent will now use qmd for vault-wide searches automatically
-> - The index updates whenever Claude writes or edits files in this vault (via hook)
-> - Run `/qmd embed` to enable semantic/similarity search (optional, slower first run)
-> - Run `/qmd status` to check index health
-> - Run `/qmd uninstall` to remove qmd integration from this vault
+──────────────────────────────────────────────────────────────
+🗄️ qmd — Search Index Ready
+──────────────────────────────────────────────────────────────
+Collection: `{collection-name}`
+Documents indexed: {N}
+Embeddings: {ready / not yet — run /qmd embed to enable semantic search}
+
+→ qmd will auto-update whenever files change in this vault
+→ Run /qmd embed for semantic/similarity search (optional)
+→ Run /qmd status to check index health
+→ Run /qmd uninstall to remove qmd integration
 
 ---
 
@@ -130,7 +134,7 @@ Generate vector embeddings for semantic search.
 ### Step 1: Check prerequisites
 
 Read vault.yml. If `qmd_collection` key is missing:
-> qmd is not configured for this vault. Run `/qmd setup` first.
+🔴 qmd not configured — run /qmd setup to enable vault search.
 
 Stop.
 
@@ -165,7 +169,7 @@ Report completion or any errors.
 ### Step 4: Confirm
 
 Say:
-> Embeddings generated. Semantic search is now active : use natural language queries like "find notes about project planning" and qmd will find conceptually related notes.
+✅ Embeddings generated. Semantic search now active — use natural language queries.
 
 ---
 
@@ -176,12 +180,12 @@ Show collection info and index health.
 ### Step 1: Check prerequisites
 
 Read vault.yml for `qmd_collection`. If missing:
-> qmd is not configured for this vault. Run `/qmd setup` to enable it.
+🔴 qmd not configured — run /qmd setup to enable vault search.
 
 Stop.
 
 Check `which qmd`. If not found:
-> qmd binary not found. It may have been uninstalled. Run `/qmd setup` to reinstall and reconfigure.
+🔴 qmd binary not found — run /qmd setup to reinstall.
 
 Stop.
 
@@ -203,7 +207,7 @@ Force a full BM25 reindex of the vault collection.
 ### Step 1: Check prerequisites
 
 Read vault.yml for `qmd_collection`. If missing:
-> qmd is not configured for this vault. Run `/qmd setup` first.
+🔴 qmd not configured — run /qmd setup to enable vault search.
 
 Stop.
 

--- a/.claude/plugins/onebrain/skills/reading-notes/SKILL.md
+++ b/.claude/plugins/onebrain/skills/reading-notes/SKILL.md
@@ -137,9 +137,12 @@ After writing, dispatch the **Tag Suggester** agent (`agents/tag-suggester.md`) 
 
 ## Step 7: Follow Up
 
-> Notes saved to `[resources_folder]/[subfolder]/[Title] : Notes.md`.
->
-> Want to:
-> - Add this to your reading list in a project note?
-> - Run `/connect` to find vault notes this connects to?
-> - Set a reminder to revisit these notes? (I can add a task)
+──────────────────────────────────────────────────────────────
+📚 Reading Notes — {Title}
+──────────────────────────────────────────────────────────────
+Author: {Author}
+Saved to `[resources_folder]/[subfolder]/[Title] : Notes.md`
+
+→ Add to a reading list in a project note?
+→ Run /connect to find related vault notes.
+→ Set a revisit reminder? (I'll add a task)

--- a/.claude/plugins/onebrain/skills/recap/SKILL.md
+++ b/.claude/plugins/onebrain/skills/recap/SKILL.md
@@ -51,13 +51,23 @@ or `status: needs-review` — skip deprecated files.
 
 Collect ALL conflicts first, then resolve sequentially:
 
-⚠️ 3 conflicts found — resolving one at a time
+──────────────────────────────────────────────────────────────
+⚠️  {N} conflicts found — resolving one at a time
+──────────────────────────────────────────────────────────────
+[{n}/{N}] 💡 insight from session {YYYY-MM-DD}:
+      "{insight text}"
 
-[1/3] 📝 insight from session YYYY-MM-DD:
-      "repo moved to ~/projects/onebrain-v2"
+      Conflicts with `memory/{filename}.md`
 
-      Conflicts with memory/onebrain-development.md
-      → update / supersede / separate / skip
+Then AskUserQuestion:
+- question: "How should I handle this conflict?"
+- header: "Conflict [{n}/{N}]"
+- multiSelect: false
+- options:
+  - label: "update", description: "Merge insight into existing file (old content still partially correct)"
+  - label: "supersede", description: "Create new file, deprecate old (old content fully outdated)"
+  - label: "separate", description: "Create new file separately (no conflict, keep both)"
+  - label: "skip", description: "Discard this insight, move on"
 
 Options:
 - **update** → merge insight into existing file in-place, bump `verified`
@@ -74,12 +84,17 @@ Scan only files whose topics appear in 2+ files — skip deprecated.
 
 Resolve sequentially [1/N]:
 
-🔀 Overlapping topics found [1/2] — merge recommended
+[{n}/{N}] 🔀 Overlapping topics — merge recommended
+  `{file-a}.md`  (topics: {a}, {b})
+  `{file-b}.md`  (topics: {a}, {b}, {c})
 
-memory/dev-workflow.md       (topics: dev, worktree)
-memory/dev-worktree-setup.md (topics: dev, worktree, setup)
-
-→ merge / skip
+Then AskUserQuestion:
+- question: "Merge these overlapping memory files?"
+- header: "Consolidate [{n}/{N}]"
+- multiSelect: false
+- options:
+  - label: "merge", description: "Synthesize into one file (preserves all unique information)"
+  - label: "skip", description: "Leave both files as-is"
 
 **merge:**
 1. Read both files
@@ -122,3 +137,20 @@ Each insight that passes the frequency filter:
 - Update INDEX.md `updated:` and `total_active` counter
 
 Do NOT write to MEMORY.md. Critical Behaviors are promoted exclusively via /learn.
+
+## Output
+
+### No unrecapped logs
+✅ No unrecapped session logs found.
+
+### Completion (after all conflicts + consolidations resolved)
+```
+──────────────────────────────────────────────────────────────
+💡 Recap — {N} sessions processed
+──────────────────────────────────────────────────────────────
+Promoted {N} insights to memory/:
+  • `{filename}.md` — {topic}
+
+{N} session logs marked recapped.
+→ Run /distill to compress a completed thread into a knowledge note.
+```

--- a/.claude/plugins/onebrain/skills/reorganize/SKILL.md
+++ b/.claude/plugins/onebrain/skills/reorganize/SKILL.md
@@ -69,16 +69,18 @@ Also check `[archive_folder]/*.md` for any flat archive files.
 Exclude `.gitkeep` files.
 
 Report:
-> Found N notes to organize:
-> - `[knowledge_folder]/`: N notes
-> - `[resources_folder]/`: N notes
-> - `[areas_folder]/`: N notes
-> - `[projects_folder]/`: N notes
-> - `[logs_folder]/`: N session logs
-> - `[archive_folder]/`: N archive files
+──────────────────────────────────────────────────────────────
+📁 Proposed Reorganization
+──────────────────────────────────────────────────────────────
+🗂️  [knowledge_folder]/ ({N} notes)
+🗂️  [resources_folder]/ ({N} notes)
+🗂️  [areas_folder]/ ({N} notes)
+🗂️  [projects_folder]/ ({N} notes)
+🗂️  [logs_folder]/ ({N} session logs)
+🗂️  [archive_folder]/ ({N} archive files)
 
-If nothing is found, say:
-> Your vault is already organized into subfolders : nothing to do!
+If nothing is found:
+✅ Nothing to do — vault already organized into subfolders.
 
 ---
 
@@ -125,6 +127,9 @@ Present the full migration plan as a table:
 |------|------------|
 | 2026-01-15-session-01.md | → 2026/01 |
 | 2026-02-03-session-01.md | → 2026/02 |
+
+──────────────────────────────────────────────────────────────
+{N} notes total · Proceed?
 ```
 
 ---
@@ -157,16 +162,16 @@ Process notes by folder (all knowledge, then resources, then areas, then project
 ### Step 5: Summary
 
 Report:
-> Reorganization complete!
->
-> - Moved N notes in `[knowledge_folder]/` into N subfolders
-> - Moved N notes in `[resources_folder]/` into N subfolders
-> - Moved N notes in `[areas_folder]/` into N subfolders
-> - Moved N notes in `[projects_folder]/` into N subfolders
-> - Moved N session logs in `[logs_folder]/` into YYYY/MM folders
-> - Moved N files in `[archive_folder]/` into YYYY/MM folders
-> - Skipped N notes (left in place)
->
-> All existing wikilinks (`[[Note Name]]`) still work : Obsidian resolves links by filename, not path.
->
-> Want to run `/connect` to find new connections between your organized notes?
+✅ Moved {N} notes into subfolders.
+
+- Moved N notes in `[knowledge_folder]/` into N subfolders
+- Moved N notes in `[resources_folder]/` into N subfolders
+- Moved N notes in `[areas_folder]/` into N subfolders
+- Moved N notes in `[projects_folder]/` into N subfolders
+- Moved N session logs in `[logs_folder]/` into YYYY/MM folders
+- Moved N files in `[archive_folder]/` into YYYY/MM folders
+- Skipped N notes (left in place)
+
+All existing wikilinks (`[[Note Name]]`) still work : Obsidian resolves links by filename, not path.
+
+Want to run `/connect` to find new connections between your organized notes?

--- a/.claude/plugins/onebrain/skills/reorganize/SKILL.md
+++ b/.claude/plugins/onebrain/skills/reorganize/SKILL.md
@@ -101,36 +101,24 @@ For each note, analyze its content and frontmatter to suggest a subfolder:
 - Use today's date for archiving: `YYYY/MM`
 - Or read the note's `created:` frontmatter if present and use that date instead
 
-Present the full migration plan as a table:
+Present the full migration plan:
 
 ```
-## Proposed Reorganization
+──────────────────────────────────────────────────────────────
+📁 Proposed Reorganization
+──────────────────────────────────────────────────────────────
+🗂️  {folder}/ ({N} notes)
+  {Note name}          →  {subfolder}
+  {Note name}          →  {subfolder}
 
-### [knowledge_folder]/ (N notes)
-| Note | → Subfolder |
-|------|------------|
-| Machine Learning.md | → technology/ai |
-| Sleep Optimization.md | → health |
-
-### [resources_folder]/ (N notes)
-| Note | → Subfolder |
-|------|------------|
-| Python Basics.md | → programming/python |
-
-### [projects_folder]/ (N notes)
-| Note | → Subfolder |
-|------|------------|
-| Website Redesign.md | → web-development |
-
-### [logs_folder]/ (N session logs)
-| File | → Subfolder |
-|------|------------|
-| 2026-01-15-session-01.md | → 2026/01 |
-| 2026-02-03-session-01.md | → 2026/02 |
-
+🗂️  {folder}/ ({N} notes)
+  {Note name}          →  {subfolder}
 ──────────────────────────────────────────────────────────────
 {N} notes total · Proceed?
 ```
+
+If more than 40 notes total, show the first 40 and add:
+  (showing 40 of {N} — run /reorganize again to continue)
 
 ---
 

--- a/.claude/plugins/onebrain/skills/research/SKILL.md
+++ b/.claude/plugins/onebrain/skills/research/SKILL.md
@@ -111,10 +111,15 @@ sources: [list of key sources]
 ## Step 6: Suggest Follow-Up
 
 After creating the note:
-> Research saved to `[resources_folder]/[subfolder]/[Topic Name].md`.
->
-> Based on what I found, you might also want to explore:
-> - [Related topic 1]
-> - [Related topic 2]
->
-> Or run `/summarize [url]` to go deeper on a specific source.
+──────────────────────────────────────────────────────────────
+🔍 Research — {topic}
+──────────────────────────────────────────────────────────────
+Saved to `[resources_folder]/[subfolder]/[Topic Name].md`
+
+You might also explore:
+  • {related topic 1}
+  • {related topic 2}
+(omit "You might also explore" block if no follow-up suggestions)
+
+→ Run /summarize [url] to go deeper on a specific source.
+→ Run /learn to save key insights to memory.

--- a/.claude/plugins/onebrain/skills/summarize/SKILL.md
+++ b/.claude/plugins/onebrain/skills/summarize/SKILL.md
@@ -116,13 +116,18 @@ published: [Publication date if known]
 
 **Suggest links:** Search for related vault notes (use qmd if available, otherwise Glob `[resources_folder]/**/*.md` and `[knowledge_folder]/**/*.md`).
 
-> Summary saved to `[resources_folder]/[subfolder]/[Title].md`.
->
-> This looks related to:
-> - "Related Note 1" : [why]
-> - "Related Note 2" : [why]
->
-> Want me to add links?
+──────────────────────────────────────────────────────────────
+📄 Summary — {Title}
+──────────────────────────────────────────────────────────────
+Saved to `[resources_folder]/[subfolder]/[Title].md`
+
+Related:
+  • "{Note 1}" — {reason}
+  • "{Note 2}" — {reason}
+(omit "Related" block if no related notes found)
+
+→ Add links? (say yes to link them)
+→ Run /learn to save key insights to memory.
 
 **Update bookmark with wikilink:** If the URL was found in `Bookmarks.md` in Step 2, append a wikilink to the existing bookmark entry so it points to the new summary note:
 
@@ -134,8 +139,16 @@ Find the line in `Bookmarks.md` containing the URL and append ` → [[Article Ti
 
 Refresh `updated` in the Bookmarks.md frontmatter. Do this silently : no confirmation needed.
 
-**Clean up bookmark:** After adding the wikilink, ask:
+**Clean up bookmark:** After adding the wikilink, show:
 
-> This URL was in your Bookmarks.md : I've linked it to "Article Title". Want me to remove the bookmark entry now that you have a full summary note?
+🔖 Linked `Bookmarks.md` → [[{Title}]].
 
-If the user confirms, remove the bookmark entry from `Bookmarks.md` and refresh `updated` in its frontmatter.
+Then AskUserQuestion:
+- question: "Remove the bookmark entry now that you have a full summary note?"
+- header: "Bookmark Cleanup"
+- multiSelect: false
+- options:
+  - label: "Remove", description: "Delete the bookmark entry — you have a full summary note now"
+  - label: "Keep both", description: "Keep the bookmark and the summary note"
+
+If the user selects "Remove", remove the bookmark entry from `Bookmarks.md` and refresh `updated` in its frontmatter.

--- a/.claude/plugins/onebrain/skills/tasks/SKILL.md
+++ b/.claude/plugins/onebrain/skills/tasks/SKILL.md
@@ -146,6 +146,6 @@ Run via Bash (fails silently if Obsidian is not installed):
 open "obsidian://open?path=$(cd "${CLAUDE_PROJECT_DIR:-.}" && pwd)/TASKS.md" 2>/dev/null || true
 ```
 
-Then say in one line:
+Then say:
 📋 TASKS.md updated.
 → Opening in Obsidian...

--- a/.claude/plugins/onebrain/skills/tasks/SKILL.md
+++ b/.claude/plugins/onebrain/skills/tasks/SKILL.md
@@ -139,6 +139,13 @@ Do not proceed to Step 3 if the write failed.
 
 ---
 
-## Step 3: Print confirmation
+## Step 3: Open in Obsidian and confirm
 
-`TASKS.md updated.`
+Run via Bash (fails silently if Obsidian is not installed):
+```bash
+open "obsidian://open?path=$(cd "${CLAUDE_PROJECT_DIR:-.}" && pwd)/TASKS.md" 2>/dev/null || true
+```
+
+Then say in one line:
+📋 TASKS.md updated.
+→ Opening in Obsidian...

--- a/.claude/plugins/onebrain/skills/update/SKILL.md
+++ b/.claude/plugins/onebrain/skills/update/SKILL.md
@@ -16,16 +16,14 @@ Update OneBrain system files from the source repo to the latest version.
    - `next` → `next`
    - `N.x` (e.g. `1.x`, `2.x`) → `N.x`
 3. Read new version from repo's `plugin.json` on the mapped branch (not always main)
-4. If equal → "Already up to date vX.X.X" and stop
-5. If newer → read `CHANGELOG.md` from repo; display the entry for the new version to the user before proceeding. Format exactly as:
+4. If equal → say: ✅ Already up to date — v{X.X.X}. and stop
+5. If newer → read `CHANGELOG.md` from repo; display before proceeding (do not skip or summarize):
+   ──────────────────────────────────────────────────────────────
+   🔄 Update Available — v{current} → v{new}
+   ──────────────────────────────────────────────────────────────
+   {changelog entry verbatim}
 
-   ```
-   ## What's new in vX.X.X
-
-   [paste the changelog entry for that version verbatim]
-   ```
-
-   Do not skip or summarize — the user must see the full entry before the confirmation prompt.
+   Then AskUserQuestion: "Update to v{new}?" Options: update / cancel
 
 ### Major Version Bump Guard
 
@@ -98,7 +96,15 @@ Steps:
    - If a step had nothing to do (e.g. context/ already absent), write `[x] Step 2: Skipped — context/ not present`
    - If /doctor found issues in Step 8, list them under the step line
 
-6. Report summary to user
+6. Report summary to user:
+
+   For each migration step (one line per step):
+   ✅ Step {N}: {description} ({N} files)
+   ✅ Step {N}: Skipped — {reason}
+   🟡 Step {N}: {description} — {N} issues (see above)
+
+   Completion:
+   ✅ OneBrain updated to v{new}. {N} files created, {M} modified.
 
 ## Vault Migration Steps
 
@@ -233,14 +239,18 @@ Never replace the entire array — user-added hooks in the same event key must b
 
 ## --dry-run Mode
 
-`/update --dry-run` → run all steps WITHOUT writing. For each migration step, output:
+`/update --dry-run` → run all steps WITHOUT writing. Display for each step:
 ```
-[Step N] Would create: [logs_folder]/YYYY/MM/YYYY-MM-DD-update-vX.X.X.md
-[Step N] Would modify: [agent_folder]/MEMORY.md — remove Key Learnings section
-[Step N] Would create: [agent_folder]/memory/kebab-topic.md
-[Step N] Would delete: [agent_folder]/context/
+──────────────────────────────────────────────────────────────
+🔄 Dry Run — v{current} → v{new}
+──────────────────────────────────────────────────────────────
+Would create: `[logs_folder]/YYYY/MM/YYYY-MM-DD-update-vX.X.X.md`
+Would modify: `[agent_folder]/MEMORY.md` — remove Key Learnings section
+Would create: `[agent_folder]/memory/kebab-topic.md`
+Would delete: `[agent_folder]/context/`
 ```
-The version check, changelog display, and AskUserQuestion confirmation still happen normally in dry-run mode. No files are written, moved, or deleted. At the end, print a summary: "Dry run complete — N files would be created, M modified, P deleted."
+The version check, changelog display, and AskUserQuestion confirmation still happen normally in dry-run mode. No files are written, moved, or deleted. At the end say:
+Dry run complete — {N} files would be created, {M} modified, {P} deleted.
 
 ## Failure Recovery
 

--- a/.claude/plugins/onebrain/skills/weekly/SKILL.md
+++ b/.claude/plugins/onebrain/skills/weekly/SKILL.md
@@ -55,24 +55,25 @@ Look for:
 
 Say:
 
-> ## Week of [Mon date] : [Sun date]
->
-> **Sessions:** N total
-> **Main focus:** [primary topic]
->
-> **What you worked on:**
-> - [Project/topic 1] : [brief status]
-> - [Project/topic 2] : [brief status]
->
-> **Wins this week:**
-> - [Something completed or progressed]
->
-> **Patterns I noticed:**
-> - [Pattern 1]
-> - [Pattern 2]
->
-> **Open threads to pick up:**
-> - [Unresolved item from sessions]
+──────────────────────────────────────────────────────────────
+📅 Week of {Mon DD Mon} : {Sun DD Mon YYYY}
+──────────────────────────────────────────────────────────────
+Sessions: {N} total
+Main focus: {primary topic}
+
+What you worked on:
+  • {Project/topic 1} : {brief status}
+  • {Project/topic 2} : {brief status}
+
+Wins this week:
+  • {Something completed or progressed}
+
+Patterns I noticed:
+  • {Pattern 1}
+  • {Pattern 2}
+
+Open threads:
+  • {Unresolved item}
 
 ---
 
@@ -80,11 +81,10 @@ Say:
 
 Ask (pick 2-3 based on context):
 
-> Before we plan ahead : a few reflection questions:
->
-> 1. What went well this week that you want to keep doing?
-> 2. What felt stuck or draining?
-> 3. What did you leave unfinished that's still important?
+Before we plan ahead — a few questions:
+  1. What went well this week that you want to keep doing?
+  2. What felt stuck or draining?
+  3. What did you leave unfinished that's still important?
 
 Wait for their answers. Take brief notes.
 
@@ -112,9 +112,8 @@ If the weekly review reveals a persistent pattern or learning, save it via `/lea
 
 ## Step 8: Close Out
 
-> Great week review, [Name]!
->
-> [If tasks created]: I logged your 3 intentions for next week.
-> [If insights saved]: Added a pattern to your `[agent_folder]/MEMORY.md`.
->
-> Enjoy your [weekend/time off]. See you next week!
+✅ Weekly note saved to `[logs_folder]/YYYY/MM/YYYY-MM-DD-weekly.md`.
+[If tasks created]: I logged your 3 intentions for next week.
+[If insights saved]: Added a pattern to your memory.
+
+Enjoy your {weekend/time off}. See you next week!

--- a/.claude/plugins/onebrain/skills/weekly/SKILL.md
+++ b/.claude/plugins/onebrain/skills/weekly/SKILL.md
@@ -96,9 +96,11 @@ Ask:
 > What are the 3 most important things to accomplish next week?
 
 Then help them create tasks:
+```markdown
 - [ ] [Intention 1] 📅 [Next Friday as default deadline]
 - [ ] [Intention 2] 📅 [Next Friday]
 - [ ] [Intention 3] 📅 [Next Friday]
+```
 
 Ask where to put these tasks: in a project note, or a new "Weekly Intentions" section in a project note.
 

--- a/.claude/plugins/onebrain/skills/wrapup/SKILL.md
+++ b/.claude/plugins/onebrain/skills/wrapup/SKILL.md
@@ -257,28 +257,31 @@ Compute:
   (always ≥ 1 after /wrapup runs — the log just written has no `recapped:` yet)
 - `last_recapped` — most recent `recapped:` date found (absent = never)
 
-Display:
-
-| Condition | Message |
-|---|---|
-| unrecapped 1–3, last recap ≤ 7 days ago | `_💾 {N} session logs not yet recapped (last: YYYY-MM-DD)_` |
-| unrecapped > 3 OR last recap > 7 days ago | `_⚠️ {N} session logs not yet recapped — last recap: YYYY-MM-DD_` |
-| never recapped | `_⚠️ {N} session logs not yet recapped — never recapped_` |
+Display based on condition:
+- unrecapped 1–3, last recap ≤ 7 days ago:
+    💾 {N} session logs not yet recapped (last: YYYY-MM-DD)
+- unrecapped > 3 OR last recap > 7 days ago:
+    ⚠️ {N} session logs not yet recapped — last recap: YYYY-MM-DD
+- never recapped:
+    ⚠️ {N} session logs not yet recapped — never recapped
 
 ---
 
 ## Step 8: Confirm
 
 Say:
-> Session saved to `[logs_folder]/YYYY/MM/YYYY-MM-DD-session-NN.md`.
->
-> [If action items]: I logged N action items : they'll appear in your Tasks view.
->
-> [If recovered_sessions is non-empty]:
-> **Auto-recovered {S} orphan session(s):**
-> - YYYY-MM-DD → session-NN.md ({C} checkpoints)
-> - YYYY-MM-DD → session-NN.md ({C} checkpoints)
->
-> [Recap reminder message from Step 7]
->
-> Good session! See you next time.
+──────────────────────────────────────────────────────────────
+💾 Session Saved
+──────────────────────────────────────────────────────────────
+`[logs_folder]/YYYY/MM/YYYY-MM-DD-session-NN.md`
+
+I logged {N} action items — they'll appear in your Tasks view.
+(omit this line if no action items)
+
+Auto-recovered {S} orphan session(s):
+  {YYYY-MM-DD} → `session-NN.md` ({C} checkpoints)
+(omit this block if none recovered)
+
+{Recap reminder message from Step 7}
+
+Good session! See you next time.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-latest_version: 1.10.4
+latest_version: 1.10.5
 released: 2026-04-18
 ---
 
@@ -9,6 +9,10 @@ All notable changes to OneBrain are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+
+## v1.10.5 — Terminal Output Formatting
+
+All 25 skill outputs now use terminal-safe formatting: 62-char `─` separators, emoji section headers, `⬜` task checkboxes, and `→` hints replace `**bold**`, `> blockquotes`, `## headers`, `- [ ]`, and `| tables |` that rendered as literal characters in Claude Code CLI. `/tasks` and `/moc` now open the file in Obsidian after writing. Interactive conflict flows in `/learn` and `/recap` use `AskUserQuestion`. `/help` output replaced with grouped plain-text command list.
 
 ## v1.10.4 — PPID Session Identity + PreCompact/PostCompact Hooks + Orphan Recovery
 


### PR DESCRIPTION
## Summary

- Replace all markdown output syntax (`**bold**`, `> blockquotes`, `## headers`, `- [ ]`, `| tables |`) with terminal-safe formatting across 25 skill files + INSTRUCTIONS.md
- Add 62-char `─` separator + emoji header to all structured skill outputs
- Adopt `⬜` (U+2B1C) as the standard task checkbox
- Add Bash `open obsidian://` step to `/tasks` and `/moc` for in-app opening
- Refactor interactive conflict flows (`/learn`, `/recap`) to use `AskUserQuestion`
- Replace `/help` markdown table with grouped plain-text command list
- Bump version: v1.10.4 → v1.10.5

## Skills updated

All 25 skills: `/capture`, `/braindump`, `/bookmark`, `/tasks`, `/moc`, `/learn`, `/daily`, `/weekly`, `/doctor`, `/reorganize`, `/wrapup`, `/recap`, `/connect`, `/clone`, `/help`, `/distill`, `/update`, `/qmd`, `/memory-review`, `/onboarding`, `/research`, `/summarize`, `/reading-notes`, `/consolidate`, `/import`

## Test Plan

- [ ] Run `/daily` — verify 62-char separator + `⬜` task items render correctly in terminal
- [ ] Run `/doctor` — verify 📁 Vault / ⚙️ Config / 🧠 Memory sections with emoji indent
- [ ] Run `/wrapup` — verify `💾 Session Saved` header, no `**bold**`
- [ ] Run `/help` — verify grouped plain-text layout with 4 categories
- [ ] Run `/recap` with conflicts — verify AskUserQuestion replaces inline `→ update/supersede`
- [ ] Run `/tasks` — verify `📋 TASKS.md updated.` + Obsidian opens

## Spec reference

`01-projects/onebrain/specs/2026-04-18-terminal-output-formatting-design.md`