### PR TITLE
fix(wrapup): session numbering counts only today's sessions; bump to v2.0.1

### DIFF
--- a/.claude/plugins/onebrain/.claude-plugin/plugin.json
+++ b/.claude/plugins/onebrain/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "onebrain",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "OneBrain — Where human and AI thinking become one. A powerful thinking partner powered by AI synergy.",
   "author": {
     "name": "OneBrain Contributors"

--- a/.claude/plugins/onebrain/skills/wrapup/SKILL.md
+++ b/.claude/plugins/onebrain/skills/wrapup/SKILL.md
@@ -139,8 +139,8 @@ auto-recovered: true
 
 ## Step 2: Determine Session File Name
 
-1. Using the date from Step 1, extract `YYYY` and `MM` (zero-padded month).
-2. List files in `[logs_folder]/YYYY/MM/` matching `YYYY-MM-DD-session-*.md`
+1. Using the date from Step 1, extract `YYYY`, `MM` (zero-padded month), and `DD` (zero-padded day).
+2. List files in `[logs_folder]/YYYY/MM/` matching **`YYYY-MM-DD-session-*.md`** — use today's actual date as a literal prefix (e.g. `2026-04-25-session-*.md`), not as a wildcard. Only count sessions from today.
 3. The next session number = count of matches + 1 (zero-padded to 2 digits: 01, 02, etc.)
 4. Verify `YYYY-MM-DD-session-NN.md` does not already exist before writing; if it does, increment NN until a free slot is found.
 5. File name: `[logs_folder]/YYYY/MM/YYYY-MM-DD-session-NN.md`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-latest_version: 2.0.0
+latest_version: 2.0.1
 released: 2026-04-25
 ---
 
@@ -13,6 +13,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 > `/update` tracks plugin version only — CLI updates happen via `npm install -g @onebrain-ai/cli`.
 
 ## [Unreleased]
+
+## v2.0.1 — Fix: /wrapup session numbering
+
+- fix(wrapup): Step 2 glob now requires today's date as a literal prefix — prevents counting all sessions in the month when determining session number for the current day
 
 ## v2.0.0 — CLI Binary
 


### PR DESCRIPTION
## Summary

- Fix `/wrapup` Step 2: session number was calculated by counting **all** sessions in the month folder instead of only today's sessions — causing `session-87` to be written instead of `session-03`
- Root cause: `YYYY-MM-DD-session-*.md` glob pattern was ambiguous — agents treated `YYYY-MM-DD` as a wildcard rather than today's literal date
- Bump plugin to `v2.0.1`

## Fix

Step 2 now explicitly states the date must be substituted as a literal prefix with a concrete example, and "Only count sessions from today" is added as a final clarifying sentence.

## Test plan

- [ ] CI passes
- [ ] After merge: run \`/update\` to sync vault
- [ ] Next \`/wrapup\` produces correct session number (e.g. session-01, session-02) based on today's sessions only