### PR TITLE
fix: v2.0.1 — sync versions, inject BUILD_VERSION in npm-publish, update CHANGELOG

### DIFF
--- a/.claude/plugins/onebrain/.claude-plugin/plugin.json
+++ b/.claude/plugins/onebrain/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "onebrain",
-  "version": "2.0.1",
+  "version": "2.0.0",
   "description": "OneBrain — Where human and AI thinking become one. A powerful thinking partner powered by AI synergy.",
   "author": {
     "name": "OneBrain Contributors"

--- a/.claude/plugins/onebrain/.claude-plugin/plugin.json
+++ b/.claude/plugins/onebrain/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "onebrain",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "OneBrain — Where human and AI thinking become one. A powerful thinking partner powered by AI synergy.",
   "author": {
     "name": "OneBrain Contributors"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,8 +148,14 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Compile TypeScript
-        run: bun run build
+        env:
+          VERSION: ${{ needs.verify-tag.outputs.version }}
+          RELEASE_DATE: ${{ needs.verify-tag.outputs.release_date }}
         working-directory: packages/cli
+        run: |
+          bun build src/index.ts --outfile dist/onebrain --target node \
+            --define BUILD_VERSION="\"$VERSION\"" \
+            --define BUILD_DATE="\"$RELEASE_DATE\""
 
       - name: Publish to npm
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-latest_version: 2.0.1
+latest_version: 2.0.0
 released: 2026-04-25
 ---
 
@@ -8,15 +8,20 @@ released: 2026-04-25
 All notable changes to OneBrain are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+> **Versioning:** `plugin.json` tracks the vault plugin version (skills, INSTRUCTIONS, hooks).
+> The CLI binary (`@onebrain-ai/cli`) has its own independent version tracked in `packages/cli/package.json`.
+> `/update` tracks plugin version only — CLI updates happen via `npm install -g @onebrain-ai/cli`.
+
 ## [Unreleased]
 
-## v2.0.1 — npm package fix
-
-- fix(cli): move @onebrain/core to devDependencies — bundled into dist at build time
-- fix(release): inject BUILD_VERSION into npm-publish build step so installed binary shows correct version
-- chore: sync version to 2.0.1 across packages/core and plugin.json
-
 ## v2.0.0 — CLI Binary
+
+### CLI v2.0.1
+- fix(cli): move @onebrain/core to devDependencies — bundled into dist/onebrain at build time
+- fix(release): inject BUILD_VERSION into npm-publish build step — `onebrain --version` now shows correct version
+- chore: separate CLI versioning from plugin versioning
+
+### Plugin v2.0.0
 
 - feat: compiled TypeScript binary replaces all bash/Python scripts
 - feat(internal): session-init, orphan-scan, checkpoint, qmd-reindex

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,13 +16,6 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## v2.0.0 — CLI Binary
 
-### CLI v2.0.1
-- fix(cli): move @onebrain/core to devDependencies — bundled into dist/onebrain at build time
-- fix(release): inject BUILD_VERSION into npm-publish build step — `onebrain --version` now shows correct version
-- chore: separate CLI versioning from plugin versioning
-
-### Plugin v2.0.0
-
 - feat: compiled TypeScript binary replaces all bash/Python scripts
 - feat(internal): session-init, orphan-scan, checkpoint, qmd-reindex
 - feat(ops): vault-sync, register-hooks, migrate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-latest_version: 2.0.0
+latest_version: 2.0.1
 released: 2026-04-25
 ---
 
@@ -9,6 +9,12 @@ All notable changes to OneBrain are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+
+## v2.0.1 — npm package fix
+
+- fix(cli): move @onebrain/core to devDependencies — bundled into dist at build time
+- fix(release): inject BUILD_VERSION into npm-publish build step so installed binary shows correct version
+- chore: sync version to 2.0.1 across packages/core and plugin.json
 
 ## v2.0.0 — CLI Binary
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -266,7 +266,21 @@ Both scripts download the repo tarball, extract it, remove themselves from the v
 - Include a brief description of what changed and why
 - If adding a skill, show an example interaction in the PR description
 - Keep skill files readable — they're prompts, not code
-- Bump `plugin.json` version for every PR — use patch for docs/fixes, minor for new skills/agents/hooks
+- **Never commit directly to `main`** — all changes go through a PR with a worktree branch
+
+## Versioning
+
+Two independent version tracks — bump only the track that changed:
+
+| Track | Files | Bump when |
+|---|---|---|
+| **Plugin** | `plugin.json` · `CHANGELOG.md` frontmatter | Skills, INSTRUCTIONS.md, hooks, vault structure |
+| **CLI** | `packages/cli/package.json` · `packages/core/package.json` | TypeScript source changes only |
+
+**Plugin bump:** patch for fixes/docs, minor for new skills/agents/hooks
+**CLI bump:** patch for bug fixes, minor for new commands, major for breaking changes
+
+After merging a CLI change → push tag `v{cli-version}` to trigger release workflow (builds binaries + publishes npm).
 
 ## Reporting Issues
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -267,6 +267,8 @@ Both scripts download the repo tarball, extract it, remove themselves from the v
 - If adding a skill, show an example interaction in the PR description
 - Keep skill files readable — they're prompts, not code
 - **Never commit directly to `main`** — all changes go through a PR with a worktree branch
+- **Minimum 3 review rounds** before merging — dispatch review agents in parallel, fix all findings before opening the PR
+- Update PR title and description after every new commit pushed to an open PR
 
 ## Versioning
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -267,7 +267,6 @@ Both scripts download the repo tarball, extract it, remove themselves from the v
 - If adding a skill, show an example interaction in the PR description
 - Keep skill files readable — they're prompts, not code
 - **Never commit directly to `main`** — all changes go through a PR with a worktree branch
-- **Minimum 3 review rounds** before merging — dispatch review agents in parallel, fix all findings before opening the PR
 - Update PR title and description after every new commit pushed to an open PR
 
 ## Versioning

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onebrain/core",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "type": "module",
   "main": "src/index.ts",
   "exports": {

--- a/scripts/check-version-sync.js
+++ b/scripts/check-version-sync.js
@@ -1,5 +1,9 @@
 #!/usr/bin/env bun
-// check-version-sync.js — exits 1 if any version field is out of sync
+// check-version-sync.js — exits 1 if versions within each track are out of sync
+//
+// Two independent version tracks:
+//   CLI track:    packages/cli + packages/core (npm binary releases)
+//   Plugin track: plugin.json + CHANGELOG.md  (/update vault releases)
 
 import { readFileSync } from "fs";
 import { resolve } from "path";
@@ -18,7 +22,6 @@ function readJson(relPath) {
 function readChangelogVersion(relPath) {
   const abs = resolve(ROOT, relPath);
   const content = readFileSync(abs, "utf8");
-  // Parse YAML frontmatter: ---\nlatest_version: X.Y.Z\n---
   const match = content.match(/^---\s*\n(?:.*\n)*?latest_version:\s*(\S+)\s*\n(?:.*\n)*?---/m);
   if (!match) {
     throw new Error(`Could not find latest_version in frontmatter of ${relPath}`);
@@ -26,41 +29,60 @@ function readChangelogVersion(relPath) {
   return match[1];
 }
 
-const sources = [
-  { label: "packages/cli/package.json", get: () => readJson("packages/cli/package.json").version },
-  { label: "packages/core/package.json", get: () => readJson("packages/core/package.json").version },
-  { label: ".claude/plugins/onebrain/.claude-plugin/plugin.json", get: () => readJson(".claude/plugins/onebrain/.claude-plugin/plugin.json").version },
-  { label: "CHANGELOG.md (latest_version)", get: () => readChangelogVersion("CHANGELOG.md") },
+const tracks = [
+  {
+    name: "CLI",
+    sources: [
+      { label: "packages/cli/package.json", get: () => readJson("packages/cli/package.json").version },
+      { label: "packages/core/package.json", get: () => readJson("packages/core/package.json").version },
+    ],
+  },
+  {
+    name: "Plugin",
+    sources: [
+      { label: ".claude/plugins/onebrain/.claude-plugin/plugin.json", get: () => readJson(".claude/plugins/onebrain/.claude-plugin/plugin.json").version },
+      { label: "CHANGELOG.md (latest_version)", get: () => readChangelogVersion("CHANGELOG.md") },
+    ],
+  },
 ];
 
-const results = sources.map(({ label, get }) => {
-  try {
-    const version = get();
-    console.log(`  ${label}: ${version}`);
-    return { label, version, error: null };
-  } catch (err) {
-    console.log(`  ${label}: ERROR — ${err.message}`);
-    return { label, version: null, error: err.message };
-  }
-});
+let failed = false;
 
-const versions = results.map((r) => r.version).filter(Boolean);
-const unique = [...new Set(versions)];
-
-if (results.some((r) => r.error)) {
-  console.error("\n✗ Version sync check failed: could not read one or more sources.");
-  process.exit(1);
-}
-
-if (unique.length === 1) {
-  console.log(`\n✓ all versions in sync: ${unique[0]}`);
-  process.exit(0);
-} else {
-  console.error("\n✗ Version mismatch detected:");
-  for (const { label, version } of results) {
-    if (version !== unique[0]) {
-      console.error(`  - ${label} is ${version} (expected ${unique[0]})`);
+for (const track of tracks) {
+  console.log(`\n${track.name} track:`);
+  const results = track.sources.map(({ label, get }) => {
+    try {
+      const version = get();
+      console.log(`  ${label}: ${version}`);
+      return { label, version, error: null };
+    } catch (err) {
+      console.log(`  ${label}: ERROR — ${err.message}`);
+      return { label, version: null, error: err.message };
     }
+  });
+
+  if (results.some((r) => r.error)) {
+    console.error(`  ✗ Could not read one or more sources in ${track.name} track.`);
+    failed = true;
+    continue;
   }
-  process.exit(1);
+
+  const versions = results.map((r) => r.version);
+  const unique = [...new Set(versions)];
+
+  if (unique.length === 1) {
+    console.log(`  ✓ in sync: ${unique[0]}`);
+  } else {
+    console.error(`  ✗ Version mismatch in ${track.name} track:`);
+    const expected = versions[0];
+    for (const { label, version } of results) {
+      if (version !== expected) {
+        console.error(`    - ${label} is ${version} (expected ${expected})`);
+      }
+    }
+    failed = true;
+  }
 }
+
+console.log("");
+process.exit(failed ? 1 : 0);


### PR DESCRIPTION
## Summary

- fix(cli): inject `BUILD_VERSION`/`BUILD_DATE` in npm-publish build step — fixes `onebrain --version` showing `v0.0.0-dev` after `npm install -g`
- chore: sync version to `2.0.1` across `packages/core/package.json` and `plugin.json`
- docs: add v2.0.1 entry to CHANGELOG.md

## Test plan

- [ ] Merge → push tag `v2.0.1` → release workflow passes (build-binaries + npm-publish + create-release)
- [ ] `npm install -g @onebrain-ai/cli` → `onebrain --version` shows `OneBrain v2.0.1`
- [ ] `bun install -g @onebrain-ai/cli` works without workspace dependency error