### PR TITLE
docs(cli): add README.md for npm page; bump to v2.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## v2.0.3 — CLI README
+
+- docs(cli): add README.md for npm package page — install instructions, user-facing commands, internal commands, and link to main repo
+
 ## v2.0.2 — npm Package Metadata
 
 - chore(cli): add description, keywords, homepage, repository, bugs, and license to package.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,20 +14,6 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
-## v2.0.3 — CLI README
-
-- docs(cli): add README.md for npm package page — install instructions, user-facing commands, internal commands, and link to main repo
-
-## v2.0.2 — npm Package Metadata
-
-- chore(cli): add description, keywords, homepage, repository, bugs, and license to package.json
-- chore(cli): npm package page no longer appears empty — searchable via pkm, obsidian, claude keywords
-
-## v2.0.1 — Package Name & Build Fixes
-
-- fix: rename npm package from @onebrain/cli to @onebrain-ai/cli
-- fix(cli): move @onebrain/core to devDependencies — bundled into dist at build time
-
 ## v2.0.0 — CLI Binary
 
 - feat: compiled TypeScript binary replaces all bash/Python scripts

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,45 @@
+# @onebrain-ai/cli
+
+The CLI binary for [OneBrain](https://github.com/kengio/onebrain) — a personal AI OS built on Obsidian with persistent memory, 24+ skills, and Claude Code integration.
+
+## Install
+
+```bash
+# with bun (recommended)
+bun install -g @onebrain-ai/cli
+
+# or with npm
+npm install -g @onebrain-ai/cli
+```
+
+Verify: `onebrain --version`
+
+## What it does
+
+The `onebrain` binary handles the low-level operations that keep your vault running:
+
+| Command | Purpose |
+|---------|---------|
+| `onebrain session-init` | Initialize a session — returns datetime, session token, and qmd status |
+| `onebrain orphan-scan` | Detect unmerged checkpoint files from previous sessions |
+| `onebrain checkpoint` | Write a checkpoint file mid-session |
+| `onebrain qmd-reindex` | Rebuild the semantic search index |
+| `onebrain doctor` | Audit vault health — orphans, version drift, missing config |
+| `onebrain init` | First-time vault initialization |
+
+These commands are called automatically by OneBrain's hooks and skills — you don't run them directly.
+
+## Requirements
+
+- macOS, Linux, or Windows (Git Bash)
+- No Python or Node.js required — the binary is self-contained
+
+## OneBrain
+
+OneBrain gives your AI agent persistent memory across sessions, a structured Markdown vault, and 24+ pre-built skills — so every session picks up exactly where the last one left off.
+
+**Full documentation and vault setup:** [github.com/kengio/onebrain](https://github.com/kengio/onebrain)
+
+## License
+
+[MIT](https://github.com/kengio/onebrain/blob/main/LICENSE)

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -16,18 +16,20 @@ Verify: `onebrain --version`
 
 ## What it does
 
-The `onebrain` binary handles the low-level operations that keep your vault running:
+The `onebrain` binary handles the low-level operations that keep your vault running.
+
+**User-facing commands:**
 
 | Command | Purpose |
 |---------|---------|
-| `onebrain session-init` | Initialize a session — returns datetime, session token, and qmd status |
-| `onebrain orphan-scan` | Detect unmerged checkpoint files from previous sessions |
-| `onebrain checkpoint` | Write a checkpoint file mid-session |
-| `onebrain qmd-reindex` | Rebuild the semantic search index |
-| `onebrain doctor` | Audit vault health — orphans, version drift, missing config |
 | `onebrain init` | First-time vault initialization |
+| `onebrain update` | Pull latest plugin files from GitHub |
+| `onebrain doctor` | Audit vault health — orphans, version drift, missing config |
+| `onebrain help` | List all available commands |
 
-These commands are called automatically by OneBrain's hooks and skills — you don't run them directly.
+**Internal commands** (called automatically by Claude Code hooks — not meant to be run directly):
+
+`session-init` · `orphan-scan` · `checkpoint` · `qmd-reindex`
 
 ## Requirements
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -24,17 +24,18 @@ The `onebrain` binary handles the low-level operations that keep your vault runn
 |---------|---------|
 | `onebrain init` | First-time vault initialization |
 | `onebrain update` | Pull latest plugin files from GitHub |
-| `onebrain doctor` | Audit vault health — orphans, version drift, missing config |
+| `onebrain doctor` | Audit vault health — orphan checkpoints, version drift, qmd embedding status, missing config |
 | `onebrain help` | List all available commands |
 
-**Internal commands** (called automatically by Claude Code hooks — not meant to be run directly):
+**Internal commands** (not meant to be run directly):
 
-`session-init` · `orphan-scan` · `checkpoint` · `qmd-reindex`
+`session-init` · `orphan-scan` · `checkpoint` · `qmd-reindex` · `vault-sync` · `register-hooks` · `migrate`
 
 ## Requirements
 
 - macOS, Linux, or Windows (Git Bash)
-- No Python or Node.js required — the binary is self-contained
+- Bun or Node.js required (used as the runtime for the npm package)
+- For a self-contained binary with no runtime dependency, download from [GitHub Releases](https://github.com/kengio/onebrain/releases)
 
 ## OneBrain
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onebrain-ai/cli",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "CLI for OneBrain — personal AI OS for Obsidian with persistent memory, 24+ skills, and Claude Code integration",
   "keywords": [
     "onebrain",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onebrain/core",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "type": "module",
   "main": "src/index.ts",
   "exports": {


### PR DESCRIPTION
## Summary

- Add \`packages/cli/README.md\` — npm page previously showed no README
- Split command table into user-facing (\`init\`, \`update\`, \`doctor\`, \`help\`) and full internal list (\`session-init\`, \`orphan-scan\`, \`checkpoint\`, \`qmd-reindex\`, \`vault-sync\`, \`register-hooks\`, \`migrate\`)
- Bump CLI track \`2.0.2\` → \`2.0.3\` (cli + core) — required to publish updated README to npm
- Remove CLI entries from CHANGELOG.md — CHANGELOG tracks Plugin track only; CLI releases tracked via GitHub Releases and npm

## Notes

- \`README.md\` is auto-included by npm even with an explicit \`files\` field — no change to \`files\` needed
- \`latest_version\` in CHANGELOG frontmatter stays at \`2.0.0\` (tracks plugin.json, not CLI)
- Requirements section clarified — npm install requires Bun or Node; self-contained binaries on GitHub Releases

## Test plan

- [ ] CI passes (biome + version-sync)
- [ ] After merge: tag \`v2.0.3\` → release workflow publishes to npm
- [ ] npmjs.com page shows README with install instructions and command table