### PR TITLE
fix(memory-review): redesign AskUserQuestion structure, display format, and update flow (v1.10.8)

### DIFF
--- a/.claude/plugins/onebrain/.claude-plugin/plugin.json
+++ b/.claude/plugins/onebrain/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "onebrain",
-  "version": "1.10.7",
+  "version": "1.10.8",
   "description": "OneBrain — Where human and AI thinking become one. A powerful thinking partner powered by AI synergy.",
   "author": {
     "name": "OneBrain Contributors"

--- a/.claude/plugins/onebrain/skills/memory-review/SKILL.md
+++ b/.claude/plugins/onebrain/skills/memory-review/SKILL.md
@@ -9,9 +9,10 @@ Interactive review session for pruning and updating memory entries.
 
 ## Data Source
 
-Read entries from INDEX.md (already in context after session startup). Only read individual
-file frontmatter when user picks `update` and needs to modify file content. This avoids
-file system scanning for the listing phase.
+Read the entry list from INDEX.md (already in context after session startup). Before
+displaying the first entry, read the frontmatter of every `active` and `needs-review`
+file in memory/ to fetch `conf` and `verified` — these fields are not in INDEX.md.
+Only read the full file body when user picks `update` and needs to modify content.
 
 ## Edge Case: Empty INDEX
 
@@ -20,8 +21,9 @@ If memory/ is empty or has no active/needs-review entries → display
 
 ## Entry Ordering
 
-1. `needs-review` first (ordered by verified date, oldest first)
-2. `active` (ordered by verified date, oldest first)
+Sort all entries by `verified` date (ascending — oldest first) before starting:
+1. `needs-review` entries first
+2. `active` entries second
 3. `deprecated` — skipped entirely
 
 ## Display Per Entry
@@ -43,7 +45,7 @@ actual newline characters in the JSON string — not backslash-n (`\n`) escape s
 
   {status_emoji} {status}  ·  conf: {level}  ·  📅 {X} days ago
   🏷️ {topics}
-  ─────────────────────────────────────────────────────────────
+  ──────────────────────────────────────────────────────────────
   `{filename}.md`
 
   What would you like to do?
@@ -74,9 +76,19 @@ After any Manage action completes (including "skip"), advance to the next entry'
 **keep** → bump `verified` to today only. `updated` unchanged (status did not change —
 `updated` tracks status changes, not verification events). Advance to next entry.
 
-**update** → show as an AskUserQuestion with options: conf-low / conf-medium / conf-high /
-conf-unchanged / change-type / change-description / confirm / cancel. (Split into two
-AskUserQuestion calls if over 4 options — group conf options first, then type/description/confirm/cancel.)
+**update** → two sequential AskUserQuestion calls:
+
+Call 1 — pick field to edit:
+- options: conf-low / conf-medium / conf-high / conf-unchanged
+- After selecting conf: apply immediately, then show Call 2.
+
+Call 2 — additional edits:
+- options: change-type / change-description / confirm / cancel
+- `change-type` → show a third AskUserQuestion with type options:
+  context / behavioral / dev / project / reference / cancel.
+  After picking: apply, return to Call 2.
+- `change-description` → prompt for new description as free text (plain text response,
+  not AskUserQuestion). After user replies: apply, return to Call 2.
 - `confirm` → save all changes; bump `verified` and `updated` to today;
   update INDEX.md row and file frontmatter. Advance to next entry.
 - `cancel` → discard all changes; return to Primary menu for this entry.
@@ -97,7 +109,7 @@ If confirm:
 3. Remove row from INDEX.md; decrement `total_active` if status was `active`, `total_needs_review` if status was `needs-review`
 4. If archive path already exists: suffix with `-NN` (e.g. `dev-workflow-02.md`) — never overwrite
 5. Auto-create `[archive_folder]/[agent_folder]/memory/YYYY-MM/` folder if missing
-Advance to next entry after confirm or cancel.
+If confirm: advance to next entry. If cancel: return to Manage menu for this entry.
 
 **skip** (via manage...) → advance to next entry, no changes to this entry.
 
@@ -111,7 +123,9 @@ Every skill that modifies INDEX.md must update these frontmatter cache fields:
 - `updated` — set to today after any modification
 
 On /memory-review completion: update `vault.yml` `stats.last_memory_review: YYYY-MM-DD`.
-Update regardless of whether any changes were made — the field tracks when the user last reviewed, not when they last changed something. Only skip the update if the user invoked **stop** before processing any entries.
+Update regardless of whether any changes were made — the field tracks when the user last
+reviewed, not when they last changed something. Only skip the update if the user invoked
+**stop** without completing any entry action (keep, update, manage..., or skip).
 
 ## Completion
 

--- a/.claude/plugins/onebrain/skills/memory-review/SKILL.md
+++ b/.claude/plugins/onebrain/skills/memory-review/SKILL.md
@@ -69,34 +69,39 @@ actual newline characters in the JSON string — not backslash-n (`\n`) escape s
   - label: "deprecate", description: "Mark as deprecated (keeps file, removes from active index)"
   - label: "delete", description: "Move to archive and remove from index"
 
-After any Manage action completes (including "skip"), advance to the next entry's Primary menu.
+After any Manage action completes, advance to the next entry's Primary menu.
 
 ## Option Behaviors
 
 **keep** → bump `verified` to today only. `updated` unchanged (status did not change —
 `updated` tracks status changes, not verification events). Advance to next entry.
 
-**update** → two sequential AskUserQuestion calls:
+**update** → two sequential AskUserQuestion calls. All changes are staged until `confirm`;
+nothing is written until the user confirms. `cancel` at any point discards all staged changes.
 
-Call 1 — pick field to edit:
+Call 1 — set confidence:
 - options: conf-unchanged / conf-low / conf-medium / conf-high
-- `conf-unchanged` is listed first (safe default — no change if user confirms by mistake)
-- After selecting conf: apply immediately, then show Call 2.
+- `conf-unchanged` is listed first (safe default)
+- After selecting: stage the conf change, then show Call 2.
 
-Call 2 — additional edits:
-- options: cancel / change-type / change-description / confirm
-- `cancel` is listed first (safe default — discards all changes if user confirms by mistake)
-- `change-type` → show a third AskUserQuestion (type selection, split across two menus
-  to stay within 4-option limit):
+Call 2 — additional edits (cancel first — safe default, discards all staged changes):
+- options:
+  - label: "cancel", description: "Discard all staged changes, return to Primary menu"
+  - label: "change-type", description: "Change the memory type"
+  - label: "change-description", description: "Rewrite the one-liner description"
+  - label: "confirm", description: "Save all staged changes and advance to next entry"
+- `change-type` → type selection split across two menus (4-option limit):
   - Call 3a: cancel / context / behavioral / more...
   - Call 3b (if "more..."): dev / project / reference / back
-  `cancel` returns to Call 2 without changing type. `back` returns to Call 3a.
-  After picking a type: apply, return to Call 2.
+  `cancel` (Call 3a) → discard type change, return to Call 2.
+  `back` (Call 3b) → return to Call 3a.
+  To exit Call 3b without picking a type: back → Call 3a → cancel → Call 2.
+  After picking a type in Call 3a or Call 3b: stage the change, return to Call 2.
 - `change-description` → prompt for new description as free text (plain text response,
-  not AskUserQuestion). After user replies: apply, return to Call 2.
-- `confirm` → save all changes; bump `verified` and `updated` to today;
+  not AskUserQuestion). After user replies: stage the change, return to Call 2.
+- `confirm` → write all staged changes; bump `verified` and `updated` to today;
   update INDEX.md row and file frontmatter. Advance to next entry.
