### PR TITLE
docs(skills): add exclusion clauses to all 25 skills + multi-harness entrypoints (v1.10.11)

### DIFF
--- a/.claude/plugins/onebrain/.claude-plugin/plugin.json
+++ b/.claude/plugins/onebrain/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "onebrain",
-  "version": "1.10.10",
+  "version": "1.10.11",
   "description": "OneBrain — Where human and AI thinking become one. A powerful thinking partner powered by AI synergy.",
   "author": {
     "name": "OneBrain Contributors"

--- a/.claude/plugins/onebrain/references/codex-tools.md
+++ b/.claude/plugins/onebrain/references/codex-tools.md
@@ -1,0 +1,34 @@
+# Codex Tool Mapping
+
+Skills and INSTRUCTIONS.md use Claude Code tool names. When you encounter these, use the Codex equivalent:
+
+| INSTRUCTIONS references | Codex equivalent |
+|---|---|
+| `Read`, `Write`, `Edit` | Use native file tools |
+| `Bash` (run commands) | Use native shell tools |
+| `Glob`, `Grep` | Use native search tools |
+| `WebSearch`, `WebFetch` | Use native web tools |
+| `AskUserQuestion` | Ask inline via output |
+| `Skill` (invoke a skill) | Skills load natively — follow instructions directly |
+| `Agent` (dispatch sub-agent) | `spawn_agent` — see below |
+| `mcp__plugin_onebrain_qmd__*` | Not available — use native search tools |
+
+## Sub-agent dispatch
+
+Enable multi-agent support in `~/.codex/config.toml`:
+
+```toml
+[features]
+multi_agent = true
+```
+
+When INSTRUCTIONS or a skill dispatches an agent (inbox-classifier, tag-suggester, etc.):
+
+1. Find the agent prompt in `.claude/plugins/onebrain/agents/[name].md`
+2. Fill any template variables
+3. Run: `spawn_agent(agent_type="worker", message="Your task is to perform the following.\n\n<agent-instructions>\n[filled prompt]\n</agent-instructions>\n\nExecute now.")`
+4. `wait` for result, then `close_agent`
+
+## TodoWrite → not needed
+
+OneBrain does not use `TodoWrite` for session tracking. Task items are written directly to vault markdown files using Obsidian task syntax (`- [ ] Task 📅 YYYY-MM-DD`).

--- a/.claude/plugins/onebrain/references/gemini-tools.md
+++ b/.claude/plugins/onebrain/references/gemini-tools.md
@@ -1,0 +1,31 @@
+# Gemini CLI Tool Mapping
+
+Skills and INSTRUCTIONS.md use Claude Code tool names. When you encounter these, use the Gemini CLI equivalent:
+
+| INSTRUCTIONS references | Gemini CLI equivalent |
+|---|---|
+| `Read` (file reading) | `read_file` |
+| `Write` (file creation) | `write_file` |
+| `Edit` (file editing) | `replace` |
+| `Bash` (run commands) | `run_shell_command` |
+| `Grep` (search content) | `grep_search` |
+| `Glob` (search by filename) | `glob` |
+| `WebSearch` | `google_web_search` |
+| `WebFetch` | `web_fetch` |
+| `AskUserQuestion` | `ask_user` |
+| Skills (follow SKILL.md) | Read `.claude/plugins/onebrain/skills/[name]/SKILL.md` via `read_file`, then follow it — no separate tool call needed |
+| `Agent` (dispatch sub-agent) | No equivalent — execute inline |
+| `mcp__plugin_onebrain_qmd__*` | Not available — use `glob` + `grep_search` |
+
+## No sub-agent support
+
+Gemini CLI has no equivalent to Claude Code's `Agent` tool. Skills that dispatch sub-agents (inbox-classifier, tag-suggester, link-suggester, task-extractor) run their logic inline instead. Results may be slightly slower but functionally equivalent.
+
+## Additional Gemini CLI tools
+
+| Tool | Purpose |
+|---|---|
+| `list_directory` | List files and subdirectories |
+| `save_memory` | Persist facts across sessions |
+| `ask_user` | Request structured input from the user |
+| `enter_plan_mode` / `exit_plan_mode` | Switch to read-only mode before making changes |

--- a/.claude/plugins/onebrain/skills/bookmark/SKILL.md
+++ b/.claude/plugins/onebrain/skills/bookmark/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bookmark
-description: "Quick URL bookmark capture : paste a link, AI generates name and description, suggests category, saves to Bookmarks.md in awesome-list format. Invoke when user wants to save a link, bookmark a URL, or add to their reading list."
+description: "Quick URL bookmark capture : paste a link, AI generates name and description, suggests category, saves to Bookmarks.md in awesome-list format. Invoke when user wants to save a URL for later — bare URL with no other context defaults to this. Do NOT use for: deeply processing or summarizing the URL content now (use summarize), saving a note that is not a URL (use capture), or researching a topic from scratch (use research)."
 ---
 
 # Bookmark

--- a/.claude/plugins/onebrain/skills/braindump/SKILL.md
+++ b/.claude/plugins/onebrain/skills/braindump/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: braindump
-description: "Capture a stream of raw thoughts : classify them and file to inbox with action items extracted"
+description: "Capture a stream of raw thoughts : classify them and file to inbox with action items extracted. Use when the user signals a free-form, stream-of-consciousness dump with multiple unrelated threads — 'let me dump everything on my mind'. Do NOT use for: a single titled idea (use capture), saving a URL (use bookmark), or anything structured and focused."
 ---
 
 # Braindump

--- a/.claude/plugins/onebrain/skills/capture/SKILL.md
+++ b/.claude/plugins/onebrain/skills/capture/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: capture
-description: "Quick note capture with automatic wikilink suggestions to related existing notes"
+description: "Quick note capture with automatic wikilink suggestions to related existing notes. Use when the user wants to save a single, specific, titled idea, insight, or piece of information to the vault. Do NOT use for: unstructured multi-thread thought dumps (use braindump), saving a URL for later (use bookmark), deeply summarizing an article or URL (use summarize), processing a book (use reading-notes), or teaching the agent a preference (use learn)."
 ---
 
 # Capture

--- a/.claude/plugins/onebrain/skills/clone/SKILL.md
+++ b/.claude/plugins/onebrain/skills/clone/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: clone
-description: "Clone your agent's portable context (agent folder including MEMORY.md) to a folder for transfer to another vault"
+description: "Clone your agent's portable context (agent folder including MEMORY.md) to a folder for transfer to another vault. Use only when the user explicitly wants to migrate or copy agent memory to a new vault. Do NOT use for: backing up the whole vault, updating OneBrain (use update), or reviewing memory (use memory-review)."
 ---
 
 # Clone

--- a/.claude/plugins/onebrain/skills/connect/SKILL.md
+++ b/.claude/plugins/onebrain/skills/connect/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: connect
-description: "Find connections between notes and suggest wikilinks to strengthen the knowledge graph"
+description: "Find connections between notes and suggest wikilinks to strengthen the knowledge graph. Use when the user wants to discover how existing notes relate to each other — 'find connections', 'what links to this note', 'strengthen my graph'. Do NOT use for: creating new notes (use capture), processing inbox (use consolidate), or searching for specific content (search directly)."
 ---
 
 # Connect

--- a/.claude/plugins/onebrain/skills/consolidate/SKILL.md
+++ b/.claude/plugins/onebrain/skills/consolidate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: consolidate
-description: "Review inbox and recent notes, synthesize and merge into the knowledge base"
+description: "Review inbox and recent notes, synthesize and merge into the knowledge base. Use when the user wants to process, organize, or clear the inbox regardless of topic — 'clean up my inbox', 'process my notes'. Do NOT use for: capturing new information now (use capture or braindump), synthesizing already-vaulted notes on a specific topic (use distill — consolidate works on the inbox), or finding note connections (use connect)."
 ---
 
 # Consolidate

--- a/.claude/plugins/onebrain/skills/daily/SKILL.md
+++ b/.claude/plugins/onebrain/skills/daily/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: daily
-description: "Daily briefing: surfaces tasks due today and open items from the last session"
+description: "Daily briefing: surfaces tasks due today and open items from the last session. Use when the user wants a snapshot of today's obligations — 'what's on today', 'daily briefing', 'what do I have today'. Do NOT use for: full weekly review (use weekly), vault health check (use doctor), or listing all tasks across future dates."
 ---
 
 # /daily : Daily Briefing

--- a/.claude/plugins/onebrain/skills/distill/SKILL.md
+++ b/.claude/plugins/onebrain/skills/distill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: distill
-description: "Aggregate notes from multiple sessions or sources on a specific topic into a single structured digest note in the knowledge base"
+description: "Aggregate already-vaulted notes from multiple sessions or sources on a specific topic into a single structured digest note. Use when the user wants to synthesize a completed research thread — 'distill everything I know about X', 'crystallize my notes on Y'. Do NOT use for: promoting session insights to memory (use recap), writing today's session summary (use wrapup), or clearing raw inbox items (use consolidate — distill works on notes already in the vault)."
 ---
 
 # Distill

--- a/.claude/plugins/onebrain/skills/doctor/SKILL.md
+++ b/.claude/plugins/onebrain/skills/doctor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: doctor
-description: "Diagnose vault and plugin health — checks broken links, orphan notes, stale memory/ files, inbox backlog, and plugin config validity"
+description: "Diagnose vault and plugin health — checks broken links, orphan notes, stale memory/ files, inbox backlog, and plugin config validity. Use when the user asks to check vault health, notices something broken, or wants a system audit — 'run /doctor', 'check my vault', 'something seems off'. Do NOT use for: searching vault content (search directly), processing inbox (use consolidate), or updating the system (use update)."
 ---
 
 # Doctor

--- a/.claude/plugins/onebrain/skills/help/SKILL.md
+++ b/.claude/plugins/onebrain/skills/help/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: help
-description: "List all available OneBrain commands with descriptions and use cases. Invoke when user asks what you can do, wants to see commands, or seems confused about capabilities."
+description: "List all available OneBrain commands with descriptions and use cases. Invoke when user asks what you can do, wants to see commands, or seems confused about capabilities. Do NOT use for: actually running a command (identify the right skill and invoke it directly), answering questions about vault content (search directly), or general Claude questions."
 ---
 
 # /help : Available Commands

--- a/.claude/plugins/onebrain/skills/import/SKILL.md
+++ b/.claude/plugins/onebrain/skills/import/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: import
-description: "Import local files (PDF, Word, PowerPoint, Excel, images, video, scripts) from a staging inbox folder or explicit path into structured markdown notes in the resources folder (default 04-resources/, resolved from vault.yml). Invoke when user runs /import, /import [path], or /import --attach."
+description: "Import local files (PDF, Word, PowerPoint, Excel, images, video, scripts) from a staging inbox folder or explicit path into structured markdown notes in the resources folder. Invoke when user mentions a local file path to bring into the vault, or runs /import or /import --attach. Do NOT use for: fetching content from a URL (use summarize), capturing a text idea (use capture), or processing a book already read (use reading-notes)."
 ---
 
 # Import

--- a/.claude/plugins/onebrain/skills/learn/SKILL.md
+++ b/.claude/plugins/onebrain/skills/learn/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: learn
-description: "Teach the agent a new fact or behavioral preference and save it to memory/ for future recall"
+description: "Teach the agent a new fact or behavioral preference and save it to memory/ for future recall. Use when the user says 'remember that', 'from now on', 'always do X', or corrects agent behavior they want persisted. Do NOT use for: capturing a general note or idea (use capture), saving a session summary (use wrapup), or promoting recurring patterns from many sessions (use recap)."
 ---
 
 # Learn

--- a/.claude/plugins/onebrain/skills/memory-review/SKILL.md
+++ b/.claude/plugins/onebrain/skills/memory-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: memory-review
-description: "Interactive review of all memory/ files — keep, update, deprecate, or delete entries one by one"
+description: "Interactive review of all memory/ files — keep, update, deprecate, or delete entries one by one. Use when the user wants to audit and prune accumulated memory — 'review my memory', 'clean up what you remember'. Do NOT use for: teaching a new fact (use learn), recalling something specific (read memory directly), or batch-promoting session insights (use recap)."
 ---
 
 # Memory Review

--- a/.claude/plugins/onebrain/skills/moc/SKILL.md
+++ b/.claude/plugins/onebrain/skills/moc/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: moc
-description: "Create or update the vault portal (MOC.md) at the vault root : a Map of Content with live Dataview queries, AI summary, and user Pinned section."
+description: "Create or update the vault portal (MOC.md) at the vault root : a Map of Content with live Dataview queries, AI summary, and user Pinned section. Use when the user wants to regenerate or view the vault overview map. Do NOT use for: the task dashboard (use tasks), adding individual notes (use capture), or vault health checks (use doctor)."
 ---
 
 # Vault Portal

--- a/.claude/plugins/onebrain/skills/onboarding/SKILL.md
+++ b/.claude/plugins/onebrain/skills/onboarding/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: onboarding
-description: "First-run setup for OneBrain : personalize identity, communication style, and vault configuration"
+description: "First-run setup for OneBrain : personalize identity, communication style, and vault configuration. Use only on first install or when the user wants to fully reconfigure OneBrain from scratch — manual only. Do NOT use for: teaching a single preference (use learn), updating system files (use update), or reviewing memory (use memory-review)."
 ---
 
 ## Install Path Detection

--- a/.claude/plugins/onebrain/skills/qmd/SKILL.md
+++ b/.claude/plugins/onebrain/skills/qmd/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: qmd
-description: "Set up and manage qmd search index for faster vault search. Subcommands: setup, embed, status, reindex, uninstall."
+description: "Set up and manage qmd search index for faster vault search. Subcommands: setup, embed, status, reindex, uninstall. Use when the user wants to configure, update, or troubleshoot the qmd search index itself. Do NOT use for: performing a search (call qmd tools directly), general vault operations, or installing OneBrain (use onboarding or update)."
 ---
 
 # /qmd : qmd Search Integration

--- a/.claude/plugins/onebrain/skills/reading-notes/SKILL.md
+++ b/.claude/plugins/onebrain/skills/reading-notes/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: reading-notes
-description: "Process a book or article into structured progressive summary notes saved to the resources folder"
+description: "Process a book or article into structured progressive summary notes saved to the resources folder. Use when the user has finished reading something and wants to capture structured notes — 'I just finished reading X', 'take notes on this book'. Do NOT use for: fetching and summarizing a URL now (use summarize), capturing a raw thought (use capture), or web research (use research)."
 ---
 
 # Reading Notes

--- a/.claude/plugins/onebrain/skills/recap/SKILL.md
+++ b/.claude/plugins/onebrain/skills/recap/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: recap
-description: "Batch-promote recurring insights from session logs into memory/ files with frequency filtering"
+description: "Batch-promote recurring insights from session logs into memory/ files with frequency filtering. Use when the user wants to extract persistent lessons or patterns from recent sessions — 'recap my recent sessions', 'what have I been learning lately'. Do NOT use for: saving a single fact now (use learn), writing today's session log (use wrapup), or synthesizing a specific topic into a note (use distill)."
 ---
 
 # Recap

--- a/.claude/plugins/onebrain/skills/reorganize/SKILL.md
+++ b/.claude/plugins/onebrain/skills/reorganize/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: reorganize
-description: "Migrate vault structure : either full 5-folder → 8-folder migration, or subfolder organization for flat notes"
+description: "Migrate vault structure : either full 5-folder → 8-folder migration, or subfolder organization for flat notes. Use only when the user explicitly wants to restructure the entire vault layout — manual only, high impact. Do NOT use for: moving a single note (do it directly), processing inbox (use consolidate), or routine note organization."
 ---
 
 # Reorganize Vault

--- a/.claude/plugins/onebrain/skills/research/SKILL.md
+++ b/.claude/plugins/onebrain/skills/research/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: research
-description: "Research a topic on the web and save a structured note to the resources folder"
+description: "Research a topic on the web and save a structured note to the resources folder. Use when the user wants to investigate a topic from scratch with no specific URL — 'research X for me', 'what do I need to know about Y'. Do NOT use for: processing a specific URL the user already has (use summarize), processing a book already read (use reading-notes), or quick note capture without web research (use capture or braindump)."
 ---
 
 # Research

--- a/.claude/plugins/onebrain/skills/summarize/SKILL.md
+++ b/.claude/plugins/onebrain/skills/summarize/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: summarize
-description: "Fetch a URL and create a structured summary note saved to the resources folder. Invoke when user wants to deeply process a link, article, blog post, documentation, or paper into a permanent vault note."
+description: "Fetch a URL and create a structured summary note saved to the resources folder. Invoke when user shares a URL and explicitly asks for a summary, deep read, or notes on it. Do NOT use for: just saving a URL without reading it (use bookmark), researching a topic without a specific URL (use research), or processing a physical book (use reading-notes)."
 ---
 
 # Summarize

--- a/.claude/plugins/onebrain/skills/tasks/SKILL.md
+++ b/.claude/plugins/onebrain/skills/tasks/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tasks
-description: "Create or update the live task dashboard (TASKS.md) in Obsidian."
+description: "Create or update the live task dashboard (TASKS.md) in Obsidian. Use when the user wants to view or regenerate the task dashboard — 'show my tasks', 'update TASKS.md', 'open task view'. Do NOT use for: the vault portal/map (use moc), capturing new tasks (add them inside project notes directly), or daily briefing (use daily)."
 ---
 
 # Task Dashboard

--- a/.claude/plugins/onebrain/skills/update/SKILL.md
+++ b/.claude/plugins/onebrain/skills/update/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: update
-description: "Update OneBrain system files from the source repo to the latest version"
+description: "Update OneBrain system files from the source repo to the latest version. Use when the user wants to pull the latest OneBrain skills, hooks, and agents — 'update OneBrain', 'pull latest version'. Do NOT use for: updating vault notes (edit directly), teaching memory (use learn), or vault health checks (use doctor)."
 ---
 
 # /update

--- a/.claude/plugins/onebrain/skills/weekly/SKILL.md
+++ b/.claude/plugins/onebrain/skills/weekly/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: weekly
-description: "Weekly reflection : review the past week's sessions, surface patterns, and plan ahead"
+description: "Weekly reflection : review the past week's sessions, surface patterns, and plan ahead. Use when the user wants a structured end-of-week review — 'weekly review', 'how did this week go', 'plan next week'. Do NOT use for: daily task check-in (use daily), session summary (use wrapup), or promoting insights to memory (use recap)."
 ---
 
 # Weekly Reflection

--- a/.claude/plugins/onebrain/skills/wrapup/SKILL.md
+++ b/.claude/plugins/onebrain/skills/wrapup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wrapup
-description: "Wrap up and save the current session summary to the session log"
+description: "Wrap up and save the current session summary to the session log. Use at end of session when the user says 'bye', 'wrap up', 'save session', or an end-of-session signal is detected. /wrapup writes to 07-logs/ only. Do NOT use for: promoting insights to memory/ (use recap), synthesizing a topic across sessions (use distill), or teaching a single preference (use learn)."
 ---
 
 # Session Summary (TL;DR)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,1 +1,18 @@
+# OneBrain — Codex CLI
+
+OneBrain is a personal AI OS for Obsidian. INSTRUCTIONS.md is written using Claude Code
+tool names — the mapping below translates them to Codex CLI equivalents and explains
+how to dispatch sub-agents for skills that require parallel execution.
+
+## Load Order
+
+1. **Tool mapping** — translates Claude Code tool names to Codex CLI equivalents, and maps `Agent` dispatch to `spawn_agent`
+2. **Shared agent instructions** — vault structure, skills, session behavior, and personality
+
+## Tool Name Mapping
+
+@.claude/plugins/onebrain/references/codex-tools.md
+
+## Agent Instructions
+
 @.claude/plugins/onebrain/INSTRUCTIONS.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-latest_version: 1.10.10
+latest_version: 1.10.11
 released: 2026-04-20
 ---
 
@@ -9,6 +9,15 @@ All notable changes to OneBrain are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+
+## v1.10.11 — Skill Exclusion Clauses + Multi-Harness Entrypoints
+
+- docs(skills): add "Do NOT use for:" exclusion clause to all 25 skill descriptions to prevent skill routing errors between overlapping skills (capture/braindump/bookmark/summarize/research, wrapup/recap/distill, etc.)
+- feat(harness): add `references/gemini-tools.md` — Gemini CLI tool name mapping for INSTRUCTIONS.md
+- feat(harness): add `references/codex-tools.md` — Codex CLI tool name mapping and sub-agent dispatch guide
+- fix(harness): update GEMINI.md to load gemini-tools.md before INSTRUCTIONS.md
+- fix(harness): update AGENTS.md to load codex-tools.md before INSTRUCTIONS.md
+- docs(contributing): add Multi-Harness Support section documenting entrypoint structure
 
 ## v1.10.10 — MEMORY-INDEX Rename + README Memory Layer
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,8 @@
+# OneBrain — Claude Code
+
+OneBrain is a personal AI OS for Obsidian, built natively for Claude Code.
+All tool names in INSTRUCTIONS.md use Claude Code conventions directly.
+
+## Agent Instructions
+
 @.claude/plugins/onebrain/INSTRUCTIONS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,8 +21,11 @@ Good contributions include:
 .claude/plugins/onebrain/                Main plugin directory
 ├── .claude-plugin/
 │   └── plugin.json                      Plugin manifest (name, version, description)
-├── INSTRUCTIONS.md                      Agent instructions — loaded by CLAUDE.md/GEMINI.md/AGENTS.md
-├── skills/                              One directory per slash command (24 skills)
+├── INSTRUCTIONS.md                      Shared agent instructions — harness-neutral core
+├── references/                          Harness-specific context loaded by GEMINI.md / AGENTS.md
+│   ├── gemini-tools.md                  Tool name mapping for Gemini CLI
+│   └── codex-tools.md                   Tool name mapping for Codex CLI
+├── skills/                              One directory per slash command (25 skills)
 │   └── [name]/
 │       └── SKILL.md                     The skill prompt — what the AI follows when invoked
 ├── hooks/
@@ -38,6 +41,20 @@ Good contributions include:
 Key files: [marketplace.json](.claude-plugin/marketplace.json) · [plugin.json](.claude/plugins/onebrain/.claude-plugin/plugin.json) · [INSTRUCTIONS.md](.claude/plugins/onebrain/INSTRUCTIONS.md) · [hooks.json](.claude/plugins/onebrain/hooks/hooks.json)
 
 Skills are plain Markdown files. The AI reads them at runtime — no compilation or build step.
+
+## Multi-Harness Support
+
+OneBrain runs on three AI harnesses. Each has a root entrypoint file that loads harness-specific context before delegating to the shared INSTRUCTIONS.md:
+
+| File | Harness | Loads |
+|---|---|---|
+| `CLAUDE.md` | Claude Code | `INSTRUCTIONS.md` directly |
+| `GEMINI.md` | Gemini CLI | `references/gemini-tools.md` → `INSTRUCTIONS.md` |
+| `AGENTS.md` | Codex CLI | `references/codex-tools.md` → `INSTRUCTIONS.md` |
+
+**INSTRUCTIONS.md is harness-neutral** — it uses Claude Code tool names throughout. The `references/` files translate those names to each harness's equivalents.
+
+When editing INSTRUCTIONS.md or skills, use Claude Code tool names (`Read`, `Write`, `Edit`, `Bash`, `Agent`, etc.) — the harness mapping handles translation automatically.
 
 ## Skills vs Agents — When to Use Which
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,1 +1,18 @@
+# OneBrain — Gemini CLI
+
+OneBrain is a personal AI OS for Obsidian. INSTRUCTIONS.md is written using Claude Code
+tool names — the mapping below translates them to Gemini CLI equivalents before the
+shared instructions load.
+
+## Load Order
+
+1. **Tool mapping** — translates Claude Code tool names (`Read`, `Write`, `Bash`, etc.) to Gemini CLI equivalents (`read_file`, `write_file`, `run_shell_command`, etc.)
+2. **Shared agent instructions** — vault structure, skills, session behavior, and personality
+
+## Tool Name Mapping
+
+@.claude/plugins/onebrain/references/gemini-tools.md
+
+## Agent Instructions
+
 @.claude/plugins/onebrain/INSTRUCTIONS.md


### PR DESCRIPTION
## Summary

- Add "Do NOT use for:" exclusion clause to all 25 skill descriptions, following the Exclusion Clause Pattern from Anthropic's skill authoring guide — prevents routing errors between overlapping skills (capture/braindump/bookmark/summarize/research, wrapup/recap/distill, etc.)
- Add `references/gemini-tools.md` and `references/codex-tools.md` — tool name mappings so Gemini CLI and Codex users can translate INSTRUCTIONS.md tool calls to their platform equivalents
- Update `GEMINI.md` and `AGENTS.md` to load the harness-specific tool mapping before `INSTRUCTIONS.md`
- Update `CONTRIBUTING.md` with a Multi-Harness Support section documenting the entrypoint structure

## Test plan

- [ ] Each skill description contains "Do NOT use for:" with at least one redirect to a named alternative skill
- [ ] `capture` exclusion says "saving a URL for later (use bookmark)" — not "without deep processing"
- [ ] `research` exclusion includes both `capture` and `braindump` for non-web-research cases
- [ ] `GEMINI.md` loads `references/gemini-tools.md` before `INSTRUCTIONS.md`
- [ ] `AGENTS.md` loads `references/codex-tools.md` before `INSTRUCTIONS.md`
- [ ] `CHANGELOG.md` `latest_version` frontmatter = `1.10.11`
- [ ] `plugin.json` version = `1.10.11`

🤖 Generated with [Claude Code](https://claude.com/claude-code)