### PR TITLE
fix: extraKnownMarketplaces key 'onebrain' → 'kengio' (v1.10.15)

### DIFF
--- a/.claude/plugins/onebrain/.claude-plugin/plugin.json
+++ b/.claude/plugins/onebrain/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "onebrain",
-  "version": "1.10.14",
+  "version": "1.10.15",
   "description": "OneBrain — Where human and AI thinking become one. A powerful thinking partner powered by AI synergy.",
   "author": {
     "name": "OneBrain Contributors"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -15,7 +15,7 @@
     "onebrain@kengio": true
   },
   "extraKnownMarketplaces": {
-    "onebrain": {
+    "kengio": {
       "source": {
         "source": "directory",
         "path": "."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-latest_version: 1.10.14
+latest_version: 1.10.15
 released: 2026-04-22
 ---
 
@@ -9,6 +9,10 @@ All notable changes to OneBrain are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+
+## v1.10.15 — Fix plugin marketplace key mismatch
+
+- fix: extraKnownMarketplaces key renamed "onebrain" → "kengio" to match enabledPlugins identifier onebrain@kengio — fixes "Plugin onebrain not found in marketplace kengio" error on every plugin reload (regression from v1.10.12 rename)
 
 ## v1.10.14 — Fix stale "source repo" refs, plugin load error, H1 heading consistency
 


### PR DESCRIPTION
## Summary

Regression from v1.10.12 (#95) which renamed `enabledPlugins` key from `onebrain@onebrain` → `onebrain@kengio` but forgot to update the `extraKnownMarketplaces` key from `"onebrain"` to `"kengio"`.

Caused **1 plugin error(s) detected: Plugin onebrain not found in marketplace kengio** on every `/reload-plugins`.

## Change

`.claude/settings.json` line 15:
```diff
-    "onebrain": {
+    "kengio": {
```

## Test plan

- [ ] Run `/reload-plugins` — confirm 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)