### PR TITLE
fix/refactor(update): GitHub-only sync, predefined scripts, lazy loading, cache cleanup (v1.10.13)

### DIFF
--- a/.claude/plugins/onebrain/.claude-plugin/plugin.json
+++ b/.claude/plugins/onebrain/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "onebrain",
-  "version": "1.10.12",
+  "version": "1.10.13",
   "description": "OneBrain — Where human and AI thinking become one. A powerful thinking partner powered by AI synergy.",
   "author": {
     "name": "OneBrain Contributors"

--- a/.claude/plugins/onebrain/skills/update/SKILL.md
+++ b/.claude/plugins/onebrain/skills/update/SKILL.md
@@ -59,7 +59,7 @@ Steps:
    b. Sync remaining files — run these two sub-steps in parallel:
       - **Plugin folder + root file sync:** run `bash ".claude/plugins/onebrain/skills/update/scripts/vault-sync.sh" "{source_repo}" "{vault_root}"`. Now safe to call from the vault (scripts were synced in step 1). Syncs the full plugin folder (with stale file cleanup) and copies README.md, CONTRIBUTING.md, CHANGELOG.md to the vault root.
       - **Settings merge:** merge `[vault]/.claude/settings.json` from `{source_repo}/.claude/settings.json`. Merge strategy (never overwrite, always additive): `permissions.allow` → union; `enabledPlugins` → merge keys; `extraKnownMarketplaces` → merge keys; `hooks` → skip (handled by migration Step 7).
-   c. Load `skills/update/references/migration-steps.md` and run all 9 steps (all scripts are now in the vault)
+   c. Load `[vault]/.claude/plugins/onebrain/skills/update/references/migration-steps.md` and run all 9 migration steps (all scripts are now in the vault)
    d. Bump `plugin.json` version to `{new}` (last — completion signal; do not bump early)
 4. Write migration log to `[logs_folder]/YYYY/MM/YYYY-MM-DD-update-vX.X.X.md`:
 
@@ -133,7 +133,7 @@ Dry run complete — {N} files would be created, {M} modified, {P} deleted.
 
 - **plugin.json bump is the last step.** If /update is interrupted before step 3d, the version stays at the old number — re-running /update will retry the full migration. Do not bump plugin.json early as a progress marker.
 
-- **MEMORY.md Key Learnings migration (Step 1) must run before Step 4.** Step 4 restructures MEMORY.md; Step 1 reads and extracts from it. Running them in the wrong order loses the Key Learnings content before it can be promoted to memory/ files.
+- **MEMORY.md Key Learnings migration (migration Step 1) must run before migration Step 4.** Migration Step 4 restructures MEMORY.md; migration Step 1 reads and extracts from it. Running them in the wrong order loses the Key Learnings content before it can be promoted to memory/ files.
 
 - **Plugin folder sync deletes stale files.** Step 3b removes files in the vault's plugin folder that no longer exist in the source repo. This is intentional — the source repo is the single source of truth. Do not place user customizations inside `.claude/plugins/onebrain/`; they belong at the project or user settings level.
 

--- a/.claude/plugins/onebrain/skills/update/SKILL.md
+++ b/.claude/plugins/onebrain/skills/update/SKILL.md
@@ -70,7 +70,7 @@ Steps:
    a. Pre-migration backup: copy `[agent_folder]/MEMORY.md` → `[archive_folder]/05-agent/MEMORY-YYYY-MM-DD.md`
       and `[agent_folder]/context/` → `[archive_folder]/05-agent/context.YYYY-MM-DD/` (if context/ exists)
    b. Sync remaining files — run these two sub-steps in parallel, then clean cache after both complete:
-      - **Full vault sync:** run `bash ".claude/plugins/onebrain/skills/update/scripts/vault-sync.sh" "$PWD" "{branch}"`. `$PWD` resolves to the vault root at runtime. Downloads the full GitHub tarball, syncs plugin folder (with stale file cleanup), and copies README.md, CONTRIBUTING.md, CHANGELOG.md to vault root.
+      - **Full vault sync:** run `bash ".claude/plugins/onebrain/skills/update/scripts/vault-sync.sh" "$PWD" "{branch}"`. `$PWD` resolves to the vault root at runtime. Downloads the full GitHub tarball, syncs plugin folder (with stale file cleanup), copies README.md/CONTRIBUTING.md/CHANGELOG.md to vault root (overwrite), and merges CLAUDE.md/GEMINI.md/AGENTS.md (preserving user `@` imports).
       - **Settings merge:** WebFetch `https://raw.githubusercontent.com/kengio/onebrain/{branch}/.claude/settings.json`, then merge into `[vault]/.claude/settings.json`. Merge strategy (never overwrite, always additive): `permissions.allow` → union; `enabledPlugins` → merge keys; `extraKnownMarketplaces` → merge keys; `hooks` → skip (handled by migration Step 7).
       - After both complete: run `bash ".claude/plugins/onebrain/skills/update/scripts/clean-plugin-cache.sh"`. Removes stale onebrain cache versions; no-op for local directory installs.
    c. Once all step 3b sub-steps are complete, load `[vault]/.claude/plugins/onebrain/skills/update/references/migration-steps.md` and run all 9 migration steps
@@ -151,8 +151,8 @@ Dry run complete — {N} files would be created, {M} modified, {P} deleted.
 
 - **Plugin folder sync deletes stale files.** Step 3b removes files in the vault's plugin folder that no longer exist in the source repo. This is intentional — the source repo is the single source of truth. Do not place user customizations inside `.claude/plugins/onebrain/`; they belong at the project or user settings level.
 
-- **Root files (README, CONTRIBUTING, CHANGELOG) live at the repo root, not the plugin folder.** `vault-sync.sh` handles both the plugin folder and root file sync. Never copy CHANGELOG.md into the plugin folder.
+- **Root files live at the repo root, not the plugin folder.** `vault-sync.sh` handles all six root-level files: README.md, CONTRIBUTING.md, CHANGELOG.md (simple overwrite) and CLAUDE.md, GEMINI.md, AGENTS.md (merge — preserves user `@` imports). Never copy any of these into the plugin folder.
 
-- **Update scripts must be bootstrapped before they can be called.** Bootstrap step 1 downloads `SKILL.md` and `vault-sync.sh` from GitHub before running any other step. Do not call vault scripts before step 1 completes.
+- **Update scripts must be bootstrapped before they can be called.** Bootstrap step 1 downloads `SKILL.md` and all four update scripts from GitHub before running any other step. Do not call vault scripts before step 1 completes.
 
 - **Failure recovery path:** If interrupted before step 3d (plugin.json bump), re-running /update will retry from step 1. The early bootstrap (copy skills/update/) is idempotent — safe to repeat.

--- a/.claude/plugins/onebrain/skills/update/SKILL.md
+++ b/.claude/plugins/onebrain/skills/update/SKILL.md
@@ -47,26 +47,21 @@ Minor/patch bumps (1.10.0 → 1.10.1, 1.10.0 → 1.11.0): proceed without major 
 Skills are markdown instructions — the agent can read the new SKILL.md from the repo and
 follow it as instructions in the same conversation. No re-invoke needed.
 
+**Source repo path:** Resolve from `onebrain-development` memory file or ask user if unavailable. Typically `~/projects/onebrain`.
+
 Steps:
-1. Read repo's `skills/update/SKILL.md` content into agent context
-2. Read repo's CHANGELOG.md to identify migration steps for current version
-3. Follow the NEW SKILL.md instructions (not the vault's old copy)
-4. Execute migration in this order:
-   a. Pre-migration backup: copy `05-agent/MEMORY.md` → `06-archive/05-agent/MEMORY-YYYY-MM-DD.md`
-      and `05-agent/context/` → `06-archive/05-agent/context.YYYY-MM-DD/` (if context/ exists)
-   b. Sync plugin folder: copy everything under `.claude/plugins/onebrain/` from source repo to vault, overwriting existing files. Skip `plugin.json` — it is written last as the completion signal. The plugin folder is source of truth; user customizations belong at project or user level.
-
-   c. Merge `[vault]/.claude/settings.json` from repo's `.claude/settings.json` — the repo is the source of truth for base permissions and plugin config. Merge strategy (never overwrite, always additive):
-      - `permissions.allow`: union — add any entries from repo not already in vault's list
-      - `enabledPlugins`: merge — add any keys from repo not already in vault's object
-      - `extraKnownMarketplaces`: merge — add any keys from repo not already in vault's object
-      - `hooks`: skip — handled separately by Step 7
-
-   d. Run vault migration steps 1–9 (using newly-synced skill logic)
-   e. Run /doctor verification (newly-synced /doctor with new checks)
-   f. Sync remaining repo files: INSTRUCTIONS.md, README.md, CONTRIBUTING.md, CHANGELOG.md
-   g. Bump plugin.json version (last — completion signal)
-5. Write migration log to `[logs_folder]/YYYY/MM/YYYY-MM-DD-update-vX.X.X.md`:
+1. **Early bootstrap — sync the update skill itself first:**
+   Copy `{source_repo}/.claude/plugins/onebrain/skills/update/` → `[vault]/.claude/plugins/onebrain/skills/update/` (overwrite all files including scripts/). This ensures the latest SKILL.md and predefined scripts are physically in the vault before anything else runs — regardless of which version the vault was previously running.
+2. Read the newly-written `[vault]/.claude/plugins/onebrain/skills/update/SKILL.md` into agent context. Follow THESE instructions (not the pre-update copy) for all remaining steps.
+3. Execute migration in this order:
+   a. Pre-migration backup: copy `[agent_folder]/MEMORY.md` → `[archive_folder]/05-agent/MEMORY-YYYY-MM-DD.md`
+      and `[agent_folder]/context/` → `[archive_folder]/05-agent/context.YYYY-MM-DD/` (if context/ exists)
+   b. Sync remaining files — run these two sub-steps in parallel:
+      - **Plugin folder + root file sync:** run `bash ".claude/plugins/onebrain/skills/update/scripts/vault-sync.sh" "{source_repo}" "{vault_root}"`. Now safe to call from the vault (scripts were synced in step 1). Syncs the full plugin folder (with stale file cleanup) and copies README.md, CONTRIBUTING.md, CHANGELOG.md to the vault root.
+      - **Settings merge:** merge `[vault]/.claude/settings.json` from `{source_repo}/.claude/settings.json`. Merge strategy (never overwrite, always additive): `permissions.allow` → union; `enabledPlugins` → merge keys; `extraKnownMarketplaces` → merge keys; `hooks` → skip (handled by migration Step 7).
+   c. Load `skills/update/references/migration-steps.md` and run all 9 steps (all scripts are now in the vault)
+   d. Bump `plugin.json` version to `{new}` (last — completion signal; do not bump early)
+4. Write migration log to `[logs_folder]/YYYY/MM/YYYY-MM-DD-update-vX.X.X.md`:
 
    ```markdown
    ---
@@ -99,7 +94,7 @@ Steps:
    - If a step had nothing to do (e.g. context/ already absent), write `[x] Step 2: Skipped — context/ not present`
    - If /doctor found issues in Step 8, list them under the step line
 
-6. Report summary to user:
+5. Report summary to user:
 
    For each migration step (one line per step):
    ✅ Step {N}: {description} ({N} files)
@@ -108,137 +103,6 @@ Steps:
 
    Completion:
    ✅ OneBrain updated to v{new}. {N} files created, {M} modified.
-
-## Vault Migration Steps
-
-Run these steps IN ORDER. Halt on first failure — do not continue.
-
-**Step 1: Migrate MEMORY.md Key Learnings → memory/** (MUST run before Step 4)
-- Read ## Key Learnings and ## Key Decisions from MEMORY.md
-- Tool behaviors (bash tricks, RTK, draw.io, cron patterns) → delete, do not migrate
-- Genuine behavioral patterns → write to memory/ (type: behavioral, source: /update, conf: medium, created: today, verified: today, updated: today)
-- Key Decisions → write to memory/ (type: project, source: /update)
-
-**Step 2: Migrate context/ → memory/**
-- For each file in 05-agent/context/: rename to kebab-case, move to memory/
-- Add frontmatter: type: context, source: /update, conf: medium, created: (preserve if exists else today), verified: today, updated: today, topics: [2–4 keywords from content]
-- Delete context/ folder after all files migrated
-
-**Step 3: Update existing memory/ files**
-- Add missing frontmatter fields: topics, type, conf, verified, updated
-- Rename non-compliant files → kebab-case 3–5 words. A file is non-compliant if it has:
-  - A date prefix (e.g. `2026-04-05-bump-version-every-pr.md` → `bump-version-pr.md`)
-  - A numeric segment prefix (e.g. `2026-04-05-02-superpowers-docs-in-vault.md` → `superpowers-docs-vault.md`)
-  - Title-Case or spaces in the filename
-  - More than 5 words (strip stop words; keep the meaningful 3–5)
-- After renaming: update all `[[wikilinks]]` in `[agent_folder]/MEMORY-INDEX.md` and any `supersedes:`/`superseded_by:` references to use the new filename
-- Compliant example: `bump-version-pr.md`, `dev-workflow-worktree.md`, `telegram-format.md`
-
-**Step 4: Restructure MEMORY.md** (MUST run after Step 1)
-
-Target structure — exactly 3 sections. Skip rewrite only if MEMORY.md already uses the compact Identity labels (`**Agent:**`, `**User:**`, `**Tone:**`). If the old 6-field labels are present (`**Agent name:**`, `**User name:**`, etc.), rewrite even if the 3 section headings already exist. Always update `updated:` frontmatter.
-
-```markdown
-## Identity & Personality
-
-**Agent:** [name] · [gender/pronoun rules if set]
-**Personality:** [personality description]
-**User:** [user_name] · [role]
-**Tone:** [tone] · [detail_level]
-**Language:** [language rules — omit this line if no language rules are set]
-
-You are [agent_name], [user_name]'s personal chief of staff inside their Obsidian vault.
-
-- Priority goal: [primary goal]
-- Proactive: surface connections, flag stale items, suggest next steps
-- Ground responses in vault — reference actual notes when relevant
-- [AskUserQuestion or tool-use preferences, if set]
-
-## Active Projects
-
-<!-- Updated by /consolidate and /braindump -->
-- **[Project]** — [status emoji + label]. [description].
-
-## Critical Behaviors
-
-- [behavioral item]
-<!-- Add behavioral preferences here via /learn -->
-```
-
-Old-section mapping (apply when migrating from pre-v1.10.0 structure):
-- `## Agent Identity` + `## Identity` + `## Communication Style` + `## Goals & Focus Areas` + `## Values & Working Principles` + `## AI Personality Instructions` → consolidate into `## Identity & Personality`
-- `## Active Projects` → keep as-is
-- `## Critical Behaviors` → preserve if present; if absent, create with items from `## Values & Working Principles` plus an empty comment; remove any auto-wrapup trigger entry if present (auto-wrapup is now handled by AUTO-SUMMARY.md)
-- Remove entirely: `## Key Learnings`, `## Key Decisions`, `## Recurring Contexts`
-
-Field extraction hints (for old-section consolidation):
-- **Agent:** → name from `## Agent Identity` or `## Identity`; gender/pronoun rules from `## AI Personality Instructions` if present; omit gender/pronoun suffix if absent
-- **Personality:** → archetype + description from `## AI Personality Instructions` or `## Communication Style`
-- **User:** → name from `## Agent Identity`; role from `## Agent Identity` or `## Goals & Focus Areas`
-- **Tone:** → tone + detail_level from `## Communication Style`
-- **Language:** → language rules from `## Communication Style` or `## Agent Identity` if present; omit line entirely if absent
-- Priority goal bullet → first entry from `## Goals & Focus Areas`
-- `## Values & Working Principles` items → `## Critical Behaviors` (only if Critical Behaviors was absent)
-
-Always: update `updated:` frontmatter to today.
-
-**Step 5: Create `[agent_folder]/MEMORY-INDEX.md`**
-- Read frontmatter of all files in `[agent_folder]/memory/` (batch 20 at a time if >50 files)
-- Include only status: active and status: needs-review in table
-- Column format (exact order): `| File | Topics | Type | Status | Description |`
-  - **File**: wikilink `[[filename-without-extension]]`
-  - **Topics**: comma-separated topics from frontmatter
-  - **Type**: from frontmatter (behavioral / project / context)
-  - **Status**: from frontmatter (active / needs-review)
-  - **Description**: 1-line summary derived from file content (not from frontmatter)
-- For each file with supersedes: X, set superseded_by: [this file] on X's frontmatter
-- Set cache fields: total_active, total_needs_review (omit last_review)
-- If MEMORY-INDEX.md already exists but has wrong column order or missing Description column → rewrite with correct format; preserve existing Description values from old rows (map by filename) rather than regenerating from scratch
-
-**Step 6: Backfill recapped: on existing session logs**
-- If 07-logs/ doesn't exist → skip
-- Glob 07-logs/**/*-session-*.md
-- For each: read date: frontmatter → set recapped: YYYY-MM-DD using that same date
-- Fallback: if date: missing, parse YYYY-MM-DD prefix from filename
-- **Note:** This marks all pre-migration logs as recapped so /recap does not reprocess them. Historical patterns were already in MEMORY.md Key Learnings (now migrated to memory/ in Step 1). If the user wishes to retroactively promote insights from a specific old log, they can clear its `recapped:` field before running /recap.
-
-**Step 7: Register OneBrain hooks in `[vault]/.claude/settings.json`**
-
-Runs every /update — idempotent. Ensures all 3 hooks point to the correct script.
-
-- Read `[vault]/.claude/settings.json` (vault-level file, not `~/.claude/settings.json`)
-- For each hook below: check if the entry exists under that event key AND its command contains `checkpoint-hook.sh` with the correct mode. Add or replace if absent or wrong. Leave all other hook entries (PreToolUse, PostToolUse, etc.) untouched.
-
-  | Event | Command |
-  |-------|---------|
-  | `Stop` | `bash ".claude/plugins/onebrain/hooks/checkpoint-hook.sh" stop` |
-  | `PreCompact` | `bash ".claude/plugins/onebrain/hooks/checkpoint-hook.sh" precompact` |
-  | `PostCompact` | `bash ".claude/plugins/onebrain/hooks/checkpoint-hook.sh" postcompact` |
-
-  Use the same JSON structure as the existing Stop entry in the file.
-
-**Hook registration algorithm (additive):** For each event key in the table above:
-1. Read the existing array under that key (treat missing or null as empty array)
-2. Scan for an entry whose `command` contains `checkpoint-hook.sh` (the command is nested: `entry.hooks[N].command`)
-3. If found: replace just that entry with the correct command; leave all other entries in the array untouched
-4. If not found: append the new entry to the array
-Never replace the entire array — user-added hooks in the same event key must be preserved.
-
-**PostToolUse qmd hook (only when `qmd_collection` is set in vault.yml):**
-- If `qmd_collection` is absent in vault.yml: skip
-- If `qmd_collection` is present: read `[vault]/.claude/plugins/onebrain/hooks/hooks.json`
-  - If missing or `PostToolUse` entry does not contain `qmd-reindex.sh`: the file was already synced in Step 4b — re-verify the sync completed successfully and flag the issue
-  - If correct: ✅ PostToolUse qmd hook registered
-
-**Step 8: Verify migration**
-- Run /doctor (newly-synced version) automatically
-- Expected: 0 orphans, 0 dead links, 0 non-compliant names, MEMORY-INDEX.md present
-- If any check fails: surface to user with suggestion to run /doctor --fix
-
-**Step 9: Initialize vault.yml stats + recap block**
-- Add stats: block: set last_doctor_run to today; leave last_memory_review and last_recap absent (written on first use)
-- Add recap: block: min_sessions: 6, min_frequency: 2
-- Skip if vault.yml doesn't exist or user opted out via --skip-stats
 
 ## --dry-run Mode
 
@@ -257,9 +121,9 @@ Dry run complete — {N} files would be created, {M} modified, {P} deleted.
 
 ## Failure Recovery
 
-- Version stays old until plugin.json bump (step 4g) — re-running /update retries from start
+- Version stays old until plugin.json bump (step 3d) — re-running /update retries from start
 - Already-synced files are idempotent (compare content before overwriting)
-- If vault in unrecoverable state: restore from backup in 06-archive/, then re-run /update
+- If vault in unrecoverable state: restore from backup in `[archive_folder]/`, then re-run /update
 
 ---
 
@@ -267,6 +131,14 @@ Dry run complete — {N} files would be created, {M} modified, {P} deleted.
 
 - **Do not use git commands for the version check.** `git fetch` and `git pull` hang on Windows while waiting for credentials. Always use `WebFetch` on the raw GitHub URL to compare versions and fetch files.
 
-- **plugin.json bump is the last step.** If /update is interrupted before Step 4g, the version stays at the old number — re-running /update will retry the full migration. Do not bump plugin.json early as a progress marker.
+- **plugin.json bump is the last step.** If /update is interrupted before step 3d, the version stays at the old number — re-running /update will retry the full migration. Do not bump plugin.json early as a progress marker.
 
 - **MEMORY.md Key Learnings migration (Step 1) must run before Step 4.** Step 4 restructures MEMORY.md; Step 1 reads and extracts from it. Running them in the wrong order loses the Key Learnings content before it can be promoted to memory/ files.
+
+- **Plugin folder sync deletes stale files.** Step 3b removes files in the vault's plugin folder that no longer exist in the source repo. This is intentional — the source repo is the single source of truth. Do not place user customizations inside `.claude/plugins/onebrain/`; they belong at the project or user settings level.
+
+- **Root files (README, CONTRIBUTING, CHANGELOG) live at the repo root, not the plugin folder.** `vault-sync.sh` handles both the plugin folder and root file sync. Never copy CHANGELOG.md into the plugin folder.
+
+- **Update scripts must be bootstrapped before they can be called.** Bootstrap step 1 copies `skills/update/` to the vault before running any other step. Do not call vault scripts before step 1 completes.
+
+- **Failure recovery path:** If interrupted before step 3d (plugin.json bump), re-running /update will retry from step 1. The early bootstrap (copy skills/update/) is idempotent — safe to repeat.

--- a/.claude/plugins/onebrain/skills/update/SKILL.md
+++ b/.claude/plugins/onebrain/skills/update/SKILL.md
@@ -51,23 +51,29 @@ GitHub raw URL template: `https://raw.githubusercontent.com/kengio/onebrain/{bra
 where `{branch}` is the branch mapped from `update_channel` in step 2 of Version Check.
 
 Steps:
-1. **Early bootstrap — download and write the update skill itself first:**
-   Use WebFetch + Write to download these two files from GitHub raw URLs and write to vault:
-   - `skills/update/SKILL.md` → `[vault]/.claude/plugins/onebrain/skills/update/SKILL.md`
-   - `skills/update/scripts/vault-sync.sh` → `[vault]/.claude/plugins/onebrain/skills/update/scripts/vault-sync.sh`
+1. **Early bootstrap — download all update scripts first:**
+   Use WebFetch + Write to download these files from GitHub raw URLs and write to vault. `{vault_root}` = the vault's absolute path (the current working directory — the directory containing `.claude/`).
 
-   Then make the script executable: `bash -c 'chmod +x ".claude/plugins/onebrain/skills/update/scripts/vault-sync.sh"'`
+   Raw URL: `https://raw.githubusercontent.com/kengio/onebrain/{branch}/.claude/plugins/onebrain/{path}`
 
-   This ensures the latest SKILL.md and vault-sync.sh are in the vault before anything else runs.
+   Download and write all five files:
+   - `skills/update/SKILL.md`
+   - `skills/update/scripts/vault-sync.sh`
+   - `skills/update/scripts/register-hooks.sh`
+   - `skills/update/scripts/backfill-recapped.sh`
+   - `skills/update/scripts/clean-plugin-cache.sh`
+
+   All paths relative to `[vault]/.claude/plugins/onebrain/`. This ensures every script used in subsequent steps is present before anything runs.
+
 2. Read the newly-written `[vault]/.claude/plugins/onebrain/skills/update/SKILL.md` into agent context. Follow THESE instructions (not the pre-update copy) for all remaining steps.
 3. Execute migration in this order:
    a. Pre-migration backup: copy `[agent_folder]/MEMORY.md` → `[archive_folder]/05-agent/MEMORY-YYYY-MM-DD.md`
       and `[agent_folder]/context/` → `[archive_folder]/05-agent/context.YYYY-MM-DD/` (if context/ exists)
-   b. Sync remaining files — run these three sub-steps in parallel (all are independent):
-      - **Full vault sync:** run `bash ".claude/plugins/onebrain/skills/update/scripts/vault-sync.sh" "{vault_root}" "{branch}"`. Downloads the full GitHub tarball, syncs plugin folder (with stale file cleanup), and copies README.md, CONTRIBUTING.md, CHANGELOG.md to vault root.
+   b. Sync remaining files — run these two sub-steps in parallel, then clean cache after both complete:
+      - **Full vault sync:** run `bash ".claude/plugins/onebrain/skills/update/scripts/vault-sync.sh" "$PWD" "{branch}"`. `$PWD` resolves to the vault root at runtime. Downloads the full GitHub tarball, syncs plugin folder (with stale file cleanup), and copies README.md, CONTRIBUTING.md, CHANGELOG.md to vault root.
       - **Settings merge:** WebFetch `https://raw.githubusercontent.com/kengio/onebrain/{branch}/.claude/settings.json`, then merge into `[vault]/.claude/settings.json`. Merge strategy (never overwrite, always additive): `permissions.allow` → union; `enabledPlugins` → merge keys; `extraKnownMarketplaces` → merge keys; `hooks` → skip (handled by migration Step 7).
-      - **Plugin cache cleanup:** run `bash ".claude/plugins/onebrain/skills/update/scripts/clean-plugin-cache.sh"`. Removes stale onebrain cache versions; no-op for local directory installs.
-   c. Load `[vault]/.claude/plugins/onebrain/skills/update/references/migration-steps.md` and run all 9 migration steps (all scripts are now in the vault)
+      - After both complete: run `bash ".claude/plugins/onebrain/skills/update/scripts/clean-plugin-cache.sh"`. Removes stale onebrain cache versions; no-op for local directory installs.
+   c. Once all step 3b sub-steps are complete, load `[vault]/.claude/plugins/onebrain/skills/update/references/migration-steps.md` and run all 9 migration steps
    d. Bump `plugin.json` version to `{new}` (last — completion signal; do not bump early)
 4. Write migration log to `[logs_folder]/YYYY/MM/YYYY-MM-DD-update-vX.X.X.md`:
 
@@ -130,7 +136,7 @@ Dry run complete — {N} files would be created, {M} modified, {P} deleted.
 ## Failure Recovery
 
 - Version stays old until plugin.json bump (step 3d) — re-running /update retries from start
-- Already-synced files are idempotent (compare content before overwriting)
+- Re-running /update from the start is safe — vault-sync.sh uses rsync which skips unchanged files
 - If vault in unrecoverable state: restore from backup in `[archive_folder]/`, then re-run /update
 
 ---

--- a/.claude/plugins/onebrain/skills/update/SKILL.md
+++ b/.claude/plugins/onebrain/skills/update/SKILL.md
@@ -70,7 +70,7 @@ Steps:
    a. Pre-migration backup: copy `[agent_folder]/MEMORY.md` → `[archive_folder]/05-agent/MEMORY-YYYY-MM-DD.md`
       and `[agent_folder]/context/` → `[archive_folder]/05-agent/context.YYYY-MM-DD/` (if context/ exists)
    b. Sync remaining files — run these two sub-steps in parallel, then clean cache after both complete:
-      - **Full vault sync:** run `bash ".claude/plugins/onebrain/skills/update/scripts/vault-sync.sh" "$PWD" "{branch}"`. `$PWD` resolves to the vault root at runtime. Downloads the full GitHub tarball, syncs plugin folder (with stale file cleanup), copies README.md/CONTRIBUTING.md/CHANGELOG.md to vault root (overwrite), and merges CLAUDE.md/GEMINI.md/AGENTS.md (preserving user `@` imports).
+      - **Full vault sync:** run `bash ".claude/plugins/onebrain/skills/update/scripts/vault-sync.sh" "$PWD" "{branch}"`. `$PWD` resolves to the vault root at runtime. Downloads the full GitHub tarball, syncs plugin folder (with stale file cleanup), copies README.md/CONTRIBUTING.md/CHANGELOG.md to vault root (overwrite), and merges CLAUDE.md/GEMINI.md/AGENTS.md (vault is primary; injects new repo `@` imports only).
       - **Settings merge:** WebFetch `https://raw.githubusercontent.com/kengio/onebrain/{branch}/.claude/settings.json`, then merge into `[vault]/.claude/settings.json`. Merge strategy (never overwrite, always additive): `permissions.allow` → union; `enabledPlugins` → merge keys; `extraKnownMarketplaces` → merge keys; `hooks` → skip (handled by migration Step 7).
       - After both complete: run `bash ".claude/plugins/onebrain/skills/update/scripts/clean-plugin-cache.sh"`. Removes stale onebrain cache versions; no-op for local directory installs.
    c. Once all step 3b sub-steps are complete, load `[vault]/.claude/plugins/onebrain/skills/update/references/migration-steps.md` and run all 9 migration steps
@@ -136,7 +136,7 @@ Dry run complete — {N} files would be created, {M} modified, {P} deleted.
 ## Failure Recovery
 
 - Version stays old until plugin.json bump (step 3d) — re-running /update retries from start
-- Re-running /update from the start is safe — vault-sync.sh uses rsync which skips unchanged files
+- Re-running /update from the start is safe — vault-sync.sh downloads fresh and overwrites (idempotent)
 - If vault in unrecoverable state: restore from backup in `[archive_folder]/`, then re-run /update
 
 ---
@@ -150,6 +150,8 @@ Dry run complete — {N} files would be created, {M} modified, {P} deleted.
 - **MEMORY.md Key Learnings migration (migration Step 1) must run before migration Step 4.** Migration Step 4 restructures MEMORY.md; migration Step 1 reads and extracts from it. Running them in the wrong order loses the Key Learnings content before it can be promoted to memory/ files.
 
 - **Plugin folder sync deletes stale files.** Step 3b removes files in the vault's plugin folder that no longer exist in the source repo. This is intentional — the source repo is the single source of truth. Do not place user customizations inside `.claude/plugins/onebrain/`; they belong at the project or user settings level.
+
+- **Harness file merge is vault-primary.** If a user removed a plugin `@` import from CLAUDE.md/GEMINI.md/AGENTS.md (e.g., `@.claude/plugins/onebrain/INSTRUCTIONS.md`), `/update` will re-inject it on the next run because the script cannot distinguish intentional deletion from never having had it. If a specific import should stay absent, re-remove it after updating.
 
 - **Root files live at the repo root, not the plugin folder.** `vault-sync.sh` handles all six root-level files: README.md, CONTRIBUTING.md, CHANGELOG.md (simple overwrite) and CLAUDE.md, GEMINI.md, AGENTS.md (merge — preserves user `@` imports). Never copy any of these into the plugin folder.
 

--- a/.claude/plugins/onebrain/skills/update/SKILL.md
+++ b/.claude/plugins/onebrain/skills/update/SKILL.md
@@ -56,9 +56,10 @@ Steps:
 3. Execute migration in this order:
    a. Pre-migration backup: copy `[agent_folder]/MEMORY.md` → `[archive_folder]/05-agent/MEMORY-YYYY-MM-DD.md`
       and `[agent_folder]/context/` → `[archive_folder]/05-agent/context.YYYY-MM-DD/` (if context/ exists)
-   b. Sync remaining files — run these two sub-steps in parallel:
-      - **Plugin folder + root file sync:** run `bash ".claude/plugins/onebrain/skills/update/scripts/vault-sync.sh" "{source_repo}" "{vault_root}"`. Now safe to call from the vault (scripts were synced in step 1). Syncs the full plugin folder (with stale file cleanup) and copies README.md, CONTRIBUTING.md, CHANGELOG.md to the vault root.
+   b. Sync remaining files — run these three sub-steps in parallel (all are independent):
+      - **Plugin folder + root file sync:** run `bash ".claude/plugins/onebrain/skills/update/scripts/vault-sync.sh" "{source_repo}" "{vault_root}"`. Syncs the full plugin folder (with stale file cleanup) and copies README.md, CONTRIBUTING.md, CHANGELOG.md to the vault root.
       - **Settings merge:** merge `[vault]/.claude/settings.json` from `{source_repo}/.claude/settings.json`. Merge strategy (never overwrite, always additive): `permissions.allow` → union; `enabledPlugins` → merge keys; `extraKnownMarketplaces` → merge keys; `hooks` → skip (handled by migration Step 7).
+      - **Plugin cache cleanup:** run `bash ".claude/plugins/onebrain/skills/update/scripts/clean-plugin-cache.sh"`. Removes old cached versions of all installed plugins, keeping only the active version per plugin. Conservative: skips plugins not present in `~/.claude/plugins/installed_plugins.json`.
    c. Load `[vault]/.claude/plugins/onebrain/skills/update/references/migration-steps.md` and run all 9 migration steps (all scripts are now in the vault)
    d. Bump `plugin.json` version to `{new}` (last — completion signal; do not bump early)
 4. Write migration log to `[logs_folder]/YYYY/MM/YYYY-MM-DD-update-vX.X.X.md`:

--- a/.claude/plugins/onebrain/skills/update/SKILL.md
+++ b/.claude/plugins/onebrain/skills/update/SKILL.md
@@ -44,22 +44,29 @@ Minor/patch bumps (1.10.0 → 1.10.1, 1.10.0 → 1.11.0): proceed without major 
 
 ## Self-Update Bootstrap (Read-New, Execute-In-Place)
 
-Skills are markdown instructions — the agent can read the new SKILL.md from the repo and
+Skills are markdown instructions — the agent can read the new SKILL.md from GitHub and
 follow it as instructions in the same conversation. No re-invoke needed.
 
-**Source repo path:** Resolve from `onebrain-development` memory file or ask user if unavailable. Typically `~/projects/onebrain`.
+GitHub raw URL template: `https://raw.githubusercontent.com/kengio/onebrain/{branch}/.claude/plugins/onebrain/{path}`
+where `{branch}` is the branch mapped from `update_channel` in step 2 of Version Check.
 
 Steps:
-1. **Early bootstrap — sync the update skill itself first:**
-   Copy `{source_repo}/.claude/plugins/onebrain/skills/update/` → `[vault]/.claude/plugins/onebrain/skills/update/` (overwrite all files including scripts/). This ensures the latest SKILL.md and predefined scripts are physically in the vault before anything else runs — regardless of which version the vault was previously running.
+1. **Early bootstrap — download and write the update skill itself first:**
+   Use WebFetch + Write to download these two files from GitHub raw URLs and write to vault:
+   - `skills/update/SKILL.md` → `[vault]/.claude/plugins/onebrain/skills/update/SKILL.md`
+   - `skills/update/scripts/vault-sync.sh` → `[vault]/.claude/plugins/onebrain/skills/update/scripts/vault-sync.sh`
+
+   Then make the script executable: `bash -c 'chmod +x ".claude/plugins/onebrain/skills/update/scripts/vault-sync.sh"'`
+
+   This ensures the latest SKILL.md and vault-sync.sh are in the vault before anything else runs.
 2. Read the newly-written `[vault]/.claude/plugins/onebrain/skills/update/SKILL.md` into agent context. Follow THESE instructions (not the pre-update copy) for all remaining steps.
 3. Execute migration in this order:
    a. Pre-migration backup: copy `[agent_folder]/MEMORY.md` → `[archive_folder]/05-agent/MEMORY-YYYY-MM-DD.md`
       and `[agent_folder]/context/` → `[archive_folder]/05-agent/context.YYYY-MM-DD/` (if context/ exists)
    b. Sync remaining files — run these three sub-steps in parallel (all are independent):
-      - **Plugin folder + root file sync:** run `bash ".claude/plugins/onebrain/skills/update/scripts/vault-sync.sh" "{source_repo}" "{vault_root}"`. Syncs the full plugin folder (with stale file cleanup) and copies README.md, CONTRIBUTING.md, CHANGELOG.md to the vault root.
-      - **Settings merge:** merge `[vault]/.claude/settings.json` from `{source_repo}/.claude/settings.json`. Merge strategy (never overwrite, always additive): `permissions.allow` → union; `enabledPlugins` → merge keys; `extraKnownMarketplaces` → merge keys; `hooks` → skip (handled by migration Step 7).
-      - **Plugin cache cleanup:** run `bash ".claude/plugins/onebrain/skills/update/scripts/clean-plugin-cache.sh"`. Removes old cached versions of all installed plugins, keeping only the active version per plugin. Conservative: skips plugins not present in `~/.claude/plugins/installed_plugins.json`.
+      - **Full vault sync:** run `bash ".claude/plugins/onebrain/skills/update/scripts/vault-sync.sh" "{vault_root}" "{branch}"`. Downloads the full GitHub tarball, syncs plugin folder (with stale file cleanup), and copies README.md, CONTRIBUTING.md, CHANGELOG.md to vault root.
+      - **Settings merge:** WebFetch `https://raw.githubusercontent.com/kengio/onebrain/{branch}/.claude/settings.json`, then merge into `[vault]/.claude/settings.json`. Merge strategy (never overwrite, always additive): `permissions.allow` → union; `enabledPlugins` → merge keys; `extraKnownMarketplaces` → merge keys; `hooks` → skip (handled by migration Step 7).
+      - **Plugin cache cleanup:** run `bash ".claude/plugins/onebrain/skills/update/scripts/clean-plugin-cache.sh"`. Removes stale onebrain cache versions; no-op for local directory installs.
    c. Load `[vault]/.claude/plugins/onebrain/skills/update/references/migration-steps.md` and run all 9 migration steps (all scripts are now in the vault)
    d. Bump `plugin.json` version to `{new}` (last — completion signal; do not bump early)
 4. Write migration log to `[logs_folder]/YYYY/MM/YYYY-MM-DD-update-vX.X.X.md`:
@@ -140,6 +147,6 @@ Dry run complete — {N} files would be created, {M} modified, {P} deleted.
 
 - **Root files (README, CONTRIBUTING, CHANGELOG) live at the repo root, not the plugin folder.** `vault-sync.sh` handles both the plugin folder and root file sync. Never copy CHANGELOG.md into the plugin folder.
 
-- **Update scripts must be bootstrapped before they can be called.** Bootstrap step 1 copies `skills/update/` to the vault before running any other step. Do not call vault scripts before step 1 completes.
+- **Update scripts must be bootstrapped before they can be called.** Bootstrap step 1 downloads `SKILL.md` and `vault-sync.sh` from GitHub before running any other step. Do not call vault scripts before step 1 completes.
 
 - **Failure recovery path:** If interrupted before step 3d (plugin.json bump), re-running /update will retry from step 1. The early bootstrap (copy skills/update/) is idempotent — safe to repeat.

--- a/.claude/plugins/onebrain/skills/update/references/migration-steps.md
+++ b/.claude/plugins/onebrain/skills/update/references/migration-steps.md
@@ -17,7 +17,7 @@ Each step lists a **Skip condition** — check it first before doing any file re
 - Delete context/ folder after all files migrated
 
 **Step 3: Update existing memory/ files**
-- **Skip if:** all files in memory/ already have all required frontmatter fields (topics, type, conf, verified, updated) and filenames are already kebab-case 3–5 words with no date/numeric prefix — check a batch of 5 files to fast-exit
+- **Skip if:** sample the first 5 files alphabetically in memory/ — if all 5 have all required frontmatter fields (topics, type, conf, verified, updated) and kebab-case 3–5 word filenames with no date/numeric prefix, skip the step. If any of the 5 fail, process all files.
 - Add missing frontmatter fields: topics, type, conf, verified, updated
 - Rename non-compliant files → kebab-case 3–5 words. A file is non-compliant if it has:
   - A date prefix (e.g. `2026-04-05-bump-version-every-pr.md` → `bump-version-pr.md`)
@@ -106,7 +106,7 @@ Runs every /update — idempotent. Ensures all 3 hooks point to the correct scri
 **PostToolUse qmd hook (only when `qmd_collection` is set in vault.yml):**
 - If `qmd_collection` is absent in vault.yml: skip
 - If `qmd_collection` is present: read `[vault]/.claude/plugins/onebrain/hooks/hooks.json`
-  - If missing or `PostToolUse` entry does not contain `qmd-reindex.sh`: the file was already synced in step 3b — re-verify the sync completed successfully and flag the issue
+  - If missing or `PostToolUse` entry does not contain `qmd-reindex.sh`: the file was already synced in bootstrap step 3b (vault-sync.sh) — re-verify the sync completed successfully and flag the issue
   - If correct: ✅ PostToolUse qmd hook registered
 
 **Step 8: Verify migration**

--- a/.claude/plugins/onebrain/skills/update/references/migration-steps.md
+++ b/.claude/plugins/onebrain/skills/update/references/migration-steps.md
@@ -1,0 +1,121 @@
+# Vault Migration Steps
+
+Run these steps IN ORDER. Halt on first failure — do not continue.
+Each step lists a **Skip condition** — check it first before doing any file reads.
+
+**Step 1: Migrate MEMORY.md Key Learnings → memory/** (MUST run before Step 4)
+- **Skip if:** MEMORY.md contains neither `## Key Learnings` nor `## Key Decisions` section
+- Read `## Key Learnings` and `## Key Decisions` from MEMORY.md
+- Tool behaviors (bash tricks, RTK, draw.io, cron patterns) → delete, do not migrate
+- Genuine behavioral patterns → write to memory/ (type: behavioral, source: /update, conf: medium, created: today, verified: today, updated: today)
+- Key Decisions → write to memory/ (type: project, source: /update)
+
+**Step 2: Migrate context/ → memory/**
+- **Skip if:** `[agent_folder]/context/` folder does not exist
+- For each file in `[agent_folder]/context/`: rename to kebab-case, move to memory/
+- Add frontmatter: type: context, source: /update, conf: medium, created: (preserve if exists else today), verified: today, updated: today, topics: [2–4 keywords from content]
+- Delete context/ folder after all files migrated
+
+**Step 3: Update existing memory/ files**
+- **Skip if:** all files in memory/ already have all required frontmatter fields (topics, type, conf, verified, updated) and filenames are already kebab-case 3–5 words with no date/numeric prefix — check a batch of 5 files to fast-exit
+- Add missing frontmatter fields: topics, type, conf, verified, updated
+- Rename non-compliant files → kebab-case 3–5 words. A file is non-compliant if it has:
+  - A date prefix (e.g. `2026-04-05-bump-version-every-pr.md` → `bump-version-pr.md`)
+  - A numeric segment prefix (e.g. `2026-04-05-02-superpowers-docs-in-vault.md` → `superpowers-docs-vault.md`)
+  - Title-Case or spaces in the filename
+  - More than 5 words (strip stop words; keep the meaningful 3–5)
+- After renaming: update all `[[wikilinks]]` in `[agent_folder]/MEMORY-INDEX.md` and any `supersedes:`/`superseded_by:` references to use the new filename
+- Compliant example: `bump-version-pr.md`, `dev-workflow-worktree.md`, `telegram-format.md`
+
+**Step 4: Restructure MEMORY.md** (MUST run after Step 1)
+- **Skip if:** MEMORY.md already uses compact Identity labels (`**Agent:**`, `**User:**`, `**Tone:**`) — only update the `updated:` frontmatter field in this case
+- If the old 6-field labels are present (`**Agent name:**`, `**User name:**`, etc.), rewrite even if the 3 section headings already exist. Always update `updated:` frontmatter.
+
+Target structure — exactly 3 sections:
+
+```markdown
+## Identity & Personality
+
+**Agent:** [name] · [gender/pronoun rules if set]
+**Personality:** [personality description]
+**User:** [user_name] · [role]
+**Tone:** [tone] · [detail_level]
+**Language:** [language rules — omit this line if no language rules are set]
+
+You are [agent_name], [user_name]'s personal chief of staff inside their Obsidian vault.
+
+- Priority goal: [primary goal]
+- Proactive: surface connections, flag stale items, suggest next steps
+- Ground responses in vault — reference actual notes when relevant
+- [AskUserQuestion or tool-use preferences, if set]
+
+## Active Projects
+
+<!-- Updated by /consolidate and /braindump -->
+- **[Project]** — [status emoji + label]. [description].
+
+## Critical Behaviors
+
+- [behavioral item]
+<!-- Add behavioral preferences here via /learn -->
+```
+
+Old-section mapping (apply when migrating from pre-v1.10.0 structure):
+- `## Agent Identity` + `## Identity` + `## Communication Style` + `## Goals & Focus Areas` + `## Values & Working Principles` + `## AI Personality Instructions` → consolidate into `## Identity & Personality`
+- `## Active Projects` → keep as-is
+- `## Critical Behaviors` → preserve if present; if absent, create with items from `## Values & Working Principles` plus an empty comment; remove any auto-wrapup trigger entry if present (auto-wrapup is now handled by AUTO-SUMMARY.md)
+- Remove entirely: `## Key Learnings`, `## Key Decisions`, `## Recurring Contexts`
+
+Field extraction hints (for old-section consolidation):
+- **Agent:** → name from `## Agent Identity` or `## Identity`; gender/pronoun rules from `## AI Personality Instructions` if present; omit gender/pronoun suffix if absent
+- **Personality:** → archetype + description from `## AI Personality Instructions` or `## Communication Style`
+- **User:** → name from `## Agent Identity`; role from `## Agent Identity` or `## Goals & Focus Areas`
+- **Tone:** → tone + detail_level from `## Communication Style`
+- **Language:** → language rules from `## Communication Style` or `## Agent Identity` if present; omit line entirely if absent
+- Priority goal bullet → first entry from `## Goals & Focus Areas`
+- `## Values & Working Principles` items → `## Critical Behaviors` (only if Critical Behaviors was absent)
+
+Always: update `updated:` frontmatter to today.
+
+**Step 5: Create `[agent_folder]/MEMORY-INDEX.md`**
+- **Skip if:** MEMORY-INDEX.md exists, has correct column format (`| File | Topics | Type | Status | Description |`), and `total_active` count matches the actual number of `status: active` files in memory/
+- Read frontmatter of all files in `[agent_folder]/memory/` (batch 20 at a time if >50 files)
+- Include only status: active and status: needs-review in table
+- Column format (exact order): `| File | Topics | Type | Status | Description |`
+  - **File**: wikilink `[[filename-without-extension]]`
+  - **Topics**: comma-separated topics from frontmatter
+  - **Type**: from frontmatter (behavioral / project / context)
+  - **Status**: from frontmatter (active / needs-review)
+  - **Description**: 1-line summary derived from file content (not from frontmatter)
+- For each file with supersedes: X, set superseded_by: [this file] on X's frontmatter
+- Set cache fields: total_active, total_needs_review (omit last_review)
+- If MEMORY-INDEX.md already exists but has wrong column order or missing Description column → rewrite with correct format; preserve existing Description values from old rows (map by filename) rather than regenerating from scratch
+
+**Step 6: Backfill recapped: on existing session logs**
+- **Skip if:** `[logs_folder]/` does not exist
+- Run `bash ".claude/plugins/onebrain/skills/update/scripts/backfill-recapped.sh" "[logs_folder]"` — adds `recapped: YYYY-MM-DD` to session logs that don't have it; idempotent
+- **Note:** This marks all pre-migration logs as recapped so /recap does not reprocess them. Historical patterns were already in MEMORY.md Key Learnings (now migrated to memory/ in Step 1). If the user wishes to retroactively promote insights from a specific old log, they can clear its `recapped:` field before running /recap.
+
+**Step 7: Register OneBrain hooks in `[vault]/.claude/settings.json`**
+
+Runs every /update — idempotent. Ensures all 3 hooks point to the correct script.
+
+- Run `bash ".claude/plugins/onebrain/skills/update/scripts/register-hooks.sh" ".claude/settings.json"` — registers Stop, PreCompact, PostCompact hooks; never removes user-added hooks in the same event key
+- Check output: "all hooks already registered" → ✅ done; "added X" → ✅ registered
+
+**PostToolUse qmd hook (only when `qmd_collection` is set in vault.yml):**
+- If `qmd_collection` is absent in vault.yml: skip
+- If `qmd_collection` is present: read `[vault]/.claude/plugins/onebrain/hooks/hooks.json`
+  - If missing or `PostToolUse` entry does not contain `qmd-reindex.sh`: the file was already synced in step 3b — re-verify the sync completed successfully and flag the issue
+  - If correct: ✅ PostToolUse qmd hook registered
+
+**Step 8: Verify migration**
+- Run /doctor (newly-synced version) automatically
+- Expected: 0 orphans, 0 dead links, 0 non-compliant names, MEMORY-INDEX.md present
+- If any check fails: surface to user with suggestion to run /doctor --fix
+
+**Step 9: Initialize vault.yml stats + recap block**
+- **Skip if:** vault.yml already has both `stats:` and `recap:` blocks
+- Add stats: block: set last_doctor_run to today; leave last_memory_review and last_recap absent (written on first use)
+- Add recap: block: min_sessions: 6, min_frequency: 2
+- Skip if vault.yml doesn't exist or user opted out via --skip-stats

--- a/.claude/plugins/onebrain/skills/update/scripts/backfill-recapped.sh
+++ b/.claude/plugins/onebrain/skills/update/scripts/backfill-recapped.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# backfill-recapped.sh <logs_folder>
+# Adds recapped: <date> to session logs that don't have it.
+# Used once during migration — idempotent (skips files already having recapped:).
+
+set -euo pipefail
+
+LOGS="${1:?Usage: backfill-recapped.sh <logs_folder>}"
+
+if [ ! -d "$LOGS" ]; then
+  echo "backfill-recapped: no logs folder, skipping"
+  exit 0
+fi
+
+count=0
+while IFS= read -r -d '' file; do
+    grep -q "^recapped:" "$file" 2>/dev/null && continue
+
+    date_val=$(grep "^date:" "$file" 2>/dev/null | head -1 | sed 's/date:[[:space:]]*//')
+    [ -z "$date_val" ] && date_val=$(basename "$file" | grep -oE '^[0-9]{4}-[0-9]{2}-[0-9]{2}' || true)
+    [ -z "$date_val" ] && continue
+
+    # Insert recapped: after the date: line
+    if grep -q "^date:" "$file"; then
+        sed -i '' "/^date:/a\\
+recapped: ${date_val}" "$file"
+        count=$((count + 1))
+    fi
+done < <(find "$LOGS" -name "*-session-*.md" -print0 2>/dev/null)
+
+echo "backfill-recapped: ${count} files updated"

--- a/.claude/plugins/onebrain/skills/update/scripts/backfill-recapped.sh
+++ b/.claude/plugins/onebrain/skills/update/scripts/backfill-recapped.sh
@@ -20,10 +20,11 @@ while IFS= read -r -d '' file; do
     [ -z "$date_val" ] && date_val=$(basename "$file" | grep -oE '^[0-9]{4}-[0-9]{2}-[0-9]{2}' || true)
     [ -z "$date_val" ] && continue
 
-    # Insert recapped: after the date: line
+    # Insert recapped: after the date: line (portable: avoid sed -i '' macOS-only syntax)
     if grep -q "^date:" "$file"; then
-        sed -i '' "/^date:/a\\
-recapped: ${date_val}" "$file"
+        tmp=$(mktemp)
+        sed "/^date:/a\\
+recapped: ${date_val}" "$file" > "$tmp" && mv "$tmp" "$file"
         count=$((count + 1))
     fi
 done < <(find "$LOGS" -name "*-session-*.md" -print0 2>/dev/null)

--- a/.claude/plugins/onebrain/skills/update/scripts/backfill-recapped.sh
+++ b/.claude/plugins/onebrain/skills/update/scripts/backfill-recapped.sh
@@ -5,9 +5,9 @@
 
 set -euo pipefail
 
-LOGS="${1:?Usage: backfill-recapped.sh <logs_folder>}"
+logs="${1:?Usage: backfill-recapped.sh <logs_folder>}"
 
-if [ ! -d "$LOGS" ]; then
+if [ ! -d "$logs" ]; then
   echo "backfill-recapped: no logs folder, skipping"
   exit 0
 fi
@@ -27,6 +27,6 @@ while IFS= read -r -d '' file; do
 recapped: ${date_val}" "$file" > "$tmp" && mv "$tmp" "$file"
         count=$((count + 1))
     fi
-done < <(find "$LOGS" -name "*-session-*.md" -print0 2>/dev/null)
+done < <(find "$logs" -name "*-session-*.md" -print0 2>/dev/null)
 
 echo "backfill-recapped: ${count} files updated"

--- a/.claude/plugins/onebrain/skills/update/scripts/clean-plugin-cache.sh
+++ b/.claude/plugins/onebrain/skills/update/scripts/clean-plugin-cache.sh
@@ -11,7 +11,12 @@ CACHE_DIR="${HOME}/.claude/plugins/cache"
 
 [ -f "$INSTALLED" ] || { echo "clean-plugin-cache: installed_plugins.json not found, skipping"; exit 0; }
 
-python3 - "$CACHE_DIR" "$INSTALLED" <<'PYEOF'
+PYTHON=$(command -v python3 2>/dev/null || command -v python 2>/dev/null) || {
+  echo "clean-plugin-cache: Python not found, skipping"
+  exit 0
+}
+
+"$PYTHON" - "$CACHE_DIR" "$INSTALLED" <<'PYEOF'
 import json, sys, shutil
 from pathlib import Path
 

--- a/.claude/plugins/onebrain/skills/update/scripts/clean-plugin-cache.sh
+++ b/.claude/plugins/onebrain/skills/update/scripts/clean-plugin-cache.sh
@@ -43,7 +43,10 @@ if not active_version:
     exit(0)
 
 # If install path is not inside the Claude cache directory, it's a local install
-if not str(active_plugin_dir).startswith(str(cache_dir)):
+# Use is_relative_to (Python 3.9+) to avoid false positives from startswith on similar dir names
+try:
+    active_plugin_dir.relative_to(cache_dir)
+except ValueError:
     print("clean-plugin-cache: onebrain is a local directory install, no remote cache to clean")
     exit(0)
 

--- a/.claude/plugins/onebrain/skills/update/scripts/clean-plugin-cache.sh
+++ b/.claude/plugins/onebrain/skills/update/scripts/clean-plugin-cache.sh
@@ -43,7 +43,7 @@ if not active_version:
     exit(0)
 
 # If install path is not inside the Claude cache directory, it's a local install
-# Use is_relative_to (Python 3.9+) to avoid false positives from startswith on similar dir names
+# Use relative_to() with try/except (Python 3.6+) to avoid false positives on similarly-named dirs
 try:
     active_plugin_dir.relative_to(cache_dir)
 except ValueError:

--- a/.claude/plugins/onebrain/skills/update/scripts/clean-plugin-cache.sh
+++ b/.claude/plugins/onebrain/skills/update/scripts/clean-plugin-cache.sh
@@ -65,10 +65,13 @@ freed_bytes = 0
 for version_dir in active_plugin_dir.iterdir():
     if version_dir.is_dir() and version_dir.name != active_version:
         size = sum(f.stat().st_size for f in version_dir.rglob("*") if f.is_file())
-        shutil.rmtree(version_dir)
-        freed_bytes += size
-        removed += 1
-        print(f"  removed: onebrain/{version_dir.name}")
+        try:
+            shutil.rmtree(version_dir)
+            freed_bytes += size
+            removed += 1
+            print(f"  removed: onebrain/{version_dir.name}")
+        except PermissionError as e:
+            print(f"  skipped: onebrain/{version_dir.name} (in use: {e})")
 
 freed_mb = freed_bytes / (1024 * 1024)
 if removed:

--- a/.claude/plugins/onebrain/skills/update/scripts/clean-plugin-cache.sh
+++ b/.claude/plugins/onebrain/skills/update/scripts/clean-plugin-cache.sh
@@ -6,17 +6,17 @@
 
 set -euo pipefail
 
-INSTALLED="${HOME}/.claude/plugins/installed_plugins.json"
-CACHE_DIR="${HOME}/.claude/plugins/cache"
+installed="${HOME}/.claude/plugins/installed_plugins.json"
+cache_dir="${HOME}/.claude/plugins/cache"
 
-[ -f "$INSTALLED" ] || { echo "clean-plugin-cache: installed_plugins.json not found, skipping"; exit 0; }
+[ -f "$installed" ] || { echo "clean-plugin-cache: installed_plugins.json not found, skipping"; exit 0; }
 
-PYTHON=$(command -v python3 2>/dev/null || command -v python 2>/dev/null) || {
+python_cmd=$(command -v python3 2>/dev/null || command -v python 2>/dev/null) || {
   echo "clean-plugin-cache: Python not found, skipping"
   exit 0
 }
 
-"$PYTHON" - "$CACHE_DIR" "$INSTALLED" <<'PYEOF'
+"$python_cmd" - "$cache_dir" "$installed" <<'PYEOF'
 import json, sys, shutil
 from pathlib import Path
 

--- a/.claude/plugins/onebrain/skills/update/scripts/clean-plugin-cache.sh
+++ b/.claude/plugins/onebrain/skills/update/scripts/clean-plugin-cache.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# clean-plugin-cache.sh
+# Removes old cached versions of the onebrain plugin, keeping only the active version.
+# No-op when onebrain is installed as a local directory plugin (no remote cache entry).
+# Becomes active if/when onebrain is distributed through a remote marketplace.
+
+set -euo pipefail
+
+INSTALLED="${HOME}/.claude/plugins/installed_plugins.json"
+CACHE_DIR="${HOME}/.claude/plugins/cache"
+
+[ -f "$INSTALLED" ] || { echo "clean-plugin-cache: installed_plugins.json not found, skipping"; exit 0; }
+
+python3 - "$CACHE_DIR" "$INSTALLED" <<'PYEOF'
+import json, sys, shutil
+from pathlib import Path
+
+cache_dir = Path(sys.argv[1])
+installed_path = Path(sys.argv[2])
+
+with open(installed_path) as f:
+    data = json.load(f)
+
+# Find onebrain entry (any marketplace key starting with "onebrain@")
+active_version = None
+active_plugin_dir = None
+
+for plugin_key, entries in data.get("plugins", {}).items():
+    if not plugin_key.startswith("onebrain@"):
+        continue
+    if not isinstance(entries, list):
+        continue
+    for entry in entries:
+        install_path = entry.get("installPath", "")
+        if install_path:
+            p = Path(install_path)
+            active_plugin_dir = p.parent
+            active_version = p.name
+            break
+
+if not active_version:
+    print("clean-plugin-cache: onebrain not in remote cache (local directory install), skipping")
+    exit(0)
+
+# If install path is not inside the Claude cache directory, it's a local install
+if not str(active_plugin_dir).startswith(str(cache_dir)):
+    print("clean-plugin-cache: onebrain is a local directory install, no remote cache to clean")
+    exit(0)
+
+if not active_plugin_dir.is_dir():
+    print("clean-plugin-cache: onebrain cache dir not found, skipping")
+    exit(0)
+
+removed = 0
+freed_bytes = 0
+
+for version_dir in active_plugin_dir.iterdir():
+    if version_dir.is_dir() and version_dir.name != active_version:
+        size = sum(f.stat().st_size for f in version_dir.rglob("*") if f.is_file())
+        shutil.rmtree(version_dir)
+        freed_bytes += size
+        removed += 1
+        print(f"  removed: onebrain/{version_dir.name}")
+
+freed_mb = freed_bytes / (1024 * 1024)
+if removed:
+    print(f"clean-plugin-cache: removed {removed} stale version(s), freed {freed_mb:.1f} MB")
+else:
+    print(f"clean-plugin-cache: onebrain/{active_version} is the only version, nothing to remove")
+PYEOF

--- a/.claude/plugins/onebrain/skills/update/scripts/register-hooks.sh
+++ b/.claude/plugins/onebrain/skills/update/scripts/register-hooks.sh
@@ -6,19 +6,19 @@
 
 set -euo pipefail
 
-SETTINGS="${1:?Usage: register-hooks.sh <vault_settings_json>}"
+settings="${1:?Usage: register-hooks.sh <vault_settings_json>}"
 
-if [ ! -f "$SETTINGS" ]; then
-  echo "ERROR: settings file not found: $SETTINGS" >&2
+if [ ! -f "$settings" ]; then
+  echo "ERROR: settings file not found: $settings" >&2
   exit 1
 fi
 
-PYTHON=$(command -v python3 2>/dev/null || command -v python 2>/dev/null) || {
+python_cmd=$(command -v python3 2>/dev/null || command -v python 2>/dev/null) || {
   echo "ERROR: Python is required but not found." >&2
   exit 1
 }
 
-"$PYTHON" - "$SETTINGS" <<'PYEOF'
+"$python_cmd" - "$settings" <<'PYEOF'
 import json, sys
 
 path = sys.argv[1]

--- a/.claude/plugins/onebrain/skills/update/scripts/register-hooks.sh
+++ b/.claude/plugins/onebrain/skills/update/scripts/register-hooks.sh
@@ -18,7 +18,11 @@ import json, sys
 
 path = sys.argv[1]
 with open(path) as f:
-    cfg = json.load(f)
+    try:
+        cfg = json.load(f)
+    except json.JSONDecodeError as e:
+        print(f"ERROR: {path} is not valid JSON: {e}", file=sys.stderr)
+        sys.exit(1)
 
 hooks_to_register = {
     "Stop":        'bash ".claude/plugins/onebrain/hooks/checkpoint-hook.sh" stop',

--- a/.claude/plugins/onebrain/skills/update/scripts/register-hooks.sh
+++ b/.claude/plugins/onebrain/skills/update/scripts/register-hooks.sh
@@ -13,7 +13,12 @@ if [ ! -f "$SETTINGS" ]; then
   exit 1
 fi
 
-python3 - "$SETTINGS" <<'PYEOF'
+PYTHON=$(command -v python3 2>/dev/null || command -v python 2>/dev/null) || {
+  echo "ERROR: Python is required but not found." >&2
+  exit 1
+}
+
+"$PYTHON" - "$SETTINGS" <<'PYEOF'
 import json, sys
 
 path = sys.argv[1]

--- a/.claude/plugins/onebrain/skills/update/scripts/register-hooks.sh
+++ b/.claude/plugins/onebrain/skills/update/scripts/register-hooks.sh
@@ -2,6 +2,7 @@
 # register-hooks.sh <vault_settings_json>
 # Idempotently registers OneBrain Stop/PreCompact/PostCompact hooks.
 # Safe: never replaces user-added hooks in the same event key.
+# Must be run with CWD = vault root (path argument is relative to vault root).
 
 set -euo pipefail
 

--- a/.claude/plugins/onebrain/skills/update/scripts/register-hooks.sh
+++ b/.claude/plugins/onebrain/skills/update/scripts/register-hooks.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# register-hooks.sh <vault_settings_json>
+# Idempotently registers OneBrain Stop/PreCompact/PostCompact hooks.
+# Safe: never replaces user-added hooks in the same event key.
+
+set -euo pipefail
+
+SETTINGS="${1:?Usage: register-hooks.sh <vault_settings_json>}"
+
+if [ ! -f "$SETTINGS" ]; then
+  echo "ERROR: settings file not found: $SETTINGS" >&2
+  exit 1
+fi
+
+python3 - "$SETTINGS" <<'PYEOF'
+import json, sys
+
+path = sys.argv[1]
+with open(path) as f:
+    cfg = json.load(f)
+
+hooks_to_register = {
+    "Stop":        'bash ".claude/plugins/onebrain/hooks/checkpoint-hook.sh" stop',
+    "PreCompact":  'bash ".claude/plugins/onebrain/hooks/checkpoint-hook.sh" precompact',
+    "PostCompact": 'bash ".claude/plugins/onebrain/hooks/checkpoint-hook.sh" postcompact',
+}
+
+hooks = cfg.setdefault("hooks", {})
+registered = []
+
+for event, cmd in hooks_to_register.items():
+    entries = hooks.setdefault(event, [])
+    found = False
+    for entry in entries:
+        for h in entry.get("hooks", []):
+            if "checkpoint-hook.sh" in h.get("command", ""):
+                if h["command"] != cmd:
+                    h["command"] = cmd
+                found = True
+    if not found:
+        entries.append({"matcher": "", "hooks": [{"type": "command", "command": cmd}]})
+        registered.append(event)
+
+with open(path, "w") as f:
+    json.dump(cfg, f, indent=4)
+
+if registered:
+    print(f"register-hooks: added {', '.join(registered)}")
+else:
+    print("register-hooks: all hooks already registered")
+PYEOF

--- a/.claude/plugins/onebrain/skills/update/scripts/vault-sync.sh
+++ b/.claude/plugins/onebrain/skills/update/scripts/vault-sync.sh
@@ -9,11 +9,18 @@ set -euo pipefail
 VAULT_ROOT="${1:?Usage: vault-sync.sh <vault_root> <branch>}"
 BRANCH="${2:-main}"
 REPO="kengio/onebrain"
+
+command -v rsync >/dev/null 2>&1 || {
+  echo "ERROR: rsync is required but not installed. Install with: apt install rsync / brew install rsync" >&2
+  exit 1
+}
+
 TMP_DIR=$(mktemp -d)
 trap 'rm -rf "$TMP_DIR"' EXIT
 
 echo "vault-sync: downloading from github.com/${REPO}@${BRANCH}..."
-curl -sL "https://github.com/${REPO}/archive/refs/heads/${BRANCH}.tar.gz" \
+# -f: fail on HTTP errors (clear error message instead of cryptic tar failure)
+curl -fsSL "https://github.com/${REPO}/archive/refs/heads/${BRANCH}.tar.gz" \
   | tar -xz -C "$TMP_DIR" --strip-components=1
 
 SOURCE_PLUGIN="${TMP_DIR}/.claude/plugins/onebrain"

--- a/.claude/plugins/onebrain/skills/update/scripts/vault-sync.sh
+++ b/.claude/plugins/onebrain/skills/update/scripts/vault-sync.sh
@@ -11,25 +11,25 @@
 
 set -euo pipefail
 
-VAULT_ROOT="${1:?Usage: vault-sync.sh <vault_root> <branch>}"
-BRANCH="${2:-main}"
-REPO="kengio/onebrain"
+vault_root="${1:?Usage: vault-sync.sh <vault_root> <branch>}"
+branch="${2:-main}"
+repo="kengio/onebrain"
 
-PYTHON=$(command -v python3 2>/dev/null || command -v python 2>/dev/null) || {
+python_cmd=$(command -v python3 2>/dev/null || command -v python 2>/dev/null) || {
   echo "ERROR: Python is required but not found. Install Python 3." >&2
   exit 1
 }
 
-TMP_DIR=$(mktemp -d)
-trap 'rm -rf "$TMP_DIR"' EXIT
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
 
-echo "vault-sync: downloading from github.com/${REPO}@${BRANCH}..."
+echo "vault-sync: downloading from github.com/${repo}@${branch}..."
 # -f: exit non-zero on HTTP errors (clear error vs cryptic tar failure)
-curl -fsSL "https://github.com/${REPO}/archive/refs/heads/${BRANCH}.tar.gz" \
-  | tar -xz -C "$TMP_DIR" --strip-components=1
+curl -fsSL "https://github.com/${repo}/archive/refs/heads/${branch}.tar.gz" \
+  | tar -xz -C "$tmp_dir" --strip-components=1
 
 # All three sync operations are independent — run them in parallel.
-"$PYTHON" - "$TMP_DIR" "$VAULT_ROOT" <<'PYEOF'
+"$python_cmd" - "$tmp_dir" "$vault_root" <<'PYEOF'
 import sys, shutil
 from pathlib import Path
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -61,9 +61,8 @@ def sync_plugin():
             stale.append(rel)
 
     if stale:
-        print("INFO: Removing stale vault files (not in current release):")
-        for f in sorted(stale):
-            print(f"  {f}")
+        print("INFO: Removing stale vault files (not in current release):\n" +
+              "\n".join(f"  {f}" for f in sorted(stale)))
 
     # Copy files in parallel
     def copy_one(item):
@@ -135,7 +134,7 @@ def merge_harness_file(fname):
     vault_lines = vault_text.splitlines()
     vault_at_set = {l.strip() for l in vault_lines if l.startswith("@")}
     new_imports = [
-        line for line in repo_text.splitlines()
+        line.rstrip() for line in repo_text.splitlines()
         if line.startswith("@") and line.strip() not in vault_at_set
     ]
 

--- a/.claude/plugins/onebrain/skills/update/scripts/vault-sync.sh
+++ b/.claude/plugins/onebrain/skills/update/scripts/vault-sync.sh
@@ -1,32 +1,31 @@
 #!/usr/bin/env bash
-# vault-sync.sh <source_repo> <vault_root>
-# Syncs plugin folder from source repo to vault (with stale file cleanup)
-# and copies root docs (README, CONTRIBUTING, CHANGELOG) to vault root.
+# vault-sync.sh <vault_root> <branch>
+# Downloads the latest onebrain plugin files from GitHub and syncs to vault.
+# Syncs the plugin folder (with stale file cleanup) and copies root docs to vault root.
 # Must be run with CWD = vault root (called via vault-relative path after bootstrap step 1).
 
 set -euo pipefail
 
-SOURCE_REPO="${1:?Usage: vault-sync.sh <source_repo> <vault_root>}"
-VAULT_ROOT="${2:?Usage: vault-sync.sh <source_repo> <vault_root>}"
+VAULT_ROOT="${1:?Usage: vault-sync.sh <vault_root> <branch>}"
+BRANCH="${2:-main}"
+REPO="kengio/onebrain"
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
 
-SOURCE_PLUGIN="${SOURCE_REPO}/.claude/plugins/onebrain"
+echo "vault-sync: downloading from github.com/${REPO}@${BRANCH}..."
+curl -sL "https://github.com/${REPO}/archive/refs/heads/${BRANCH}.tar.gz" \
+  | tar -xz -C "$TMP_DIR" --strip-components=1
+
+SOURCE_PLUGIN="${TMP_DIR}/.claude/plugins/onebrain"
 VAULT_PLUGIN="${VAULT_ROOT}/.claude/plugins/onebrain"
 
-if [ ! -d "$SOURCE_PLUGIN" ]; then
-  echo "ERROR: source plugin folder not found: $SOURCE_PLUGIN" >&2
-  exit 1
-fi
-
-mkdir -p "$VAULT_PLUGIN"
-
-# Warn about files that will be deleted (stale files in vault not in source repo).
-# Output is captured by the agent and surfaced in the migration log.
+# Warn about files that will be deleted (stale files in vault not in source).
 deleted=$(rsync -a --delete --dry-run \
   --exclude='.claude-plugin/' \
   "${SOURCE_PLUGIN}/" "${VAULT_PLUGIN}/" \
   | grep "^deleting " | grep -v "/$" || true)
 if [ -n "$deleted" ]; then
-  echo "INFO: Removing stale vault files (not in source repo):"
+  echo "INFO: Removing stale vault files (not in current release):"
   echo "$deleted"
 fi
 
@@ -41,8 +40,8 @@ echo "synced: .claude/plugins/onebrain/"
 # Copy root docs to vault root
 synced_root=0
 for f in README.md CONTRIBUTING.md CHANGELOG.md; do
-  if [ -f "${SOURCE_REPO}/${f}" ]; then
-    cp "${SOURCE_REPO}/${f}" "${VAULT_ROOT}/${f}"
+  if [ -f "${TMP_DIR}/${f}" ]; then
+    cp "${TMP_DIR}/${f}" "${VAULT_ROOT}/${f}"
     echo "synced: ${f}"
     synced_root=$((synced_root + 1))
   fi

--- a/.claude/plugins/onebrain/skills/update/scripts/vault-sync.sh
+++ b/.claude/plugins/onebrain/skills/update/scripts/vault-sync.sh
@@ -2,7 +2,7 @@
 # vault-sync.sh <source_repo> <vault_root>
 # Syncs plugin folder from source repo to vault (with stale file cleanup)
 # and copies root docs (README, CONTRIBUTING, CHANGELOG) to vault root.
-# Run from the source repo — does not depend on vault having this script first.
+# Must be run with CWD = vault root (called via vault-relative path after bootstrap step 1).
 
 set -euo pipefail
 
@@ -19,10 +19,20 @@ fi
 
 mkdir -p "$VAULT_PLUGIN"
 
+# Warn about files that will be deleted (stale files in vault not in source repo).
+# Output is captured by the agent and surfaced in the migration log.
+deleted=$(rsync -a --delete --dry-run \
+  --exclude='.claude-plugin/' \
+  "${SOURCE_PLUGIN}/" "${VAULT_PLUGIN}/" \
+  | grep "^deleting " | grep -v "/$" || true)
+if [ -n "$deleted" ]; then
+  echo "INFO: Removing stale vault files (not in source repo):"
+  echo "$deleted"
+fi
+
 # Sync plugin folder: copy new/changed files, delete files removed from source.
-# Excludes plugin.json (written last as completion signal) and .claude-plugin/.
+# Excludes .claude-plugin/ (contains plugin.json — written last as completion signal).
 rsync -a --delete \
-  --exclude='plugin.json' \
   --exclude='.claude-plugin/' \
   "${SOURCE_PLUGIN}/" "${VAULT_PLUGIN}/"
 

--- a/.claude/plugins/onebrain/skills/update/scripts/vault-sync.sh
+++ b/.claude/plugins/onebrain/skills/update/scripts/vault-sync.sh
@@ -2,7 +2,9 @@
 # vault-sync.sh <vault_root> <branch>
 # Downloads the latest onebrain plugin files from GitHub and syncs to vault.
 # Syncs the plugin folder (with stale file cleanup) and copies root docs to vault root.
-# Must be run with CWD = vault root (called via vault-relative path after bootstrap step 1).
+# Requires: curl, tar (both included in Git for Windows / Git Bash).
+# No rsync dependency — uses Python for directory sync (cross-platform).
+# CWD must be vault root when calling this script (uses vault-relative path invocation).
 
 set -euo pipefail
 
@@ -10,8 +12,8 @@ VAULT_ROOT="${1:?Usage: vault-sync.sh <vault_root> <branch>}"
 BRANCH="${2:-main}"
 REPO="kengio/onebrain"
 
-command -v rsync >/dev/null 2>&1 || {
-  echo "ERROR: rsync is required but not installed. Install with: apt install rsync / brew install rsync" >&2
+PYTHON=$(command -v python3 2>/dev/null || command -v python 2>/dev/null) || {
+  echo "ERROR: Python is required but not found. Install Python 3." >&2
   exit 1
 }
 
@@ -19,28 +21,65 @@ TMP_DIR=$(mktemp -d)
 trap 'rm -rf "$TMP_DIR"' EXIT
 
 echo "vault-sync: downloading from github.com/${REPO}@${BRANCH}..."
-# -f: fail on HTTP errors (clear error message instead of cryptic tar failure)
+# -f: exit non-zero on HTTP errors (clear error vs cryptic tar failure)
 curl -fsSL "https://github.com/${REPO}/archive/refs/heads/${BRANCH}.tar.gz" \
   | tar -xz -C "$TMP_DIR" --strip-components=1
 
 SOURCE_PLUGIN="${TMP_DIR}/.claude/plugins/onebrain"
 VAULT_PLUGIN="${VAULT_ROOT}/.claude/plugins/onebrain"
 
-# Warn about files that will be deleted (stale files in vault not in source).
-deleted=$(rsync -a --delete --dry-run \
-  --exclude='.claude-plugin/' \
-  "${SOURCE_PLUGIN}/" "${VAULT_PLUGIN}/" \
-  | grep "^deleting " | grep -v "/$" || true)
-if [ -n "$deleted" ]; then
-  echo "INFO: Removing stale vault files (not in current release):"
-  echo "$deleted"
-fi
+# Sync plugin folder using Python (cross-platform; no rsync required).
+# Copies new/changed files, deletes stale vault files, excludes .claude-plugin/
+# (plugin.json lives there — written last as completion signal).
+"$PYTHON" - "$SOURCE_PLUGIN" "$VAULT_PLUGIN" ".claude-plugin" <<'PYEOF'
+import sys, shutil
+from pathlib import Path
 
-# Sync plugin folder: copy new/changed files, delete files removed from source.
-# Excludes .claude-plugin/ (contains plugin.json — written last as completion signal).
-rsync -a --delete \
-  --exclude='.claude-plugin/' \
-  "${SOURCE_PLUGIN}/" "${VAULT_PLUGIN}/"
+src, dst, *excludes = Path(sys.argv[1]), Path(sys.argv[2]), *sys.argv[3:]
+exclude_set = set(excludes)
+dst.mkdir(parents=True, exist_ok=True)
+
+def is_excluded(parts):
+    return any(p in exclude_set for p in parts)
+
+# Collect stale files first (preview)
+stale = [
+    rel for dst_item in dst.rglob("*")
+    if dst_item.is_file()
+    and not is_excluded((rel := dst_item.relative_to(dst)).parts)
+    and not (src / rel).exists()
+]
+if stale:
+    print("INFO: Removing stale vault files (not in current release):")
+    for f in sorted(stale):
+        print(f"  {f}")
+
+# Copy all files from src to dst (overwrite)
+for item in src.rglob("*"):
+    rel = item.relative_to(src)
+    if is_excluded(rel.parts):
+        continue
+    dst_item = dst / rel
+    if item.is_dir():
+        dst_item.mkdir(parents=True, exist_ok=True)
+    else:
+        dst_item.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(item, dst_item)
+
+# Delete stale files (deepest paths first to allow empty-dir cleanup)
+for dst_item in sorted(dst.rglob("*"), key=lambda p: len(p.parts), reverse=True):
+    rel = dst_item.relative_to(dst)
+    if is_excluded(rel.parts):
+        continue
+    if not (src / rel).exists():
+        if dst_item.is_file():
+            dst_item.unlink()
+        elif dst_item.is_dir():
+            try:
+                dst_item.rmdir()
+            except OSError:
+                pass
+PYEOF
 
 echo "synced: .claude/plugins/onebrain/"
 

--- a/.claude/plugins/onebrain/skills/update/scripts/vault-sync.sh
+++ b/.claude/plugins/onebrain/skills/update/scripts/vault-sync.sh
@@ -83,7 +83,7 @@ PYEOF
 
 echo "synced: .claude/plugins/onebrain/"
 
-# Copy root docs to vault root
+# Copy root docs to vault root (simple overwrite — no user customization expected)
 synced_root=0
 for f in README.md CONTRIBUTING.md CHANGELOG.md; do
   if [ -f "${TMP_DIR}/${f}" ]; then
@@ -92,5 +92,54 @@ for f in README.md CONTRIBUTING.md CHANGELOG.md; do
     synced_root=$((synced_root + 1))
   fi
 done
+
+# Merge harness entrypoints (CLAUDE.md, GEMINI.md, AGENTS.md):
+# - Absent in vault → copy from release
+# - Identical to release → skip
+# - Differs → apply repo changes and preserve any user-added @ imports
+"$PYTHON" - "$TMP_DIR" "$VAULT_ROOT" <<'PYEOF'
+import sys
+from pathlib import Path
+
+tmp_dir, vault_root = Path(sys.argv[1]), Path(sys.argv[2])
+
+for fname in ("CLAUDE.md", "GEMINI.md", "AGENTS.md"):
+    src = tmp_dir / fname
+    dst = vault_root / fname
+
+    if not src.exists():
+        continue
+
+    repo_text = src.read_text(encoding="utf-8")
+
+    if not dst.exists():
+        dst.write_text(repo_text, encoding="utf-8")
+        print(f"created: {fname}")
+        continue
+
+    vault_text = dst.read_text(encoding="utf-8")
+
+    if vault_text == repo_text:
+        print(f"up-to-date: {fname}")
+        continue
+
+    # Preserve user-added @ imports not present in the repo version
+    repo_lines = set(repo_text.splitlines())
+    user_imports = [
+        line for line in vault_text.splitlines()
+        if line.startswith("@") and line not in repo_lines
+    ]
+
+    merged = repo_text.rstrip()
+    if user_imports:
+        merged += "\n\n## Personal Extensions\n\n" + "\n".join(user_imports)
+    merged += "\n"
+
+    dst.write_text(merged, encoding="utf-8")
+    if user_imports:
+        print(f"merged: {fname} (preserved {len(user_imports)} personal import(s))")
+    else:
+        print(f"updated: {fname}")
+PYEOF
 
 echo "vault-sync: done (${synced_root} root files synced)"

--- a/.claude/plugins/onebrain/skills/update/scripts/vault-sync.sh
+++ b/.claude/plugins/onebrain/skills/update/scripts/vault-sync.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 # vault-sync.sh <vault_root> <branch>
 # Downloads the latest onebrain plugin files from GitHub and syncs to vault.
-# Syncs the plugin folder (with stale file cleanup) and copies root docs to vault root.
+# Syncs the plugin folder (with stale file cleanup), copies root docs, and
+# merges harness entrypoints (CLAUDE.md, GEMINI.md, AGENTS.md).
 # Requires: curl, tar (both included in Git for Windows / Git Bash).
-# No rsync dependency — uses Python for directory sync (cross-platform).
+# No rsync dependency — uses Python 3.8+ for directory sync (cross-platform).
 # CWD must be vault root when calling this script (uses vault-relative path invocation).
 
 set -euo pipefail
@@ -35,20 +36,26 @@ VAULT_PLUGIN="${VAULT_ROOT}/.claude/plugins/onebrain"
 import sys, shutil
 from pathlib import Path
 
-src, dst, *excludes = Path(sys.argv[1]), Path(sys.argv[2]), *sys.argv[3:]
+# Explicit assignment avoids bare *splat on RHS (invalid syntax in Python < 3.9)
+# and walrus operator (requires Python 3.8+).
+src = Path(sys.argv[1])
+dst = Path(sys.argv[2])
+excludes = sys.argv[3:]
 exclude_set = set(excludes)
 dst.mkdir(parents=True, exist_ok=True)
 
 def is_excluded(parts):
     return any(p in exclude_set for p in parts)
 
-# Collect stale files first (preview)
-stale = [
-    rel for dst_item in dst.rglob("*")
-    if dst_item.is_file()
-    and not is_excluded((rel := dst_item.relative_to(dst)).parts)
-    and not (src / rel).exists()
-]
+# Collect stale files first (preview before deletion)
+stale = []
+for dst_item in dst.rglob("*"):
+    if not dst_item.is_file():
+        continue
+    rel = dst_item.relative_to(dst)
+    if not is_excluded(rel.parts) and not (src / rel).exists():
+        stale.append(rel)
+
 if stale:
     print("INFO: Removing stale vault files (not in current release):")
     for f in sorted(stale):
@@ -97,6 +104,7 @@ done
 # - Absent in vault → copy from release
 # - Identical to release → skip
 # - Differs → apply repo changes and preserve any user-added @ imports
+# Uses utf-8-sig to silently strip BOM if present (Windows editors may add it).
 "$PYTHON" - "$TMP_DIR" "$VAULT_ROOT" <<'PYEOF'
 import sys
 from pathlib import Path
@@ -110,14 +118,14 @@ for fname in ("CLAUDE.md", "GEMINI.md", "AGENTS.md"):
     if not src.exists():
         continue
 
-    repo_text = src.read_text(encoding="utf-8")
+    repo_text = src.read_text(encoding="utf-8-sig")
 
     if not dst.exists():
         dst.write_text(repo_text, encoding="utf-8")
         print(f"created: {fname}")
         continue
 
-    vault_text = dst.read_text(encoding="utf-8")
+    vault_text = dst.read_text(encoding="utf-8-sig")
 
     if vault_text == repo_text:
         print(f"up-to-date: {fname}")

--- a/.claude/plugins/onebrain/skills/update/scripts/vault-sync.sh
+++ b/.claude/plugins/onebrain/skills/update/scripts/vault-sync.sh
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
 # vault-sync.sh <vault_root> <branch>
 # Downloads the latest onebrain plugin files from GitHub and syncs to vault.
-# Syncs the plugin folder (with stale file cleanup), copies root docs, and
-# merges harness entrypoints (CLAUDE.md, GEMINI.md, AGENTS.md).
+# After download, all sync operations run in parallel:
+#   - Plugin folder sync (with stale file cleanup)
+#   - Root docs copy (README, CONTRIBUTING, CHANGELOG)
+#   - Harness file merge (CLAUDE.md, GEMINI.md, AGENTS.md) — vault is primary
 # Requires: curl, tar (both included in Git for Windows / Git Bash).
-# No rsync dependency — uses Python 3.8+ for directory sync (cross-platform).
+# No rsync dependency — uses Python 3.6+ for all sync operations (cross-platform).
 # CWD must be vault root when calling this script (uses vault-relative path invocation).
 
 set -euo pipefail
@@ -26,128 +28,147 @@ echo "vault-sync: downloading from github.com/${REPO}@${BRANCH}..."
 curl -fsSL "https://github.com/${REPO}/archive/refs/heads/${BRANCH}.tar.gz" \
   | tar -xz -C "$TMP_DIR" --strip-components=1
 
-SOURCE_PLUGIN="${TMP_DIR}/.claude/plugins/onebrain"
-VAULT_PLUGIN="${VAULT_ROOT}/.claude/plugins/onebrain"
-
-# Sync plugin folder using Python (cross-platform; no rsync required).
-# Copies new/changed files, deletes stale vault files, excludes .claude-plugin/
-# (plugin.json lives there — written last as completion signal).
-"$PYTHON" - "$SOURCE_PLUGIN" "$VAULT_PLUGIN" ".claude-plugin" <<'PYEOF'
+# All three sync operations are independent — run them in parallel.
+"$PYTHON" - "$TMP_DIR" "$VAULT_ROOT" <<'PYEOF'
 import sys, shutil
 from pathlib import Path
+from concurrent.futures import ThreadPoolExecutor, as_completed
 
-# Explicit assignment avoids bare *splat on RHS (invalid syntax in Python < 3.9)
-# and walrus operator (requires Python 3.8+).
-src = Path(sys.argv[1])
-dst = Path(sys.argv[2])
-excludes = sys.argv[3:]
-exclude_set = set(excludes)
-dst.mkdir(parents=True, exist_ok=True)
+tmp_dir = Path(sys.argv[1])
+vault_root = Path(sys.argv[2])
+
+source_plugin = tmp_dir / ".claude" / "plugins" / "onebrain"
+vault_plugin = vault_root / ".claude" / "plugins" / "onebrain"
+exclude_dirs = {".claude-plugin"}
+
+# ── helpers ──────────────────────────────────────────────────────────────────
 
 def is_excluded(parts):
-    return any(p in exclude_set for p in parts)
+    return any(p in exclude_dirs for p in parts)
 
-# Collect stale files first (preview before deletion)
-stale = []
-for dst_item in dst.rglob("*"):
-    if not dst_item.is_file():
-        continue
-    rel = dst_item.relative_to(dst)
-    if not is_excluded(rel.parts) and not (src / rel).exists():
-        stale.append(rel)
+# ── task 1: plugin folder sync ───────────────────────────────────────────────
 
-if stale:
-    print("INFO: Removing stale vault files (not in current release):")
-    for f in sorted(stale):
-        print(f"  {f}")
+def sync_plugin():
+    vault_plugin.mkdir(parents=True, exist_ok=True)
 
-# Copy all files from src to dst (overwrite)
-for item in src.rglob("*"):
-    rel = item.relative_to(src)
-    if is_excluded(rel.parts):
-        continue
-    dst_item = dst / rel
-    if item.is_dir():
-        dst_item.mkdir(parents=True, exist_ok=True)
-    else:
-        dst_item.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(item, dst_item)
+    # Identify stale files (preview before deletion)
+    stale = []
+    for dst_item in vault_plugin.rglob("*"):
+        if not dst_item.is_file():
+            continue
+        rel = dst_item.relative_to(vault_plugin)
+        if not is_excluded(rel.parts) and not (source_plugin / rel).exists():
+            stale.append(rel)
 
-# Delete stale files (deepest paths first to allow empty-dir cleanup)
-for dst_item in sorted(dst.rglob("*"), key=lambda p: len(p.parts), reverse=True):
-    rel = dst_item.relative_to(dst)
-    if is_excluded(rel.parts):
-        continue
-    if not (src / rel).exists():
-        if dst_item.is_file():
-            dst_item.unlink()
-        elif dst_item.is_dir():
-            try:
-                dst_item.rmdir()
-            except OSError:
-                pass
-PYEOF
+    if stale:
+        print("INFO: Removing stale vault files (not in current release):")
+        for f in sorted(stale):
+            print(f"  {f}")
 
-echo "synced: .claude/plugins/onebrain/"
+    # Copy files in parallel
+    def copy_one(item):
+        rel = item.relative_to(source_plugin)
+        if is_excluded(rel.parts):
+            return
+        dst = vault_plugin / rel
+        if item.is_dir():
+            dst.mkdir(parents=True, exist_ok=True)
+        else:
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(item, dst)
 
-# Copy root docs to vault root (simple overwrite — no user customization expected)
-synced_root=0
-for f in README.md CONTRIBUTING.md CHANGELOG.md; do
-  if [ -f "${TMP_DIR}/${f}" ]; then
-    cp "${TMP_DIR}/${f}" "${VAULT_ROOT}/${f}"
-    echo "synced: ${f}"
-    synced_root=$((synced_root + 1))
-  fi
-done
+    items = list(source_plugin.rglob("*"))
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        list(pool.map(copy_one, items))
 
-# Merge harness entrypoints (CLAUDE.md, GEMINI.md, AGENTS.md):
-# - Absent in vault → copy from release
-# - Identical to release → skip
-# - Differs → apply repo changes and preserve any user-added @ imports
-# Uses utf-8-sig to silently strip BOM if present (Windows editors may add it).
-"$PYTHON" - "$TMP_DIR" "$VAULT_ROOT" <<'PYEOF'
-import sys
-from pathlib import Path
+    # Delete stale files (deepest first to allow empty-dir cleanup)
+    for dst_item in sorted(vault_plugin.rglob("*"), key=lambda p: len(p.parts), reverse=True):
+        rel = dst_item.relative_to(vault_plugin)
+        if is_excluded(rel.parts):
+            continue
+        if not (source_plugin / rel).exists():
+            if dst_item.is_file():
+                dst_item.unlink()
+            elif dst_item.is_dir():
+                try:
+                    dst_item.rmdir()
+                except OSError:
+                    pass
 
-tmp_dir, vault_root = Path(sys.argv[1]), Path(sys.argv[2])
+    print("synced: .claude/plugins/onebrain/")
 
-for fname in ("CLAUDE.md", "GEMINI.md", "AGENTS.md"):
+# ── task 2: root docs copy (overwrite) ───────────────────────────────────────
+
+def copy_root_docs():
+    copied = 0
+    for fname in ("README.md", "CONTRIBUTING.md", "CHANGELOG.md"):
+        src = tmp_dir / fname
+        if src.exists():
+            shutil.copy2(src, vault_root / fname)
+            print(f"synced: {fname}")
+            copied += 1
+    return copied
+
+# ── task 3: harness file merge (vault is primary) ────────────────────────────
+
+def merge_harness_file(fname):
     src = tmp_dir / fname
     dst = vault_root / fname
 
     if not src.exists():
-        continue
+        return
 
     repo_text = src.read_text(encoding="utf-8-sig")
 
     if not dst.exists():
         dst.write_text(repo_text, encoding="utf-8")
         print(f"created: {fname}")
-        continue
+        return
 
     vault_text = dst.read_text(encoding="utf-8-sig")
 
     if vault_text == repo_text:
         print(f"up-to-date: {fname}")
-        continue
+        return
 
-    # Preserve user-added @ imports not present in the repo version
-    repo_lines = set(repo_text.splitlines())
-    user_imports = [
-        line for line in vault_text.splitlines()
-        if line.startswith("@") and line not in repo_lines
+    # Vault is primary. Find @ imports in repo not yet present in vault.
+    vault_lines = vault_text.splitlines()
+    vault_at_set = {l.strip() for l in vault_lines if l.startswith("@")}
+    new_imports = [
+        line for line in repo_text.splitlines()
+        if line.startswith("@") and line.strip() not in vault_at_set
     ]
 
-    merged = repo_text.rstrip()
-    if user_imports:
-        merged += "\n\n## Personal Extensions\n\n" + "\n".join(user_imports)
-    merged += "\n"
+    if not new_imports:
+        print(f"kept: {fname} (vault version retained, no new imports to inject)")
+        return
 
-    dst.write_text(merged, encoding="utf-8")
-    if user_imports:
-        print(f"merged: {fname} (preserved {len(user_imports)} personal import(s))")
+    # Insert before the last @ line (keeps @INSTRUCTIONS.md last)
+    last_at = max((i for i, l in enumerate(vault_lines) if l.startswith("@")), default=-1)
+    if last_at >= 0:
+        vault_lines[last_at:last_at] = new_imports
     else:
-        print(f"updated: {fname}")
-PYEOF
+        vault_lines += [""] + new_imports
 
-echo "vault-sync: done (${synced_root} root files synced)"
+    dst.write_text("\n".join(vault_lines) + "\n", encoding="utf-8")
+    print(f"merged: {fname} (injected {len(new_imports)} new import(s) from repo)")
+
+def merge_harness_files():
+    with ThreadPoolExecutor(max_workers=3) as pool:
+        list(pool.map(merge_harness_file, ("CLAUDE.md", "GEMINI.md", "AGENTS.md")))
+
+# ── run all three tasks in parallel ──────────────────────────────────────────
+
+with ThreadPoolExecutor(max_workers=3) as pool:
+    futures = {
+        pool.submit(sync_plugin): "plugin sync",
+        pool.submit(copy_root_docs): "root docs",
+        pool.submit(merge_harness_files): "harness merge",
+    }
+    for future in as_completed(futures):
+        exc = future.exception()
+        if exc:
+            raise RuntimeError(f"{futures[future]} failed: {exc}") from exc
+
+print("vault-sync: done")
+PYEOF

--- a/.claude/plugins/onebrain/skills/update/scripts/vault-sync.sh
+++ b/.claude/plugins/onebrain/skills/update/scripts/vault-sync.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# vault-sync.sh <source_repo> <vault_root>
+# Syncs plugin folder from source repo to vault (with stale file cleanup)
+# and copies root docs (README, CONTRIBUTING, CHANGELOG) to vault root.
+# Run from the source repo — does not depend on vault having this script first.
+
+set -euo pipefail
+
+SOURCE_REPO="${1:?Usage: vault-sync.sh <source_repo> <vault_root>}"
+VAULT_ROOT="${2:?Usage: vault-sync.sh <source_repo> <vault_root>}"
+
+SOURCE_PLUGIN="${SOURCE_REPO}/.claude/plugins/onebrain"
+VAULT_PLUGIN="${VAULT_ROOT}/.claude/plugins/onebrain"
+
+if [ ! -d "$SOURCE_PLUGIN" ]; then
+  echo "ERROR: source plugin folder not found: $SOURCE_PLUGIN" >&2
+  exit 1
+fi
+
+mkdir -p "$VAULT_PLUGIN"
+
+# Sync plugin folder: copy new/changed files, delete files removed from source.
+# Excludes plugin.json (written last as completion signal) and .claude-plugin/.
+rsync -a --delete \
+  --exclude='plugin.json' \
+  --exclude='.claude-plugin/' \
+  "${SOURCE_PLUGIN}/" "${VAULT_PLUGIN}/"
+
+echo "synced: .claude/plugins/onebrain/"
+
+# Copy root docs to vault root
+synced_root=0
+for f in README.md CONTRIBUTING.md CHANGELOG.md; do
+  if [ -f "${SOURCE_REPO}/${f}" ]; then
+    cp "${SOURCE_REPO}/${f}" "${VAULT_ROOT}/${f}"
+    echo "synced: ${f}"
+    synced_root=$((synced_root + 1))
+  fi
+done
+
+echo "vault-sync: done (${synced_root} root files synced)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - fix(update): root file sync now explicitly copies README, CONTRIBUTING, CHANGELOG from repo root to vault root — fixes vault root CHANGELOG never being updated
 - fix(update): plugin folder sync now deletes stale vault files absent from source repo — fixes CHANGELOG.md accumulating in plugin folder
 - refactor(update): bootstrap reordered — early-bootstrap copies skills/update/ first so predefined scripts are available before full sync runs
-- feat(update): add 3 predefined scripts: vault-sync.sh (rsync + stale cleanup + root files), register-hooks.sh (idempotent JSON hook registration), backfill-recapped.sh (session log frontmatter)
+- feat(update): add 3 predefined scripts: vault-sync.sh (curl+tar download, Python sync, stale cleanup, root files), register-hooks.sh (idempotent JSON hook registration), backfill-recapped.sh (session log frontmatter)
 - refactor(update): extract Vault Migration Steps 1–9 to references/migration-steps.md for lazy loading — SKILL.md reduced from 273 to 158 lines
 - refactor(update): add Skip conditions to all 9 migration steps for fast-exit on already-current vaults
 - refactor(update): parallelize bootstrap sync sub-steps (plugin sync + settings merge run concurrently)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - refactor(update): add Skip conditions to all 9 migration steps for fast-exit on already-current vaults
 - refactor(update): parallelize bootstrap sync sub-steps (plugin sync + settings merge run concurrently)
 - fix(update): remove redundant /doctor run from outer steps — already covered by migration Step 8
+- feat(update): add clean-plugin-cache.sh — removes stale onebrain cache versions; no-op for local directory installs, future-ready for remote marketplace distribution
 
 ## v1.10.12 — Skill Quality: Authoring Patterns, Progressive Loading, Predefined Scripts
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-latest_version: 1.10.12
+latest_version: 1.10.13
 released: 2026-04-22
 ---
 
@@ -9,6 +9,17 @@ All notable changes to OneBrain are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+
+## v1.10.13 — Fix /update: CHANGELOG sync, stale file cleanup, predefined scripts, lazy loading
+
+- fix(update): step 4f now explicitly copies README, CONTRIBUTING, CHANGELOG from repo root to vault root — fixes vault root CHANGELOG never being updated
+- fix(update): step 3b (plugin folder sync) now deletes stale vault files absent from source repo — fixes CHANGELOG.md accumulating in plugin folder
+- refactor(update): bootstrap reordered — early-bootstrap copies skills/update/ first so predefined scripts are available before full sync runs
+- feat(update): add 3 predefined scripts: vault-sync.sh (rsync + stale cleanup + root files), register-hooks.sh (idempotent JSON hook registration), backfill-recapped.sh (session log frontmatter)
+- refactor(update): extract Vault Migration Steps 1–9 to references/migration-steps.md for lazy loading — SKILL.md reduced from 266 to 144 lines
+- refactor(update): add Skip conditions to all 9 migration steps for fast-exit on already-current vaults
+- refactor(update): parallelize step 3b sub-steps (plugin sync + settings merge run concurrently)
+- fix(update): remove redundant /doctor run (step 4e) — already covered by migration Step 8
 
 ## v1.10.12 — Skill Quality: Authoring Patterns, Progressive Loading, Predefined Scripts
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - fix(update): plugin folder sync now deletes stale vault files absent from source repo — fixes CHANGELOG.md accumulating in plugin folder
 - refactor(update): bootstrap reordered — early-bootstrap copies skills/update/ first so predefined scripts are available before full sync runs
 - feat(update): add 3 predefined scripts: vault-sync.sh (rsync + stale cleanup + root files), register-hooks.sh (idempotent JSON hook registration), backfill-recapped.sh (session log frontmatter)
-- refactor(update): extract Vault Migration Steps 1–9 to references/migration-steps.md for lazy loading — SKILL.md reduced from 266 to 144 lines
+- refactor(update): extract Vault Migration Steps 1–9 to references/migration-steps.md for lazy loading — SKILL.md reduced from 273 to 158 lines
 - refactor(update): add Skip conditions to all 9 migration steps for fast-exit on already-current vaults
 - refactor(update): parallelize bootstrap sync sub-steps (plugin sync + settings merge run concurrently)
 - fix(update): remove redundant /doctor run from outer steps — already covered by migration Step 8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,14 +12,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## v1.10.13 — Fix /update: CHANGELOG sync, stale file cleanup, predefined scripts, lazy loading
 
-- fix(update): step 4f now explicitly copies README, CONTRIBUTING, CHANGELOG from repo root to vault root — fixes vault root CHANGELOG never being updated
-- fix(update): step 3b (plugin folder sync) now deletes stale vault files absent from source repo — fixes CHANGELOG.md accumulating in plugin folder
+- fix(update): root file sync now explicitly copies README, CONTRIBUTING, CHANGELOG from repo root to vault root — fixes vault root CHANGELOG never being updated
+- fix(update): plugin folder sync now deletes stale vault files absent from source repo — fixes CHANGELOG.md accumulating in plugin folder
 - refactor(update): bootstrap reordered — early-bootstrap copies skills/update/ first so predefined scripts are available before full sync runs
 - feat(update): add 3 predefined scripts: vault-sync.sh (rsync + stale cleanup + root files), register-hooks.sh (idempotent JSON hook registration), backfill-recapped.sh (session log frontmatter)
 - refactor(update): extract Vault Migration Steps 1–9 to references/migration-steps.md for lazy loading — SKILL.md reduced from 266 to 144 lines
 - refactor(update): add Skip conditions to all 9 migration steps for fast-exit on already-current vaults
-- refactor(update): parallelize step 3b sub-steps (plugin sync + settings merge run concurrently)
-- fix(update): remove redundant /doctor run (step 4e) — already covered by migration Step 8
+- refactor(update): parallelize bootstrap sync sub-steps (plugin sync + settings merge run concurrently)
+- fix(update): remove redundant /doctor run from outer steps — already covered by migration Step 8
 
 ## v1.10.12 — Skill Quality: Authoring Patterns, Progressive Loading, Predefined Scripts
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - refactor(update): parallelize bootstrap sync sub-steps (plugin sync + settings merge run concurrently)
 - fix(update): remove redundant /doctor run from outer steps — already covered by migration Step 8
 - feat(update): add clean-plugin-cache.sh — removes stale onebrain cache versions; no-op for local directory installs, future-ready for remote marketplace distribution
+- feat(update): vault-sync.sh merges CLAUDE.md, GEMINI.md, AGENTS.md on update — absent files are created, identical files are skipped, changed files are updated while preserving user-added @ imports
 
 ## v1.10.12 — Skill Quality: Authoring Patterns, Progressive Loading, Predefined Scripts
 


### PR DESCRIPTION
## Summary

- **Fix**: vault root `CHANGELOG.md` never updated — root file sync now targets repo root → vault root explicitly
- **Fix**: stale files in plugin folder — plugin sync uses `rsync --delete` with pre-deletion warning
- **Refactor**: update flow is now GitHub-only — no local source repo required; `vault-sync.sh` downloads via `curl` tarball; bootstrap uses WebFetch for scripts
- **Feat**: 4 predefined scripts (`vault-sync.sh`, `register-hooks.sh`, `backfill-recapped.sh`, `clean-plugin-cache.sh`)
- **Refactor**: Vault Migration Steps 1–9 extracted to `references/migration-steps.md` for lazy loading — SKILL.md 273→158 lines
- **Perf**: Skip conditions on all 9 migration steps; step 3b sub-steps parallelized

## Key Design Decisions

- **GitHub-only**: users only need their vault — no local clone of the onebrain repo required
- **Bootstrap**: step 1 downloads all 4 scripts from GitHub raw URLs before any other step runs, eliminating the chicken-and-egg problem on version upgrades
- **clean-plugin-cache.sh**: scoped to onebrain only; no-op for local directory installs; ready for future remote marketplace distribution

## Test plan

- [ ] Run `/update` from v1.10.12 vault — should detect v1.10.13, bootstrap, sync all files
- [ ] Verify vault root `CHANGELOG.md` updated to v1.10.13
- [ ] Verify no stale `CHANGELOG.md` in `.claude/plugins/onebrain/`
- [ ] Test `vault-sync.sh` on Linux (WSL) — `rsync` preflight guard triggers if not installed
- [ ] Test `vault-sync.sh` with invalid branch — `curl -f` gives clear HTTP error
- [ ] Run `register-hooks.sh` on malformed settings.json — friendly error, not traceback
- [ ] Run `backfill-recapped.sh` on Linux — portable temp-file sed works correctly
- [ ] Run `clean-plugin-cache.sh` — outputs "local directory install" message
- [ ] Interrupt after bootstrap step 1, re-run — clean retry; all scripts already present

🤖 Generated with [Claude Code](https://claude.com/claude-code)