### PR TITLE
fix(auto-summary): session logs must not include recapped: in frontmatter (v1.10.18)

### DIFF
--- a/.claude/plugins/onebrain/.claude-plugin/plugin.json
+++ b/.claude/plugins/onebrain/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "onebrain",
-  "version": "1.10.17",
+  "version": "1.10.18",
   "description": "OneBrain — Where human and AI thinking become one. A powerful thinking partner powered by AI synergy.",
   "author": {
     "name": "OneBrain Contributors"

--- a/.claude/plugins/onebrain/skills/startup/AUTO-SUMMARY.md
+++ b/.claude/plugins/onebrain/skills/startup/AUTO-SUMMARY.md
@@ -20,7 +20,7 @@ If conditions are met:
   synthesized_from_checkpoints: true   # only if checkpoints were found and incorporated
   ---
   ```
-  **Never add `recapped:` or `topics:` to this frontmatter.** These fields are written by /recap only. Their absence is how /recap identifies unprocessed logs.
+  **Never add `recapped:` or `topics:` to this frontmatter.** These fields are set exclusively by /recap. Writing them here causes /recap to silently skip the log.
   The log must include all sections: `## What We Worked On`, `## Key Decisions`, `## Insights & Learnings`, `## What Worked / Didn't Work`, `## Action Items`, `## Open Questions`. Omit `## What Worked / Didn't Work` only if the session had no notable friction or technique worth logging. **Do not write the session log if any unmerged checkpoint's content is absent from the relevant sections** : every checkpoint's Key Decisions, Action Items, and Open Questions must appear explicitly in the output.
 - Mark as `merged: true` the checkpoint files that were read and incorporated above. Handle all frontmatter variants: `merged: false` → replace with `merged: true`; `merged: null` or bare `merged:` → replace with `merged: true`; key absent → add `merged: true`.
 - Guard: only delete checkpoint files AFTER confirming the session log file was successfully written. Never delete before or during the write.

--- a/.claude/plugins/onebrain/skills/startup/AUTO-SUMMARY.md
+++ b/.claude/plugins/onebrain/skills/startup/AUTO-SUMMARY.md
@@ -20,6 +20,7 @@ If conditions are met:
   synthesized_from_checkpoints: true   # only if checkpoints were found and incorporated
   ---
   ```
+  **Never add `recapped:` or `topics:` to this frontmatter.** These fields are written by /recap only. Their absence is how /recap identifies unprocessed logs.
   The log must include all sections: `## What We Worked On`, `## Key Decisions`, `## Insights & Learnings`, `## What Worked / Didn't Work`, `## Action Items`, `## Open Questions`. Omit `## What Worked / Didn't Work` only if the session had no notable friction or technique worth logging. **Do not write the session log if any unmerged checkpoint's content is absent from the relevant sections** : every checkpoint's Key Decisions, Action Items, and Open Questions must appear explicitly in the output.
 - Mark as `merged: true` the checkpoint files that were read and incorporated above. Handle all frontmatter variants: `merged: false` → replace with `merged: true`; `merged: null` or bare `merged:` → replace with `merged: true`; key absent → add `merged: true`.
 - Guard: only delete checkpoint files AFTER confirming the session log file was successfully written. Never delete before or during the write.
@@ -31,3 +32,7 @@ If conditions are met:
 - Safety-net: glob `[logs_folder]/YYYY/MM/*-checkpoint-*.md` (current month only) for any remaining files with `merged: true` — delete them. Scoped to current month to avoid vault-wide glob on large vaults.
 - If a genuinely useful long-term insight emerged, write it to a new `memory/` file using /learn conventions: filename `[agent_folder]/memory/kebab-case-topic.md`, frontmatter `tags: [agent-memory], type: behavioral, source: auto-summary, status: active, conf: medium, verified: today, updated: today, created: today, topics: [2–4 keywords]`. Add a row to MEMORY-INDEX.md and increment `total_active`. **Do not write to MEMORY.md.**
 - Do NOT show any output about the auto-save to the user
+
+## Known Gotchas
+
+- **Never write `recapped:` or `topics:` in session log frontmatter.** These fields are set exclusively by /recap. Writing them here causes /recap to silently skip the log, meaning insights are never promoted to memory/. The frontmatter template above is the complete list of valid fields.

--- a/.claude/plugins/onebrain/skills/wrapup/SKILL.md
+++ b/.claude/plugins/onebrain/skills/wrapup/SKILL.md
@@ -31,7 +31,7 @@ synthesized_from_checkpoints: true      # only if synthesized from checkpoints
 ---
 ```
 
-Absence of `recapped:` field = not yet processed by /recap.
+**Never add `recapped:` or `topics:` to this frontmatter** — these fields are set exclusively by /recap. Writing them here causes /recap to silently skip the log.
 
 ---
 

--- a/.claude/plugins/onebrain/skills/wrapup/SKILL.md
+++ b/.claude/plugins/onebrain/skills/wrapup/SKILL.md
@@ -125,6 +125,8 @@ auto-recovered: true
 - [Open questions from checkpoints]
 ```
 
+**Never add `recapped:` or `topics:` to this frontmatter** — these fields are set exclusively by /recap. Writing them here causes /recap to silently skip the log.
+
 **e. Write the session log** (per the template above). Verify the file exists and is non-empty before continuing.
 
 **f. Mark checkpoints as merged:** only after step e succeeds — for each checkpoint file in this group, set `merged: true` (same rules as Step 5).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-latest_version: 1.10.17
+latest_version: 1.10.18
 released: 2026-04-22
 ---
 
@@ -9,6 +9,12 @@ All notable changes to OneBrain are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+
+## v1.10.18 — Fix: session logs must not include recapped: in frontmatter
+
+- fix(auto-summary): add explicit prohibition against writing `recapped:` or `topics:` in session log frontmatter
+- fix(auto-summary): add Known Gotchas section documenting that writing `recapped:` causes /recap to silently skip the log
+- fix(wrapup): strengthen `recapped:` prohibition from descriptive to directive with consequence clause
 
 ## v1.10.17 — Revert onebrain@kengio → onebrain@onebrain
 


### PR DESCRIPTION
## Summary

Session logs written by AUTO-SUMMARY.md and wrapup orphan recovery incorrectly included \`recapped: YYYY-MM-DD\` in frontmatter. This caused \`/recap\` to silently skip those sessions, meaning insights were never promoted to \`memory/\`.

**Root cause:** No explicit prohibition against writing \`recapped:\` in any of the three session log frontmatter templates.

## Changes

- \`AUTO-SUMMARY.md\`: add bold inline prohibition after frontmatter template + new Known Gotchas section
- \`wrapup/SKILL.md\` main template (L34): replace passive description with direct bold prohibition + consequence clause
- \`wrapup/SKILL.md\` orphan recovery template (Step 1b): add same prohibition — same bug class, same fix
- Language standardized across all 4 instances: "set exclusively by /recap. Writing them here causes /recap to silently skip the log."

## Test plan

- [ ] Read AUTO-SUMMARY.md — prohibition appears immediately after frontmatter template block
- [ ] Read AUTO-SUMMARY.md — Known Gotchas section present at end of file
- [ ] Read wrapup/SKILL.md main template — prohibition is bold + includes consequence clause
- [ ] Read wrapup/SKILL.md Step 1b orphan recovery template — prohibition present after closing fence
- [ ] Run /update on vault after merge to pull in the fix
- [ ] Run /recap — confirm sessions 01–05 from 2026-04-22 are all processed

🤖 Generated with [Claude Code](https://claude.com/claude-code)