### PR TITLE
fix: Windows installer bugs (issues 14–17) + update version fetch hang

### DIFF
--- a/.claude/plugins/onebrain/.claude-plugin/plugin.json
+++ b/.claude/plugins/onebrain/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "onebrain",
-  "version": "1.10.8",
+  "version": "1.10.9",
   "description": "OneBrain — Where human and AI thinking become one. A powerful thinking partner powered by AI synergy.",
   "author": {
     "name": "OneBrain Contributors"

--- a/.claude/plugins/onebrain/skills/update/SKILL.md
+++ b/.claude/plugins/onebrain/skills/update/SKILL.md
@@ -15,7 +15,10 @@ Update OneBrain system files from the source repo to the latest version.
    - `stable` → `main`
    - `next` → `next`
    - `N.x` (e.g. `1.x`, `2.x`) → `N.x`
-3. Read new version from repo's `plugin.json` on the mapped branch (not always main)
+3. Read new version from repo's `plugin.json` on the mapped branch using `WebFetch` — never use `git` commands (they hang on Windows waiting for credentials):
+   `https://raw.githubusercontent.com/kengio/onebrain/{branch}/.claude/plugins/onebrain/.claude-plugin/plugin.json`
+   where `{branch}` is the mapped branch from step 2.
+   Parse the `version` field from the JSON response.
 4. If equal → say: ✅ Already up to date — v{X.X.X}. and stop
 5. If newer → read `CHANGELOG.md` from repo; display before proceeding (do not skip or summarize):
    ──────────────────────────────────────────────────────────────

--- a/.claude/plugins/onebrain/skills/update/SKILL.md
+++ b/.claude/plugins/onebrain/skills/update/SKILL.md
@@ -211,11 +211,11 @@ Runs every /update — idempotent. Ensures all 3 hooks point to the correct scri
 
   | Event | Command |
   |-------|---------|
-  | `Stop` | `bash "[vault]/.claude/plugins/onebrain/hooks/checkpoint-hook.sh" stop` |
-  | `PreCompact` | `bash "[vault]/.claude/plugins/onebrain/hooks/checkpoint-hook.sh" precompact` |
-  | `PostCompact` | `bash "[vault]/.claude/plugins/onebrain/hooks/checkpoint-hook.sh" postcompact` |
+  | `Stop` | `bash ".claude/plugins/onebrain/hooks/checkpoint-hook.sh" stop` |
+  | `PreCompact` | `bash ".claude/plugins/onebrain/hooks/checkpoint-hook.sh" precompact` |
+  | `PostCompact` | `bash ".claude/plugins/onebrain/hooks/checkpoint-hook.sh" postcompact` |
 
-  Replace `[vault]` with the vault's absolute path (the directory containing `vault.yml`). Use the same JSON structure as the existing Stop entry in the file.
+  Use the same JSON structure as the existing Stop entry in the file.
 
 **Hook registration algorithm (additive):** For each event key in the table above:
 1. Read the existing array under that key (treat missing or null as empty array)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-latest_version: 1.10.8
+latest_version: 1.10.9
 released: 2026-04-20
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## v1.10.9
+
+- fix(ps1): write settings.json without UTF-8 BOM on PowerShell 5 (issue 14)
+- fix(ps1): exit early with clear message in non-interactive sessions (issue 15)
+- fix(ps1): validate ZIP archive before Expand-Archive to catch HTML error pages (issue 16)
+- fix(ps1): add -UseBasicParsing to all Invoke-WebRequest calls for Server Core compatibility (issue 17)
+- fix(ps1): Set-StrictMode -Version Latest to catch undefined variables
+- fix(ps1): force [object[]] cast on hook array to prevent PS5 serialisation bug
+- fix(ps1/docs): relative hook path + tilde expansion; correct "absolute path required" claim in 3 files
+- fix(update): use WebFetch for version check instead of git commands (prevents hang on Windows)
+
 ## v1.10.8 — /memory-review Redesign
 
 - `/memory-review`: entry display redesigned — description first, status emoji (🟢/🟡/⚫), 📅 verified date, 🏷️ topics, backtick filename as footer with separator line

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -174,7 +174,7 @@ Most hooks support a `matcher` field to filter by tool name or event subtype. `U
 
 4. **Stop hooks must NOT use `"async": true`** — they inject prompts via `decision:block` written to stdout, which requires synchronous completion before Claude's next response. Async execution fires too late for prompt injection. PreCompact hooks do not support `decision:block` and cannot inject prompts.
 
-5. **Stop, PreCompact, and PostCompact hooks cannot be registered in `hooks.json`** — Claude Code does not fire them from plugin hook files. Register them in the **vault's** `.claude/settings.json` (the `.claude/` folder inside the vault, not `~/.claude/settings.json`). Hook commands must use absolute paths — `${CLAUDE_PLUGIN_ROOT}` is only available in `hooks.json`, not `settings.json`. Use `/update` to register or repair these hooks automatically.
+5. **Stop, PreCompact, and PostCompact hooks cannot be registered in `hooks.json`** — Claude Code does not fire them from plugin hook files. Register them in the **vault's** `.claude/settings.json` (the `.claude/` folder inside the vault, not `~/.claude/settings.json`). Hook commands use relative paths — Claude Code runs hooks from the vault directory as CWD, so `${CLAUDE_PLUGIN_ROOT}` (hooks.json only) is not needed. Use `/update` to register or repair these hooks automatically.
 
 ## Memory System
 

--- a/install.ps1
+++ b/install.ps1
@@ -297,7 +297,7 @@ function Register-OnebrainHooks {
               $isMatch = $true; break
             }
           }
-        } elseif ($e -is [PSCustomObject]) {
+        } elseif ($e -is [PSCustomObject] -and $e.PSObject.Properties['hooks']) {
           foreach ($h in $e.hooks) {
             if ($h -is [PSCustomObject] -and $h.command -like '*checkpoint-hook.sh*') {
               $isMatch = $true; break

--- a/install.ps1
+++ b/install.ps1
@@ -335,6 +335,13 @@ function Main {
   Write-Host "$($script:Bold)This script downloads OneBrain and sets up a fresh Obsidian vault.$($script:BoldReset)" -ForegroundColor Cyan
   Write-Host
 
+  if (-not [Environment]::UserInteractive -or $Host.Name -eq 'Default Host') {
+    Print-Error "Cannot read user input (non-interactive session)."
+    Print-Error "Download and run the script directly:"
+    Print-Error "  Invoke-WebRequest -Uri 'https://raw.githubusercontent.com/kengio/onebrain/main/install.ps1' -OutFile install.ps1; pwsh install.ps1"
+    exit 1
+  }
+
   Check-Deps
 
   # ── Step 1: Install location ────────────────────────────────────────────────

--- a/install.ps1
+++ b/install.ps1
@@ -336,7 +336,7 @@ function Main {
   Write-Host "$($script:Bold)This script downloads OneBrain and sets up a fresh Obsidian vault.$($script:BoldReset)" -ForegroundColor Cyan
   Write-Host
 
-  if (-not [Environment]::UserInteractive -or $Host.Name -eq 'Default Host') {
+  if (-not [Environment]::UserInteractive -or $Host.Name -eq 'Default Host' -or [Console]::IsInputRedirected) {
     Print-Error "Cannot read user input (non-interactive session)."
     Print-Error "Download and run the script directly:"
     Print-Error "  Invoke-WebRequest -Uri 'https://raw.githubusercontent.com/kengio/onebrain/main/install.ps1' -OutFile install.ps1; pwsh install.ps1"
@@ -350,7 +350,7 @@ function Main {
   $installLocation = Prompt-WithDefault "1" "Where should the vault be created?" $defaultLocation
   # Expand a leading ~ to $HOME (matches install.sh behaviour)
   if ($installLocation -eq '~' -or $installLocation.StartsWith('~\') -or $installLocation.StartsWith('~/')) {
-    $installLocation = $installLocation -replace '^~', $env:USERPROFILE
+    $installLocation = $env:USERPROFILE + $installLocation.Substring(1)
   }
 
   if (-not (Test-Path $installLocation)) {
@@ -417,7 +417,7 @@ function Main {
     try {
       Add-Type -AssemblyName System.IO.Compression.FileSystem -ErrorAction Stop
       $zip = [System.IO.Compression.ZipFile]::OpenRead($zipPath)
-      $zip.Dispose()
+      try { } finally { $zip.Dispose() }
     } catch {
       Print-Error "Downloaded archive is not a valid ZIP (corrupt download or GitHub error page)."
       Print-Error "Try again. If this persists, check https://githubstatus.com"

--- a/install.ps1
+++ b/install.ps1
@@ -417,7 +417,7 @@ function Main {
     try {
       Add-Type -AssemblyName System.IO.Compression.FileSystem -ErrorAction Stop
       $zip = [System.IO.Compression.ZipFile]::OpenRead($zipPath)
-      try { } finally { $zip.Dispose() }
+      try { } finally { $zip.Dispose() }  # empty try: OpenRead already succeeded; finally guarantees handle release
     } catch {
       Print-Error "Downloaded archive is not a valid ZIP (corrupt download or GitHub error page)."
       Print-Error "Try again. If this persists, check https://githubstatus.com"

--- a/install.ps1
+++ b/install.ps1
@@ -253,7 +253,7 @@ function Register-OnebrainHooks {
   param([string]$VaultPath)
 
   $settingsPath = Join-Path $VaultPath ".claude\settings.json"
-  $hookScript   = Join-Path $VaultPath ".claude\plugins\onebrain\hooks\checkpoint-hook.sh"
+  $hookScript   = ".claude/plugins/onebrain/hooks/checkpoint-hook.sh"
 
   if (-not (Test-Path $settingsPath)) {
     Print-Info "Warning: .claude/settings.json not found — hooks not registered"
@@ -348,6 +348,10 @@ function Main {
   # ── Step 1: Install location ────────────────────────────────────────────────
   $defaultLocation = (Get-Location).Path
   $installLocation = Prompt-WithDefault "1" "Where should the vault be created?" $defaultLocation
+  # Expand a leading ~ to $HOME (matches install.sh behaviour)
+  if ($installLocation -eq '~' -or $installLocation.StartsWith('~\') -or $installLocation.StartsWith('~/')) {
+    $installLocation = $installLocation -replace '^~', $env:USERPROFILE
+  }
 
   if (-not (Test-Path $installLocation)) {
     Write-Host "  ? " -NoNewline -ForegroundColor Yellow

--- a/install.ps1
+++ b/install.ps1
@@ -247,8 +247,8 @@ function Install-Plugins {
 # ─── Hook registration ────────────────────────────────────────────────────────
 # Register-OnebrainHooks <VaultPath>
 # Writes Stop, PreCompact, and PostCompact hook entries into .claude/settings.json
-# using the vault's absolute path. settings.json does not support ${CLAUDE_PLUGIN_ROOT}
-# (only hooks.json does), so absolute paths are required.
+# using a relative path. Claude Code runs hooks from the vault directory as CWD, so
+# relative paths work and avoid issues with spaces in absolute paths (e.g. iCloud paths).
 function Register-OnebrainHooks {
   param([string]$VaultPath)
 

--- a/install.ps1
+++ b/install.ps1
@@ -410,6 +410,16 @@ function Main {
     Write-Done "Downloaded"
 
     try {
+      Add-Type -AssemblyName System.IO.Compression.FileSystem -ErrorAction Stop
+      $zip = [System.IO.Compression.ZipFile]::OpenRead($zipPath)
+      $zip.Dispose()
+    } catch {
+      Print-Error "Downloaded archive is not a valid ZIP (corrupt download or GitHub error page)."
+      Print-Error "Try again. If this persists, check https://githubstatus.com"
+      throw "error:already-printed"
+    }
+
+    try {
       Expand-Archive -Path $zipPath -DestinationPath $tmpDir -Force
     } catch {
       Print-Error "Extraction failed. The archive may be corrupted or your disk may be full."

--- a/install.ps1
+++ b/install.ps1
@@ -1,5 +1,6 @@
 #Requires -Version 5.0
 $ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
 
 # Ensure TLS 1.2 is enabled — required by GitHub (PS 5 defaults to TLS 1.0 which GitHub dropped)
 [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
@@ -176,7 +177,7 @@ function Install-Plugins {
       if (-not $ok) { break }
       $assetPath = Join-Path $pluginDir $asset
       try {
-        Invoke-WebRequest -Uri "$baseUrl/$asset" -OutFile $assetPath -ErrorAction Stop | Out-Null
+        Invoke-WebRequest -Uri "$baseUrl/$asset" -OutFile $assetPath -UseBasicParsing -ErrorAction Stop | Out-Null
         $assetLen = try { (Get-Item $assetPath -ErrorAction Stop).Length } catch { 0 }
         if ($assetLen -eq 0) {
           Write-Host "  ⚠️  $pluginId/$asset downloaded as empty (network drop?)" -ForegroundColor Yellow
@@ -194,7 +195,7 @@ function Install-Plugins {
     if ($ok) {
       $cssPath = Join-Path $pluginDir "styles.css"
       try {
-        $cssResponse = Invoke-WebRequest -Uri "$baseUrl/styles.css" -OutFile $cssPath -PassThru -ErrorAction Stop
+        $cssResponse = Invoke-WebRequest -Uri "$baseUrl/styles.css" -OutFile $cssPath -PassThru -UseBasicParsing -ErrorAction Stop
         # Defensive: remove if non-200 or empty (guards against zero-byte writes on network drop)
         $cssLen = try { (Get-Item $cssPath -ErrorAction Stop).Length } catch { 0 }
         if ($cssResponse.StatusCode -ne 200 -or $cssLen -eq 0) {
@@ -307,9 +308,9 @@ function Register-OnebrainHooks {
       }
       if (-not $found) { $arr += $entry }
       if ($null -eq $existing) {
-        $hooksObj | Add-Member -NotePropertyName $event -NotePropertyValue $arr -Force
+        $hooksObj | Add-Member -NotePropertyName $event -NotePropertyValue ([object[]]$arr) -Force
       } else {
-        $hooksObj.PSObject.Properties[$event].Value = $arr
+        $hooksObj.PSObject.Properties[$event].Value = [object[]]$arr
       }
     }
 

--- a/install.ps1
+++ b/install.ps1
@@ -317,7 +317,11 @@ function Register-OnebrainHooks {
     Register-Hook $cfg.hooks "PreCompact"  (& $makeHook "precompact")
     Register-Hook $cfg.hooks "PostCompact" (& $makeHook "postcompact")
 
-    $cfg | ConvertTo-Json -Depth 10 | Set-Content $settingsPath -Encoding UTF8
+    [System.IO.File]::WriteAllText(
+      $settingsPath,
+      ($cfg | ConvertTo-Json -Depth 10) + "`n",
+      [System.Text.UTF8Encoding]::new($false)
+    )
     Print-Info "Registered Stop, PreCompact, PostCompact hooks in .claude/settings.json"
   } catch {
     Print-Info "Warning: could not register hooks: $($_.Exception.Message). Run /update after first session."


### PR DESCRIPTION
## Summary

- **Issue 14**: `Set-Content -Encoding UTF8` on PS5 writes a UTF-8 BOM — replaced with `[System.IO.File]::WriteAllText` (no-BOM)
- **Issue 15**: Script hangs in CI/non-interactive sessions — added `[Environment]::UserInteractive`, `Default Host`, and `[Console]::IsInputRedirected` checks at top of `Main` (covers both PS5 and PS7)
- **Issue 16**: No ZIP validation before `Expand-Archive` — added `ZipFile::OpenRead` check with `try/finally` for safe handle disposal; surfaces GitHub error pages clearly
- **Issue 17**: Missing `-UseBasicParsing` (fails on Server Core), no `Set-StrictMode`, single-element hook array serialises as object on PS5
- **Parity + docs**: tilde expansion uses string concat (not regex replace) to avoid `$USERPROFILE` back-reference bug; relative hook path matches install.sh; corrected "absolute path required" claim in 3 files
- **Update hang**: `/update` version check now explicitly uses `WebFetch` with raw GitHub URL — no git commands that hang waiting for credentials on Windows

## Test plan

- [ ] Run `install.ps1` on PS5 (Windows) — verify `settings.json` has no BOM
- [ ] Run `install.ps1` with stdin redirected — verify it exits with clear error message
- [ ] Simulate corrupt ZIP — verify validation error message appears before Expand-Archive
- [ ] Run on Windows Server Core (no IE engine) — verify plugin downloads succeed
- [ ] Run `/update` on Windows — verify version is fetched without hanging
- [ ] Test tilde expansion with path containing `$` in username