### PR TITLE
fix: QMD.md load error + stale source-repo refs + H1 heading consistency (v1.10.14)

### DIFF
--- a/.claude/plugins/onebrain/.claude-plugin/plugin.json
+++ b/.claude/plugins/onebrain/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "onebrain",
-  "version": "1.10.13",
+  "version": "1.10.14",
   "description": "OneBrain — Where human and AI thinking become one. A powerful thinking partner powered by AI synergy.",
   "author": {
     "name": "OneBrain Contributors"

--- a/.claude/plugins/onebrain/skills/daily/SKILL.md
+++ b/.claude/plugins/onebrain/skills/daily/SKILL.md
@@ -3,7 +3,7 @@ name: daily
 description: "Daily briefing: surfaces tasks due today and open items from the last session. Use when the user wants a snapshot of today's obligations — 'what's on today', 'daily briefing', 'what do I have today'. Do NOT use for: full weekly review (use weekly), vault health check (use doctor), or listing all tasks across future dates."
 ---
 
-# /daily : Daily Briefing
+# Daily Briefing
 
 Surfaces tasks due today and open items from the last session.
 

--- a/.claude/plugins/onebrain/skills/help/SKILL.md
+++ b/.claude/plugins/onebrain/skills/help/SKILL.md
@@ -3,7 +3,7 @@ name: help
 description: "List all available OneBrain commands with descriptions and use cases. Invoke when user asks what you can do, wants to see commands, or seems confused about capabilities. Do NOT use for: actually running a command (identify the right skill and invoke it directly), answering questions about vault content (search directly), or general Claude questions."
 ---
 
-# /help : Available Commands
+# Available Commands
 
 When this skill is invoked, present all available OneBrain commands to the user.
 

--- a/.claude/plugins/onebrain/skills/qmd/SKILL.md
+++ b/.claude/plugins/onebrain/skills/qmd/SKILL.md
@@ -3,7 +3,7 @@ name: qmd
 description: "Set up and manage qmd search index for faster vault search. Subcommands: setup, embed, status, reindex, uninstall. Use when the user wants to configure, update, or troubleshoot the qmd search index itself. Do NOT use for: performing a search (call qmd tools directly), general vault operations, or installing OneBrain (use onboarding or update)."
 ---
 
-# /qmd : qmd Search Integration
+# qmd Search Integration
 
 qmd is an optional local search engine that indexes your vault for fast keyword and semantic search. When active, the agent uses it automatically for vault-wide searches.
 

--- a/.claude/plugins/onebrain/skills/startup/QMD.md
+++ b/.claude/plugins/onebrain/skills/startup/QMD.md
@@ -1,8 +1,3 @@
----
-name: qmd-guide
-description: "Search strategy and index maintenance rules for qmd MCP tools"
----
-
 # QMD Guide
 
 ## Search Strategy

--- a/.claude/plugins/onebrain/skills/update/SKILL.md
+++ b/.claude/plugins/onebrain/skills/update/SKILL.md
@@ -3,7 +3,7 @@ name: update
 description: "Update OneBrain system files from GitHub to the latest version. Use when the user wants to pull the latest OneBrain skills, hooks, and agents — 'update OneBrain', 'pull latest version'. Do NOT use for: updating vault notes (edit directly), teaching memory (use learn), or vault health checks (use doctor)."
 ---
 
-# /update
+# Update
 
 Update OneBrain system files from GitHub to the latest version.
 

--- a/.claude/plugins/onebrain/skills/update/SKILL.md
+++ b/.claude/plugins/onebrain/skills/update/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: update
-description: "Update OneBrain system files from the source repo to the latest version. Use when the user wants to pull the latest OneBrain skills, hooks, and agents — 'update OneBrain', 'pull latest version'. Do NOT use for: updating vault notes (edit directly), teaching memory (use learn), or vault health checks (use doctor)."
+description: "Update OneBrain system files from GitHub to the latest version. Use when the user wants to pull the latest OneBrain skills, hooks, and agents — 'update OneBrain', 'pull latest version'. Do NOT use for: updating vault notes (edit directly), teaching memory (use learn), or vault health checks (use doctor)."
 ---
 
 # /update
 
-Update OneBrain system files from the source repo to the latest version.
+Update OneBrain system files from GitHub to the latest version.
 
 ## Version Check
 
@@ -20,7 +20,7 @@ Update OneBrain system files from the source repo to the latest version.
    where `{branch}` is the mapped branch from step 2.
    Parse the `version` field from the JSON response.
 4. If equal → say: ✅ Already up to date — v{X.X.X}. and stop
-5. If newer → read `CHANGELOG.md` from repo; display before proceeding (do not skip or summarize):
+5. If newer → WebFetch `https://raw.githubusercontent.com/kengio/onebrain/{branch}/CHANGELOG.md`; display before proceeding (do not skip or summarize):
    ──────────────────────────────────────────────────────────────
    🔄 Update Available — v{current} → v{new}
    ──────────────────────────────────────────────────────────────

--- a/.claude/plugins/onebrain/skills/update/SKILL.md
+++ b/.claude/plugins/onebrain/skills/update/SKILL.md
@@ -149,7 +149,7 @@ Dry run complete — {N} files would be created, {M} modified, {P} deleted.
 
 - **MEMORY.md Key Learnings migration (migration Step 1) must run before migration Step 4.** Migration Step 4 restructures MEMORY.md; migration Step 1 reads and extracts from it. Running them in the wrong order loses the Key Learnings content before it can be promoted to memory/ files.
 
-- **Plugin folder sync deletes stale files.** Step 3b removes files in the vault's plugin folder that no longer exist in the source repo. This is intentional — the source repo is the single source of truth. Do not place user customizations inside `.claude/plugins/onebrain/`; they belong at the project or user settings level.
+- **Plugin folder sync deletes stale files.** Step 3b removes files in the vault's plugin folder that no longer exist in the GitHub repo. This is intentional — the GitHub repo is the single source of truth. Do not place user customizations inside `.claude/plugins/onebrain/`; they belong at the project or user settings level.
 
 - **Harness file merge is vault-primary.** If a user removed a plugin `@` import from CLAUDE.md/GEMINI.md/AGENTS.md (e.g., `@.claude/plugins/onebrain/INSTRUCTIONS.md`), `/update` will re-inject it on the next run because the script cannot distinguish intentional deletion from never having had it. If a specific import should stay absent, re-remove it after updating.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
-## v1.10.14 — Fix stale "source repo" references in /update skill
+## v1.10.14 — Fix stale "source repo" refs, plugin load error, H1 heading consistency
 
 - fix(update): description and body heading now say "from GitHub" instead of "from the source repo"
 - fix(update): Version Check step 5 now specifies WebFetch URL for CHANGELOG.md instead of ambiguous "read from repo"
+- fix(startup): remove YAML frontmatter from QMD.md — was incorrectly registered as a skill by the plugin loader, causing "1 error during load" on every plugin reload
+- fix(skills): standardise H1 headings — update/daily/help/qmd were using /command format; now consistent plain titles matching all other skills
 
 ## v1.10.13 — Fix /update: CHANGELOG sync, stale file cleanup, predefined scripts, lazy loading
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-latest_version: 1.10.13
+latest_version: 1.10.14
 released: 2026-04-22
 ---
 
@@ -9,6 +9,11 @@ All notable changes to OneBrain are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+
+## v1.10.14 — Fix stale "source repo" references in /update skill
+
+- fix(update): description and body heading now say "from GitHub" instead of "from the source repo"
+- fix(update): Version Check step 5 now specifies WebFetch URL for CHANGELOG.md instead of ambiguous "read from repo"
 
 ## v1.10.13 — Fix /update: CHANGELOG sync, stale file cleanup, predefined scripts, lazy loading
 


### PR DESCRIPTION
## Summary

- **Fix plugin load error**: `skills/startup/QMD.md` had `name`/`description` frontmatter that caused it to be registered as a skill named `qmd-guide` — causing \"1 error during load\" on every `/reload-plugins`
- **Fix stale docs**: `/update` SKILL.md still said \"from the source repo\" after the GitHub-only refactor in v1.10.13
- **Fix H1 headings**: `update`, `daily`, `help`, `qmd` skills used `# /command : Description` format inconsistent with the other 21 skills that use plain `# Title`

## Root cause of "1 error during load"

`skills/startup/QMD.md` was a reference guide (not a skill) but had YAML frontmatter with `name: qmd-guide` and `description`. The plugin loader treated it as a skill definition and failed to register it properly, producing one load error on every plugin reload.

## Test plan

- [ ] Run `/reload-plugins` — confirm \"0 errors during load\"
- [ ] Confirm OneBrain skills work via text routing (type `/doctor` in chat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)