### PR TITLE
chore(cli): add npm package metadata + bump to v2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,6 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - fix: rename npm package from @onebrain/cli to @onebrain-ai/cli
 - fix(cli): move @onebrain/core to devDependencies — bundled into dist at build time
-- fix(ci): split version-sync check into CLI track and Plugin track
-- fix(release): inject BUILD_VERSION and BUILD_DATE at compile time via --define
 
 ## v2.0.0 — CLI Binary
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-latest_version: 2.0.2
+latest_version: 2.0.0
 released: 2026-04-25
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-latest_version: 2.0.0
+latest_version: 2.0.2
 released: 2026-04-25
 ---
 
@@ -13,6 +13,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 > `/update` tracks plugin version only — CLI updates happen via `npm install -g @onebrain-ai/cli`.
 
 ## [Unreleased]
+
+## v2.0.2 — npm Package Metadata
+
+- chore(cli): add description, keywords, homepage, repository, bugs, and license to package.json
+- chore(cli): npm package page no longer appears empty — searchable via pkm, obsidian, claude keywords
+
+## v2.0.1 — Package Name & Build Fixes
+
+- fix: rename npm package from @onebrain/cli to @onebrain-ai/cli
+- fix(cli): move @onebrain/core to devDependencies — bundled into dist at build time
+- fix(ci): split version-sync check into CLI track and Plugin track
+- fix(release): inject BUILD_VERSION and BUILD_DATE at compile time via --define
 
 ## v2.0.0 — CLI Binary
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -22,9 +22,7 @@
   },
   "bugs": "https://github.com/kengio/onebrain/issues",
   "license": "MIT",
-  "files": [
-    "dist/onebrain"
-  ],
+  "files": ["dist/onebrain"],
   "type": "module",
   "bin": {
     "onebrain": "dist/onebrain"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -22,6 +22,9 @@
   },
   "bugs": "https://github.com/kengio/onebrain/issues",
   "license": "MIT",
+  "files": [
+    "dist/onebrain"
+  ],
   "type": "module",
   "bin": {
     "onebrain": "dist/onebrain"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,27 @@
 {
   "name": "@onebrain-ai/cli",
-  "version": "2.0.1",
+  "version": "2.0.2",
+  "description": "CLI for OneBrain — personal AI OS for Obsidian with persistent memory, 24+ skills, and Claude Code integration",
+  "keywords": [
+    "onebrain",
+    "obsidian",
+    "ai",
+    "cli",
+    "memory",
+    "knowledge-management",
+    "claude",
+    "agent",
+    "pkm",
+    "productivity",
+    "vault"
+  ],
+  "homepage": "https://github.com/kengio/onebrain",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/kengio/onebrain.git"
+  },
+  "bugs": "https://github.com/kengio/onebrain/issues",
+  "license": "MIT",
   "type": "module",
   "bin": {
     "onebrain": "dist/onebrain"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onebrain/core",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "type": "module",
   "main": "src/index.ts",
   "exports": {


### PR DESCRIPTION
## Summary

- Add \`description\`, \`keywords\`, \`homepage\`, \`repository\`, \`bugs\`, \`license\`, and \`files\` to \`packages/cli/package.json\` — npm page was completely empty before this
- Bump CLI track \`2.0.1\` → \`2.0.2\` (both \`packages/cli\` and \`packages/core\`)
- Add missing CHANGELOG entries for \`v2.0.1\` and \`v2.0.2\`

## Details

- **\`files: ["dist/onebrain"]\`** — critical: \`dist/\` is gitignored and no \`.npmignore\` exists; without this npm would publish a broken package with no binary
- **\`packages/core\` bumped to 2.0.2** — CLI track requires cli + core to match
- **\`CHANGELOG.md latest_version\` stays at 2.0.0** — Plugin track: tracks \`plugin.json\` version, not CLI

## Test plan

- [ ] CI passes (biome + version-sync)
- [ ] After merge: tag \`v2.0.2\` → release workflow publishes to npm
- [ ] \`npm view @onebrain-ai/cli\` shows description, keywords, homepage
- [ ] \`npm install -g @onebrain-ai/cli\` and \`onebrain --version\` works