-- `cancel` → discard all changes; return to Primary menu for this entry.
+- `cancel` → discard all staged changes; return to Primary menu for this entry.
 
 **needs-review** (via manage...) → sets `status: needs-review`; bumps `updated` to today.
 `verified` unchanged. Advance to next entry.
@@ -107,14 +112,17 @@ removes row from INDEX.md; decrement `total_active` if entry was `active`, or
 File stays in memory/ (browsable in Obsidian). Advance to next entry.
 
 **delete** (via manage...) → AskUserQuestion: "Move `memory/X.md` to archive and remove from INDEX?"
-Options: `cancel / confirm` (`cancel` listed first — safe default)
+- options:
+  - label: "cancel", description: "Return to Manage menu, no changes"
+  - label: "confirm", description: "Archive file and remove from INDEX"
+If cancel: return to Manage menu for this entry.
 If confirm:
 1. Move file to `[archive_folder]/[agent_folder]/memory/YYYY-MM/X.md`
 2. Add `archived: YYYY-MM-DD` to file frontmatter
 3. Remove row from INDEX.md; decrement `total_active` if status was `active`, `total_needs_review` if status was `needs-review`
 4. If archive path already exists: suffix with `-NN` (e.g. `dev-workflow-02.md`) — never overwrite
 5. Auto-create `[archive_folder]/[agent_folder]/memory/YYYY-MM/` folder if missing
-If confirm: advance to next entry. If cancel: return to Manage menu for this entry.
+Advance to next entry.
 
 **skip** (via manage...) → advance to next entry, no changes to this entry.
 
@@ -135,9 +143,9 @@ reviewed, not when they last changed something. Only skip the update if the user
 ## Completion
 
 After the review session ends:
-✅ Memory review complete — kept {N}, updated {M}, flagged {R}, deprecated {P}, deleted {Q}.
+✅ Memory review complete — kept {N}, updated {M}, skipped {S}, flagged {R}, deprecated {P}, deleted {Q}.
 
-(`flagged` = entries moved to `needs-review` status via manage...)
+(`skipped` = entries passed via manage... → skip; `flagged` = entries moved to `needs-review` via manage...)
 
 Note: If more than 40 entries, review shows all entries sequentially (no truncation needed — user controls pace via manage.../stop).
 
@@ -145,9 +153,9 @@ Note: If more than 40 entries, review shows all entries sequentially (no truncat
 
 - If entry's row is missing from INDEX.md but file exists in memory/ (out of sync) →
   silently pass over the entry and report "INDEX out of sync — run /doctor --fix"
-- All choices except stop and skip commit immediately (keep, update, and via manage...:
-  needs-review, deprecate, delete). No undo for completed actions. `stop` only preserves
-  remaining unreviewed entries.
+- All choices except `stop` and `skip` (via manage...) commit immediately — keep, update,
+  and via manage...: needs-review, deprecate, delete. No undo for completed actions.
+  `stop` only preserves remaining unreviewed entries.
 
 ## Restore from Archive
 

--- a/.claude/plugins/onebrain/skills/memory-review/SKILL.md
+++ b/.claude/plugins/onebrain/skills/memory-review/SKILL.md
@@ -81,7 +81,8 @@ nothing is written until the user confirms. `cancel` at any point discards all s
 
 Call 1 — set confidence:
 - options: conf-unchanged / conf-low / conf-medium / conf-high
-- `conf-unchanged` is listed first (safe default)
+- `conf-unchanged` is listed first (safe default for confidence only — it does NOT cancel
+  the update flow; always advance to Call 2 after any selection in Call 1)
 - After selecting: stage the conf change, then show Call 2.
 
 Call 2 — additional edits (cancel first — safe default, discards all staged changes):
@@ -152,10 +153,10 @@ Note: If more than 40 entries, review shows all entries sequentially (no truncat
 ## Edge Cases
 
 - If entry's row is missing from INDEX.md but file exists in memory/ (out of sync) →
-  silently pass over the entry and report "INDEX out of sync — run /doctor --fix"
-- All choices except `stop` and `skip` (via manage...) commit immediately — keep, update,
-  and via manage...: needs-review, deprecate, delete. No undo for completed actions.
-  `stop` only preserves remaining unreviewed entries.
+  pass over the entry and output: "INDEX out of sync — run /doctor --fix"
+- `keep`, `needs-review`, `deprecate`, `delete` commit immediately. No undo.
+  `update` commits only on explicit `confirm` (cancel at any stage discards all staged changes).
+  `stop` and `skip` (via manage...) never commit.
 
 ## Restore from Archive
 

--- a/.claude/plugins/onebrain/skills/memory-review/SKILL.md
+++ b/.claude/plugins/onebrain/skills/memory-review/SKILL.md
@@ -79,7 +79,8 @@ After any Manage action completes (including "skip"), advance to the next entry'
 **update** → two sequential AskUserQuestion calls:
 
 Call 1 — pick field to edit:
-- options: conf-low / conf-medium / conf-high / conf-unchanged
+- options: conf-unchanged / conf-low / conf-medium / conf-high
+- `conf-unchanged` is listed first (safe default — no change if user confirms by mistake)
 - After selecting conf: apply immediately, then show Call 2.
 
 Call 2 — additional edits:

--- a/.claude/plugins/onebrain/skills/memory-review/SKILL.md
+++ b/.claude/plugins/onebrain/skills/memory-review/SKILL.md
@@ -26,21 +26,26 @@ If memory/ is empty or has no active/needs-review entries → display
 
 ## Display Per Entry
 
-Show this header once before the first entry (not repeated per entry):
+Print this header as plain text output before making the first AskUserQuestion call.
+Do not repeat it per entry and do not embed it inside any question string:
 ──────────────────────────────────────────────────────────────
 🔬 Memory Review — {N} files to review
 ──────────────────────────────────────────────────────────────
 
 Per-entry: use a single AskUserQuestion with entry details embedded in the question text.
-Use real newline characters in the question string — not `\n` escape sequences.
+When constructing the AskUserQuestion tool call, the `question` parameter must contain
+actual newline characters in the JSON string — not backslash-n (`\n`) escape sequences.
 
 **Primary menu** (shown for every entry):
-- question:
-  "[{n}/{N}] {topics} | {status} | conf:{level} | verified {X} days ago
+- question (use real newlines — the lines below are separate lines in the string):
+  ```
+  [{n}/{N}] {topics} | {status} | conf:{level} | verified {X} days ago
   `{filename}.md`
-  "{1-line description}"
+  '{1-line description}'
 
-  What would you like to do?"
+  What would you like to do?
+  ```
+  Note: the description is wrapped in single quotes to avoid ambiguity with the outer string.
 - header: "Memory Review [{n}/{N}]"
 - multiSelect: false
 - options:
@@ -57,30 +62,29 @@ Use real newline characters in the question string — not `\n` escape sequences
   - label: "needs-review", description: "Flag for later review"
   - label: "deprecate", description: "Mark as deprecated (keeps file, removes from active index)"
   - label: "delete", description: "Move to archive and remove from index"
-  - label: "back", description: "Return to Primary menu for this entry, no changes"
+  - label: "skip", description: "Advance to next entry, no changes to this entry"
 
-After any Manage action completes (except "back"), advance to the next entry's Primary menu.
-"back" returns to the same entry's Primary menu.
+After any Manage action completes (including "skip"), advance to the next entry's Primary menu.
 
 ## Option Behaviors
 
 **keep** → bump `verified` to today only. `updated` unchanged (status did not change —
 `updated` tracks status changes, not verification events). Advance to next entry.
 
-**update** → interactive sub-menu:
-- `conf`: low / medium / high / unchanged
-- `type`: pick from defaults (context, behavioral, dev, project, reference) or type custom value
-  (also updates INDEX.md Type column)
-- `description`: rewrite one-liner (also updates INDEX.md Description column)
+**update** → show as an AskUserQuestion with options: conf-low / conf-medium / conf-high /
+conf-unchanged / change-type / change-description / confirm / cancel. (Split into two
+AskUserQuestion calls if over 4 options — group conf options first, then type/description/confirm/cancel.)
 - `confirm` → save all changes; bump `verified` and `updated` to today;
   update INDEX.md row and file frontmatter. Advance to next entry.
-- `cancel` → discard all changes; return to Primary menu for this entry
+- `cancel` → discard all changes; return to Primary menu for this entry.
 
-**needs-review** (via manage...) → sets `status: needs-review`; bumps `updated` to today. `verified` unchanged.
+**needs-review** (via manage...) → sets `status: needs-review`; bumps `updated` to today.
+`verified` unchanged. Advance to next entry.
 
-**deprecate** (via manage...) → sets `status: deprecated`; bumps `updated` to today; removes row from INDEX.md;
-decrement `total_active` if entry was `active`, or `total_needs_review` if entry was `needs-review`.
-`verified` unchanged. File stays in memory/ (browsable in Obsidian).
+**deprecate** (via manage...) → sets `status: deprecated`; bumps `updated` to today;
+removes row from INDEX.md; decrement `total_active` if entry was `active`, or
+`total_needs_review` if entry was `needs-review`. `verified` unchanged.
+File stays in memory/ (browsable in Obsidian). Advance to next entry.
 
 **delete** (via manage...) → AskUserQuestion: "Move `memory/X.md` to archive and remove from INDEX?"
 Options: `confirm / cancel`
@@ -90,8 +94,9 @@ If confirm:
 3. Remove row from INDEX.md; decrement `total_active` if status was `active`, `total_needs_review` if status was `needs-review`
 4. If archive path already exists: suffix with `-NN` (e.g. `dev-workflow-02.md`) — never overwrite
 5. Auto-create `[archive_folder]/[agent_folder]/memory/YYYY-MM/` folder if missing
+Advance to next entry after confirm or cancel.
 
-**back** (via manage...) → return to Primary menu for this entry, no changes.
+**skip** (via manage...) → advance to next entry, no changes to this entry.
 
 **stop** → exit session, all unreviewed entries unchanged.
 
@@ -108,16 +113,19 @@ Update regardless of whether any changes were made — the field tracks when the
 ## Completion
 
 After the review session ends:
-✅ Memory review complete — kept {N}, updated {M}, deprecated {P}, deleted {Q}.
+✅ Memory review complete — kept {N}, updated {M}, flagged {R}, deprecated {P}, deleted {Q}.
+
+(`flagged` = entries moved to `needs-review` status via manage...)
 
 Note: If more than 40 entries, review shows all entries sequentially (no truncation needed — user controls pace via manage.../stop).
 
 ## Edge Cases
 
 - If entry's row is missing from INDEX.md but file exists in memory/ (out of sync) →
-  skip the entry and report "INDEX out of sync — run /doctor --fix"
-- All choices except stop commit immediately (keep, update, and via manage...: needs-review,
-  deprecate, delete). No undo for completed actions. `stop` only preserves remaining unreviewed entries.
+  silently pass over the entry and report "INDEX out of sync — run /doctor --fix"
+- All choices except stop and skip commit immediately (keep, update, and via manage...:
+  needs-review, deprecate, delete). No undo for completed actions. `stop` only preserves
+  remaining unreviewed entries.
 
 ## Restore from Archive
 

--- a/.claude/plugins/onebrain/skills/memory-review/SKILL.md
+++ b/.claude/plugins/onebrain/skills/memory-review/SKILL.md
@@ -31,22 +31,26 @@ Header before first entry:
 🔬 Memory Review — {N} files to review
 ──────────────────────────────────────────────────────────────
 
-Per-entry format:
-[{n}/{N}] {topics} | {status} | conf:{level} | verified {X} days ago
-      `{filename}.md`
-      "{1-line description}"
+Per-entry: use a single AskUserQuestion with entry details embedded in the question text.
 
-Then AskUserQuestion:
-- question: "What would you like to do with this entry?"
+**Primary menu** (shown for every entry):
+- question: "[{n}/{N}] {topics} | {status} | conf:{level} | verified {X} days ago\n`{filename}.md`\n\"{1-line description}\"\n\nWhat would you like to do?"
 - header: "Memory Review [{n}/{N}]"
 - multiSelect: false
 - options:
-  - label: "keep", description: "Bump verified date to today, no other changes"
+  - label: "keep", description: "Bump verified date to today, no changes"
   - label: "update", description: "Edit confidence, type, or description"
+  - label: "skip", description: "Move to next entry, no changes"
+  - label: "manage...", description: "Flag, deprecate, delete, or stop"
+
+**Manage menu** (shown only when user picks "manage..."):
+- question: "`{filename}.md` — choose an action:"
+- header: "Manage [{n}/{N}]"
+- multiSelect: false
+- options:
   - label: "needs-review", description: "Flag for later review"
   - label: "deprecate", description: "Mark as deprecated (keeps file, removes from active index)"
   - label: "delete", description: "Move to archive and remove from index"
-  - label: "skip", description: "Move to next entry, no changes"
   - label: "stop", description: "Exit review, leave remaining entries unchanged"
 
 ## Option Behaviors

--- a/.claude/plugins/onebrain/skills/memory-review/SKILL.md
+++ b/.claude/plugins/onebrain/skills/memory-review/SKILL.md
@@ -40,10 +40,11 @@ actual newline characters in the JSON string — not backslash-n (`\n`) escape s
 - question (use real newlines — the lines below are separate lines in the string):
   ```
   [{n}/{N}] "{1-line description}"
-  {filename}.md
 
   status: {status}  ·  conf: {level}  ·  verified {X} days ago
   topics: {topics}
+  ─────────────────────────────────────────────────────────────
+  `{filename}.md`
 
   What would you like to do?
   ```

--- a/.claude/plugins/onebrain/skills/memory-review/SKILL.md
+++ b/.claude/plugins/onebrain/skills/memory-review/SKILL.md
@@ -26,24 +26,30 @@ If memory/ is empty or has no active/needs-review entries → display
 
 ## Display Per Entry
 
-Header before first entry:
+Show this header once before the first entry (not repeated per entry):
 ──────────────────────────────────────────────────────────────
 🔬 Memory Review — {N} files to review
 ──────────────────────────────────────────────────────────────
 
 Per-entry: use a single AskUserQuestion with entry details embedded in the question text.
+Use real newline characters in the question string — not `\n` escape sequences.
 
 **Primary menu** (shown for every entry):
-- question: "[{n}/{N}] {topics} | {status} | conf:{level} | verified {X} days ago\n`{filename}.md`\n\"{1-line description}\"\n\nWhat would you like to do?"
+- question:
+  "[{n}/{N}] {topics} | {status} | conf:{level} | verified {X} days ago
+  `{filename}.md`
+  "{1-line description}"
+
+  What would you like to do?"
 - header: "Memory Review [{n}/{N}]"
 - multiSelect: false
 - options:
   - label: "keep", description: "Bump verified date to today, no changes"
   - label: "update", description: "Edit confidence, type, or description"
-  - label: "skip", description: "Move to next entry, no changes"
-  - label: "manage...", description: "Flag, deprecate, delete, or stop"
+  - label: "manage...", description: "Flag, deprecate, or delete this entry"
+  - label: "stop", description: "Exit review, leave remaining entries unchanged"
 
-**Manage menu** (shown only when user picks "manage..."):
+**Manage menu** (shown only when user picks "manage..." from Primary):
 - question: "`{filename}.md` — choose an action:"
 - header: "Manage [{n}/{N}]"
 - multiSelect: false
@@ -51,12 +57,15 @@ Per-entry: use a single AskUserQuestion with entry details embedded in the quest
   - label: "needs-review", description: "Flag for later review"
   - label: "deprecate", description: "Mark as deprecated (keeps file, removes from active index)"
   - label: "delete", description: "Move to archive and remove from index"
-  - label: "stop", description: "Exit review, leave remaining entries unchanged"
+  - label: "back", description: "Return to Primary menu for this entry, no changes"
+
+After any Manage action completes (except "back"), advance to the next entry's Primary menu.
+"back" returns to the same entry's Primary menu.
 
 ## Option Behaviors
 
 **keep** → bump `verified` to today only. `updated` unchanged (status did not change —
-`updated` tracks status changes, not verification events).
+`updated` tracks status changes, not verification events). Advance to next entry.
 
 **update** → interactive sub-menu:
 - `conf`: low / medium / high / unchanged
@@ -64,16 +73,16 @@ Per-entry: use a single AskUserQuestion with entry details embedded in the quest
   (also updates INDEX.md Type column)
 - `description`: rewrite one-liner (also updates INDEX.md Description column)
 - `confirm` → save all changes; bump `verified` and `updated` to today;
-  update INDEX.md row and file frontmatter
-- `cancel` → discard all changes; return to main options for this entry
+  update INDEX.md row and file frontmatter. Advance to next entry.
+- `cancel` → discard all changes; return to Primary menu for this entry
 
-**needs-review** → sets `status: needs-review`; bumps `updated` to today. `verified` unchanged.
+**needs-review** (via manage...) → sets `status: needs-review`; bumps `updated` to today. `verified` unchanged.
 
-**deprecate** → sets `status: deprecated`; bumps `updated` to today; removes row from INDEX.md;
+**deprecate** (via manage...) → sets `status: deprecated`; bumps `updated` to today; removes row from INDEX.md;
 decrement `total_active` if entry was `active`, or `total_needs_review` if entry was `needs-review`.
 `verified` unchanged. File stays in memory/ (browsable in Obsidian).
 
-**delete** → AskUserQuestion: "Move `memory/X.md` to archive and remove from INDEX?"
+**delete** (via manage...) → AskUserQuestion: "Move `memory/X.md` to archive and remove from INDEX?"
 Options: `confirm / cancel`
 If confirm:
 1. Move file to `[archive_folder]/[agent_folder]/memory/YYYY-MM/X.md`
@@ -82,7 +91,7 @@ If confirm:
 4. If archive path already exists: suffix with `-NN` (e.g. `dev-workflow-02.md`) — never overwrite
 5. Auto-create `[archive_folder]/[agent_folder]/memory/YYYY-MM/` folder if missing
 
-**skip** → move to next entry, no changes.
+**back** (via manage...) → return to Primary menu for this entry, no changes.
 
 **stop** → exit session, all unreviewed entries unchanged.
 
@@ -101,14 +110,14 @@ Update regardless of whether any changes were made — the field tracks when the
 After the review session ends:
 ✅ Memory review complete — kept {N}, updated {M}, deprecated {P}, deleted {Q}.
 
-Note: If more than 40 entries, review shows all entries sequentially (no truncation needed — user controls pace via skip/stop).
+Note: If more than 40 entries, review shows all entries sequentially (no truncation needed — user controls pace via manage.../stop).
 
 ## Edge Cases
 
 - If entry's row is missing from INDEX.md but file exists in memory/ (out of sync) →
   skip the entry and report "INDEX out of sync — run /doctor --fix"
-- All choices (keep/update/needs-review/deprecate/delete) commit immediately.
-  No undo for completed actions. `stop` only preserves remaining unreviewed entries.
+- All choices except stop commit immediately (keep, update, and via manage...: needs-review,
+  deprecate, delete). No undo for completed actions. `stop` only preserves remaining unreviewed entries.
 
 ## Restore from Archive
 

--- a/.claude/plugins/onebrain/skills/memory-review/SKILL.md
+++ b/.claude/plugins/onebrain/skills/memory-review/SKILL.md
@@ -64,10 +64,10 @@ actual newline characters in the JSON string — not backslash-n (`\n`) escape s
 - header: "Manage [{n}/{N}]"
 - multiSelect: false
 - options:
+  - label: "skip", description: "Advance to next entry, no changes to this entry"
   - label: "needs-review", description: "Flag for later review"
   - label: "deprecate", description: "Mark as deprecated (keeps file, removes from active index)"
   - label: "delete", description: "Move to archive and remove from index"
-  - label: "skip", description: "Advance to next entry, no changes to this entry"
 
 After any Manage action completes (including "skip"), advance to the next entry's Primary menu.
 
@@ -84,10 +84,14 @@ Call 1 — pick field to edit:
 - After selecting conf: apply immediately, then show Call 2.
 
 Call 2 — additional edits:
-- options: change-type / change-description / confirm / cancel
-- `change-type` → show a third AskUserQuestion with type options:
-  context / behavioral / dev / project / reference / cancel.
-  After picking: apply, return to Call 2.
+- options: cancel / change-type / change-description / confirm
+- `cancel` is listed first (safe default — discards all changes if user confirms by mistake)
+- `change-type` → show a third AskUserQuestion (type selection, split across two menus
+  to stay within 4-option limit):
+  - Call 3a: cancel / context / behavioral / more...
+  - Call 3b (if "more..."): dev / project / reference / back
+  `cancel` returns to Call 2 without changing type. `back` returns to Call 3a.
+  After picking a type: apply, return to Call 2.
 - `change-description` → prompt for new description as free text (plain text response,
   not AskUserQuestion). After user replies: apply, return to Call 2.
 - `confirm` → save all changes; bump `verified` and `updated` to today;
@@ -103,7 +107,7 @@ removes row from INDEX.md; decrement `total_active` if entry was `active`, or
 File stays in memory/ (browsable in Obsidian). Advance to next entry.
 
 **delete** (via manage...) → AskUserQuestion: "Move `memory/X.md` to archive and remove from INDEX?"
-Options: `confirm / cancel`
+Options: `cancel / confirm` (`cancel` listed first — safe default)
 If confirm:
 1. Move file to `[archive_folder]/[agent_folder]/memory/YYYY-MM/X.md`
 2. Add `archived: YYYY-MM-DD` to file frontmatter

--- a/.claude/plugins/onebrain/skills/memory-review/SKILL.md
+++ b/.claude/plugins/onebrain/skills/memory-review/SKILL.md
@@ -41,13 +41,14 @@ actual newline characters in the JSON string — not backslash-n (`\n`) escape s
   ```
   [{n}/{N}] "{1-line description}"
 
-  status: {status}  ·  conf: {level}  ·  verified {X} days ago
-  topics: {topics}
+  {status_emoji} {status}  ·  conf: {level}  ·  📅 {X} days ago
+  🏷️ {topics}
   ─────────────────────────────────────────────────────────────
   `{filename}.md`
 
   What would you like to do?
   ```
+  Status emoji: 🟢 active, 🟡 needs-review, ⚫ deprecated
 - header: "Memory Review [{n}/{N}]"
 - multiSelect: false
 - options:

--- a/.claude/plugins/onebrain/skills/memory-review/SKILL.md
+++ b/.claude/plugins/onebrain/skills/memory-review/SKILL.md
@@ -39,13 +39,14 @@ actual newline characters in the JSON string — not backslash-n (`\n`) escape s
 **Primary menu** (shown for every entry):
 - question (use real newlines — the lines below are separate lines in the string):
   ```
-  [{n}/{N}] {topics} | {status} | conf:{level} | verified {X} days ago
-  `{filename}.md`
-  '{1-line description}'
+  [{n}/{N}] "{1-line description}"
+  {filename}.md
+
+  status: {status}  ·  conf: {level}  ·  verified {X} days ago
+  topics: {topics}
 
   What would you like to do?
   ```
-  Note: the description is wrapped in single quotes to avoid ambiguity with the outer string.
 - header: "Memory Review [{n}/{N}]"
 - multiSelect: false
 - options:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## v1.10.8 — Fix /memory-review AskUserQuestion structure
 
 ### Fixed
-- `/memory-review`: entry details (topics, status, conf, filename, description) now embedded in AskUserQuestion question text — no separate pre-display block
-- `/memory-review`: split 7 options into Primary (keep/update/manage.../stop) and Manage (needs-review/deprecate/delete/back) menus to respect 4-option limit
-- `/memory-review`: "stop" accessible from Primary menu directly (no longer buried in Manage sub-menu)
-- `/memory-review`: "back" option in Manage menu to return to Primary without action or losing session
+- `/memory-review`: entry details (topics, status, conf, filename, description) now embedded in AskUserQuestion question text — no separate plain-text pre-display block
+- `/memory-review`: split into Primary menu (keep/update/manage.../stop) and Manage submenu (needs-review/deprecate/delete/skip) to respect 4-option limit — `manage...` and `skip` are navigation affordances, not new actions
+- `/memory-review`: "stop" accessible from Primary menu directly (no longer buried in a submenu)
+- `/memory-review`: "skip" restored in Manage submenu — advance to next entry without taking action, including as an escape from manage... if opened by mistake
+- `/memory-review`: completion summary now includes `flagged {R}` counter for needs-review actions
+- `/memory-review`: "update" sub-menu now specified as AskUserQuestion calls (no ambiguous plain-text loop)
 
 ## v1.10.7 — Documentation Reorganization
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - `/memory-review`: entry display redesigned — description first, status emoji (🟢/🟡/⚫), 📅 verified date, 🏷️ topics, backtick filename as footer with separator line
 - `/memory-review`: split into Primary (keep/update/manage.../stop) and Manage (skip/needs-review/deprecate/delete) to respect 4-option AskUserQuestion limit
-- `/memory-review`: safe-default principle — no-op or cancel listed first in every menu (skip, conf-unchanged, cancel)
+- `/memory-review`: safe-default principle — non-destructive option listed first in every menu: skip (Manage), conf-unchanged (Call 1), cancel (Call 2, Call 3a, delete confirm)
 - `/memory-review`: update uses staged model — conf in Call 1, edits in Call 2; nothing written until explicit confirm; change-type split into Call 3a/3b for 4-option limit
 - `/memory-review`: Data Source pre-reads all entry frontmatter before starting (conf + verified not in INDEX.md)
 - `/memory-review`: delete cancel returns to Manage menu; completion summary adds skipped + flagged counters

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,15 +10,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
-## v1.10.8 — Fix /memory-review AskUserQuestion structure
+## v1.10.8 — /memory-review Redesign
 
-### Fixed
-- `/memory-review`: entry details (topics, status, conf, filename, description) now embedded in AskUserQuestion question text — no separate plain-text pre-display block
-- `/memory-review`: split into Primary menu (keep/update/manage.../stop) and Manage submenu (needs-review/deprecate/delete/skip) to respect 4-option limit — `manage...` and `skip` are navigation affordances, not new actions
-- `/memory-review`: "stop" accessible from Primary menu directly (no longer buried in a submenu)
-- `/memory-review`: "skip" restored in Manage submenu — advance to next entry without taking action, including as an escape from manage... if opened by mistake
-- `/memory-review`: completion summary now includes `flagged {R}` counter for needs-review actions
-- `/memory-review`: "update" sub-menu now specified as AskUserQuestion calls (no ambiguous plain-text loop)
+- `/memory-review`: entry display redesigned — description first, status emoji (🟢/🟡/⚫), 📅 verified date, 🏷️ topics, backtick filename as footer with separator line
+- `/memory-review`: split into Primary (keep/update/manage.../stop) and Manage (skip/needs-review/deprecate/delete) to respect 4-option AskUserQuestion limit
+- `/memory-review`: safe-default principle — no-op or cancel listed first in every menu (skip, conf-unchanged, cancel)
+- `/memory-review`: update uses staged model — conf in Call 1, edits in Call 2; nothing written until explicit confirm; change-type split into Call 3a/3b for 4-option limit
+- `/memory-review`: Data Source pre-reads all entry frontmatter before starting (conf + verified not in INDEX.md)
+- `/memory-review`: delete cancel returns to Manage menu; completion summary adds skipped + flagged counters
+- `/memory-review`: Edge Cases rewritten with per-action commit rules (update uses staged model, not immediate commit)
 
 ## v1.10.7 — Documentation Reorganization
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ---
-latest_version: 1.10.7
-released: 2026-04-19
+latest_version: 1.10.8
+released: 2026-04-20
 ---
 
 # Changelog
@@ -9,6 +9,14 @@ All notable changes to OneBrain are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+
+## v1.10.8 — Fix /memory-review AskUserQuestion structure
+
+### Fixed
+- `/memory-review`: entry details (topics, status, conf, filename, description) now embedded in AskUserQuestion question text — no separate pre-display block
+- `/memory-review`: split 7 options into Primary (keep/update/manage.../stop) and Manage (needs-review/deprecate/delete/back) menus to respect 4-option limit
+- `/memory-review`: "stop" accessible from Primary menu directly (no longer buried in Manage sub-menu)
+- `/memory-review`: "back" option in Manage menu to return to Primary without action or losing session
 
 ## v1.10.7 — Documentation Reorganization
 


### PR DESCRIPTION
## Summary

Complete redesign of the \`/memory-review\` skill's interactive display and option flow.

### Display format
- Entry details embedded directly into AskUserQuestion question text (no separate plain-text pre-display)
- Description leads (first line, full width — most important signal for decision-making)
- Status emoji: 🟢 active / 🟡 needs-review / ⚫ deprecated (scannable at a glance)
- Metadata line: \`{status} · conf: {level} · 📅 {X} days ago\`
- Topics line: \`🏷️ {topics}\`
- Filename as footer: separator line + \`\`\`{filename}.md\`\`\` in backtick (consistent with OneBrain terminal output convention)

### Menu structure (4-option limit respected throughout)
- **Primary**: keep / update / manage... / stop
- **Manage**: skip / needs-review / deprecate / delete
- **update Call 1** (conf): conf-unchanged / conf-low / conf-medium / conf-high
- **update Call 2** (edits): cancel / change-type / change-description / confirm
- **change-type Call 3a**: cancel / context / behavioral / more...
- **change-type Call 3b**: dev / project / reference / back
- **delete confirm**: cancel / confirm

### Safe-default principle
No-op or cancel option listed first in every menu — accidental Enter never causes destructive action.

### Update staged model
All changes in \`update\` are staged; nothing is written until explicit \`confirm\`. \`cancel\` at any stage discards all staged changes. \`conf-unchanged\` in Call 1 is a safe default for confidence only — always advances to Call 2, does not cancel the update flow.

### Other fixes
- Data Source: pre-read frontmatter of all entries before starting (conf + verified not in INDEX.md)
- delete cancel: returns to Manage menu (not advance) — consistent with update cancel
- Completion summary: \`kept / updated / skipped / flagged / deprecated / deleted\` counters
- Edge Cases: per-action commit rules (update removed from "commits immediately" — uses staged model)

## Test plan

- [ ] Run \`/memory-review\` — verify description appears first, filename at footer with backtick
- [ ] Verify emoji: 🟢 active, 🟡 needs-review entries show correct color
- [ ] Primary menu: keep / update / manage... / stop (in that order)
- [ ] Manage menu: skip / needs-review / deprecate / delete (skip first)
- [ ] update → Call 1: conf-unchanged first; selecting any option advances to Call 2 (does not cancel)
- [ ] update → Call 2: cancel first; confirm saves and advances
- [ ] change-type → Call 3a: cancel first; more... shows Call 3b
- [ ] delete → cancel returns to Manage; confirm archives and advances
- [ ] Completion line shows all 6 counters including skipped and flagged

🤖 Generated with [Claude Code](https://claude.com/claude-code)