### PR TITLE
fix: backfill-recapped cutoff + checkpoint postcompact NN advancement (v2.0.3)

### DIFF
--- a/.claude/plugins/onebrain/.claude-plugin/plugin.json
+++ b/.claude/plugins/onebrain/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "onebrain",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "OneBrain — Where human and AI thinking become one. A powerful thinking partner powered by AI synergy.",
   "author": {
     "name": "OneBrain Contributors"

--- a/.claude/plugins/onebrain/skills/update/references/migration-steps.md
+++ b/.claude/plugins/onebrain/skills/update/references/migration-steps.md
@@ -93,8 +93,9 @@ Always: update `updated:` frontmatter to today.
 
 **Step 6: Backfill recapped: on existing session logs**
 - **Skip if:** `[logs_folder]/` does not exist
-- Run `bash ".claude/plugins/onebrain/skills/update/scripts/backfill-recapped.sh" "[logs_folder]"` — adds `recapped: YYYY-MM-DD` to session logs that don't have it; idempotent
-- **Note:** This marks all pre-migration logs as recapped so /recap does not reprocess them. Historical patterns were already in MEMORY.md Key Learnings (now migrated to memory/ in Step 1). If the user wishes to retroactively promote insights from a specific old log, they can clear its `recapped:` field before running /recap.
+- Read `stats.last_recap` from vault.yml (may be absent — treat as empty string if missing)
+- Run `bash ".claude/plugins/onebrain/skills/update/scripts/backfill-recapped.sh" "[logs_folder]" "[last_recap]"` — adds `recapped: YYYY-MM-DD` to session logs that don't have it; skips logs newer than `[last_recap]` if provided; idempotent
+- **Note:** The cutoff prevents /update from incorrectly marking recent sessions as recapped. Only logs on or before the last recap date are marked — newer sessions remain available for /recap to process.
 
 **Step 7: Register OneBrain hooks in `[vault]/.claude/settings.json`**
 

--- a/.claude/plugins/onebrain/skills/update/references/migration-steps.md
+++ b/.claude/plugins/onebrain/skills/update/references/migration-steps.md
@@ -93,7 +93,7 @@ Always: update `updated:` frontmatter to today.
 
 **Step 6: Backfill recapped: on existing session logs**
 - **Skip if:** `[logs_folder]/` does not exist
-- Read `stats.last_recap` from vault.yml (may be absent — treat as empty string if missing)
+- Read `stats.last_recap` from vault.yml (may be absent — treat as empty string if missing). To extract: read vault.yml, navigate to `stats.last_recap`; if the `stats:` block or `last_recap:` key is absent, use `""`.
 - Run `bash ".claude/plugins/onebrain/skills/update/scripts/backfill-recapped.sh" "[logs_folder]" "[last_recap]"` — adds `recapped: YYYY-MM-DD` to session logs that don't have it; skips logs newer than `[last_recap]` if provided; idempotent
 - **Note:** The cutoff prevents /update from incorrectly marking recent sessions as recapped. Only logs on or before the last recap date are marked — newer sessions remain available for /recap to process.
 

--- a/.claude/plugins/onebrain/skills/update/scripts/backfill-recapped.sh
+++ b/.claude/plugins/onebrain/skills/update/scripts/backfill-recapped.sh
@@ -19,7 +19,7 @@ count=0
 while IFS= read -r -d '' file; do
     grep -q "^recapped:" "$file" 2>/dev/null && continue
 
-    date_val=$(grep "^date:" "$file" 2>/dev/null | head -1 | sed 's/date:[[:space:]]*//' | tr -d '\r\n')
+    date_val=$(grep "^date:" "$file" 2>/dev/null | head -1 | sed 's/date:[[:space:]]*//' | tr -d '\r\n ')
     [ -z "$date_val" ] && date_val=$(basename "$file" | grep -oE '^[0-9]{4}-[0-9]{2}-[0-9]{2}' || true)
     [ -z "$date_val" ] && continue
 

--- a/.claude/plugins/onebrain/skills/update/scripts/backfill-recapped.sh
+++ b/.claude/plugins/onebrain/skills/update/scripts/backfill-recapped.sh
@@ -1,11 +1,14 @@
 #!/usr/bin/env bash
-# backfill-recapped.sh <logs_folder>
+# backfill-recapped.sh <logs_folder> [cutoff_date]
 # Adds recapped: <date> to session logs that don't have it.
-# Used once during migration — idempotent (skips files already having recapped:).
+# cutoff_date (YYYY-MM-DD): only mark logs on or before this date.
+# If absent, marks all logs (initial migration scenario).
+# Idempotent — skips files already having recapped:.
 
 set -euo pipefail
 
-logs="${1:?Usage: backfill-recapped.sh <logs_folder>}"
+logs="${1:?Usage: backfill-recapped.sh <logs_folder> [cutoff_date]}"
+cutoff="${2:-}"
 
 if [ ! -d "$logs" ]; then
   echo "backfill-recapped: no logs folder, skipping"
@@ -19,6 +22,9 @@ while IFS= read -r -d '' file; do
     date_val=$(grep "^date:" "$file" 2>/dev/null | head -1 | sed 's/date:[[:space:]]*//')
     [ -z "$date_val" ] && date_val=$(basename "$file" | grep -oE '^[0-9]{4}-[0-9]{2}-[0-9]{2}' || true)
     [ -z "$date_val" ] && continue
+
+    # Skip logs newer than cutoff (string comparison works for YYYY-MM-DD)
+    [ -n "$cutoff" ] && [[ "$date_val" > "$cutoff" ]] && continue
 
     # Insert recapped: after the date: line (portable: avoid sed -i '' macOS-only syntax)
     if grep -q "^date:" "$file"; then

--- a/.claude/plugins/onebrain/skills/update/scripts/backfill-recapped.sh
+++ b/.claude/plugins/onebrain/skills/update/scripts/backfill-recapped.sh
@@ -19,18 +19,17 @@ count=0
 while IFS= read -r -d '' file; do
     grep -q "^recapped:" "$file" 2>/dev/null && continue
 
-    date_val=$(grep "^date:" "$file" 2>/dev/null | head -1 | sed 's/date:[[:space:]]*//')
+    date_val=$(grep "^date:" "$file" 2>/dev/null | head -1 | sed 's/date:[[:space:]]*//' | tr -d '\r\n')
     [ -z "$date_val" ] && date_val=$(basename "$file" | grep -oE '^[0-9]{4}-[0-9]{2}-[0-9]{2}' || true)
     [ -z "$date_val" ] && continue
 
     # Skip logs newer than cutoff (string comparison works for YYYY-MM-DD)
     [ -n "$cutoff" ] && [[ "$date_val" > "$cutoff" ]] && continue
 
-    # Insert recapped: after the date: line (portable: avoid sed -i '' macOS-only syntax)
+    # Insert recapped: after the date: line (awk: portable across BSD/GNU; no blank-line issue)
     if grep -q "^date:" "$file"; then
         tmp=$(mktemp)
-        sed "/^date:/a\\
-recapped: ${date_val}" "$file" > "$tmp" && mv "$tmp" "$file"
+        awk -v recap="recapped: ${date_val}" '/^date:/{print; print recap; next}1' "$file" > "$tmp" && mv "$tmp" "$file"
         count=$((count + 1))
     fi
 done < <(find "$logs" -name "*-session-*.md" -print0 2>/dev/null)

--- a/.claude/plugins/onebrain/skills/update/scripts/backfill-recapped.sh
+++ b/.claude/plugins/onebrain/skills/update/scripts/backfill-recapped.sh
@@ -29,7 +29,7 @@ while IFS= read -r -d '' file; do
     # Insert recapped: after the date: line (awk: portable across BSD/GNU; no blank-line issue)
     if grep -q "^date:" "$file"; then
         tmp=$(mktemp)
-        awk -v recap="recapped: ${date_val}" '/^date:/{print; print recap; next}1' "$file" > "$tmp" && mv "$tmp" "$file"
+        awk -v recap="recapped: ${date_val}" 'done{print;next} /^date:/{print;print recap;done=1;next}1' "$file" > "$tmp" && mv "$tmp" "$file"
         count=$((count + 1))
     fi
 done < <(find "$logs" -name "*-session-*.md" -print0 2>/dev/null)

--- a/.claude/plugins/onebrain/skills/wrapup/SKILL.md
+++ b/.claude/plugins/onebrain/skills/wrapup/SKILL.md
@@ -212,7 +212,7 @@ After writing the session log, reset the checkpoint hook counter to prevent spur
 bash ".claude/plugins/onebrain/skills/wrapup/scripts/reset-checkpoint-counter.sh"
 ```
 
-This writes `0:<epoch>` into the session state file, triggering a 60-second skip window and resetting the message counter.
+This writes `0:<epoch>:00` into the session state file, triggering a 60-second skip window and resetting the message counter.
 
 ---
 

--- a/.claude/plugins/onebrain/skills/wrapup/scripts/reset-checkpoint-counter.sh
+++ b/.claude/plugins/onebrain/skills/wrapup/scripts/reset-checkpoint-counter.sh
@@ -18,4 +18,4 @@ else
   _token=$(cat "$_f" 2>/dev/null || echo '99999')
 fi
 
-[ -n "${_token:-}" ] && echo "0:$(date +%s)" > "${tmpdir_safe}/onebrain-${_token}.state" 2>/dev/null
+[ -n "${_token:-}" ] && echo "0:$(date +%s):00" > "${tmpdir_safe}/onebrain-${_token}.state" 2>/dev/null

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - fix(checkpoint): derive checkpoint NN from disk scan (`maxCheckpointNnSync`) in both stop and precompact hooks — guarantees sequential numbering even when Claude fails to write a file
 - fix(checkpoint): `handlePostcompact` writes `last_ts=now` so precompact recency guard blocks re-fire within 5 minutes after a compact cycle; prevents stub overwrite on back-to-back compacts
 - fix(checkpoint): `handlePrecompact` double-compact guard — returns early if `pending_stub` already set, preventing orphaned stubs on consecutive compact events
+- fix(checkpoint): `handleStop` preserves `pending_stub` in state write — was clearing it with a 3-field write, causing postcompact to miss the stub when stop fires before compact
+- fix(checkpoint): `postcompactFallback` — disk scans for unmerged `trigger: precompact` stubs when state has no `pending_stub` (e.g. state lost or expired); called from `checkpointCommand` dispatch
 - fix(checkpoint): `loadVaultSettings` regex strips surrounding quotes from `logs:` folder value — was capturing literal quote characters as part of the path
 - fix(wrapup): `reset-checkpoint-counter.sh` writes 3-field state (`0:<epoch>:00`) — was writing 2-field (v1 format) which bypassed the 60-second skip window after /wrapup; fix stale comment in SKILL.md
 - fix(update): `backfill-recapped.sh` accepts optional `[cutoff_date]` arg; migration Step 6 reads `stats.last_recap` from vault.yml and passes it as cutoff — prevents /update from re-marking recent sessions on every run

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - fix(checkpoint): `handlePostcompact` writes `last_ts=now` so precompact recency guard blocks re-fire within 5 minutes after a compact cycle; prevents stub overwrite on back-to-back compacts
 - fix(checkpoint): `handlePrecompact` double-compact guard — returns early if `pending_stub` already set, preventing orphaned stubs on consecutive compact events
 - fix(checkpoint): `handleStop` preserves `pending_stub` in state write — was clearing it with a 3-field write, causing postcompact to miss the stub when stop fires before compact
-- fix(checkpoint): `postcompactFallback` — disk scans for unmerged `trigger: precompact` stubs when state has no `pending_stub` (e.g. state lost or expired); called from `checkpointCommand` dispatch
+- fix(checkpoint): `postcompactFallback` — disk scans for unmerged `trigger: precompact` stubs when state has no `pending_stub` (e.g. state lost or expired); `handlePostcompact` and `postcompactFallback` both derive `since` predecessor from disk scan (not arithmetic) — correct even when there are gaps in checkpoint numbering
 - fix(checkpoint): `loadVaultSettings` regex strips surrounding quotes from `logs:` folder value — was capturing literal quote characters as part of the path
 - fix(wrapup): `reset-checkpoint-counter.sh` writes 3-field state (`0:<epoch>:00`) — was writing 2-field (v1 format) which bypassed the 60-second skip window after /wrapup; fix stale comment in SKILL.md
 - fix(update): `backfill-recapped.sh` accepts optional `[cutoff_date]` arg; migration Step 6 reads `stats.last_recap` from vault.yml and passes it as cutoff — prevents /update from re-marking recent sessions on every run

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-latest_version: 2.0.2
+latest_version: 2.0.3
 released: 2026-04-25
 ---
 
@@ -13,6 +13,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 > `/update` tracks plugin version only — CLI updates happen via `npm install -g @onebrain-ai/cli`.
 
 ## [Unreleased]
+
+## v2.0.3 — Fix: checkpoint numbering + backfill-recapped cutoff
+
+- fix(checkpoint): `handlePostcompact` now advances `last_stop_nn` to the stub's NN after emitting fill-checkpoint block — prevents subsequent stop hooks from reusing the same NN and overwriting the filled stub
+- fix(wrapup): `reset-checkpoint-counter.sh` writes 3-field state (`0:<epoch>:00`) — was writing 2-field (v1 format) which bypassed the 60-second skip window after /wrapup
+- fix(update): `backfill-recapped.sh` accepts optional `[cutoff_date]` arg; migration Step 6 reads `stats.last_recap` from vault.yml and passes it as cutoff — prevents /update from re-marking recent sessions on every run
 
 ## v2.0.2 — Fix: complete hook migration to CLI
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## v2.0.3 — Fix: checkpoint numbering + backfill-recapped cutoff
 
-- fix(checkpoint): `handlePostcompact` now advances `last_stop_nn` to the stub's NN after emitting fill-checkpoint block — prevents subsequent stop hooks from reusing the same NN and overwriting the filled stub
-- fix(wrapup): `reset-checkpoint-counter.sh` writes 3-field state (`0:<epoch>:00`) — was writing 2-field (v1 format) which bypassed the 60-second skip window after /wrapup
+- fix(checkpoint): derive checkpoint NN from disk scan (`maxCheckpointNnSync`) in both stop and precompact hooks — guarantees sequential numbering even when Claude fails to write a file
+- fix(checkpoint): `handlePostcompact` writes `last_ts=now` so precompact recency guard blocks re-fire within 5 minutes after a compact cycle; prevents stub overwrite on back-to-back compacts
+- fix(checkpoint): `handlePrecompact` double-compact guard — returns early if `pending_stub` already set, preventing orphaned stubs on consecutive compact events
+- fix(checkpoint): `loadVaultSettings` regex strips surrounding quotes from `logs:` folder value — was capturing literal quote characters as part of the path
+- fix(wrapup): `reset-checkpoint-counter.sh` writes 3-field state (`0:<epoch>:00`) — was writing 2-field (v1 format) which bypassed the 60-second skip window after /wrapup; fix stale comment in SKILL.md
 - fix(update): `backfill-recapped.sh` accepts optional `[cutoff_date]` arg; migration Step 6 reads `stats.last_recap` from vault.yml and passes it as cutoff — prevents /update from re-marking recent sessions on every run
 
 ## v2.0.2 — Fix: complete hook migration to CLI

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onebrain-ai/cli",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "CLI for OneBrain — personal AI OS for Obsidian with persistent memory, 24+ skills, and Claude Code integration",
   "keywords": [
     "onebrain",

--- a/packages/cli/src/internal/checkpoint.test.ts
+++ b/packages/cli/src/internal/checkpoint.test.ts
@@ -208,6 +208,15 @@ describe('handleReset', () => {
     const out = cap.stop();
     expect(out).toBe('');
   });
+
+  it('clears pending_stub from 4-field state', async () => {
+    writeState(TOKEN, { count: 3, last_ts: 999, last_stop_nn: '02', pending_stub: 'some-checkpoint.md' }, tmpDir);
+    handleReset(TOKEN, 1700000000, tmpDir);
+    const raw = await readStateRaw(tmpDir, TOKEN);
+    expect(raw).toBe('0:1700000000:00');
+    const state = readState(TOKEN, tmpDir);
+    expect(state.pending_stub).toBeUndefined();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/cli/src/internal/checkpoint.test.ts
+++ b/packages/cli/src/internal/checkpoint.test.ts
@@ -409,6 +409,22 @@ describe('handleStop', () => {
     expect(state.last_stop_nn).toBe('02');
   });
 
+  it('preserves pending_stub when stop fires while precompact stub is waiting for postcompact', async () => {
+    const now = 1700001000;
+    const stubFile = '2023-11-14-41928-checkpoint-03.md';
+    // State has pending_stub set (precompact wrote stub, postcompact hasn't run yet)
+    await createCheckpointFile(vaultDir, now, TOKEN, 3);
+    writeState(TOKEN, { count: 4, last_ts: now - 10, last_stop_nn: '03', pending_stub: stubFile }, tmpDir);
+
+    const cap = captureStdout();
+    handleStop(TOKEN, vaultDir, now, tmpDir);
+    cap.stop();
+
+    const state = readState(TOKEN, tmpDir);
+    // pending_stub must survive so postcompact can still fill stub-03
+    expect(state.pending_stub).toBe(stubFile);
+  });
+
   it('elapsed calc: last_ts=0 → elapsed=0, never triggers time threshold alone', () => {
     const now = 1700001000;
     // last_ts=0 sentinel (post-compact), count=1 (below min_activity)

--- a/packages/cli/src/internal/checkpoint.test.ts
+++ b/packages/cli/src/internal/checkpoint.test.ts
@@ -954,6 +954,7 @@ describe('postcompactFallback', () => {
   });
 
   it('unmerged precompact stub found → emits fill-checkpoint, writes state', async () => {
+    await writeStubFile('01', 'stop', 'true'); // prior merged checkpoint on disk
     await writeStubFile('02', 'precompact', false);
     writeState(TOKEN, { count: 0, last_ts: 0, last_stop_nn: '01' }, tmpDir);
     const cap = captureStdout();
@@ -993,7 +994,8 @@ describe('postcompactFallback', () => {
     postcompactFallback(TOKEN, vaultDir, now, tmpDir);
     const out = cap.stop();
     const parsed = JSON.parse(out.trim());
-    expect(parsed.reason).toMatch(/checkpoint-03\.md since checkpoint-02$/);
+    // predecessor derived from disk: stub-01 is highest NN < 03
+    expect(parsed.reason).toMatch(/checkpoint-03\.md since checkpoint-01$/);
   });
 
   it('first stub (NN=01) → since reference is "start"', async () => {
@@ -1004,6 +1006,29 @@ describe('postcompactFallback', () => {
     const out = cap.stop();
     const parsed = JSON.parse(out.trim());
     expect(parsed.reason).toMatch(/since start$/);
+  });
+
+  it('gap in checkpoint numbering → predecessor derived from disk, not arithmetic', async () => {
+    // checkpoint-03 was never written by Claude; stop-triggered -04 exists; stub is -05
+    await writeStubFile('04', 'stop', 'true'); // merged stop checkpoint
+    await writeStubFile('05', 'precompact', false); // unmerged precompact stub
+    writeState(TOKEN, { count: 0, last_ts: 0, last_stop_nn: '04' }, tmpDir);
+    const cap = captureStdout();
+    postcompactFallback(TOKEN, vaultDir, now, tmpDir);
+    const out = cap.stop();
+    const parsed = JSON.parse(out.trim());
+    // arithmetic would say checkpoint-04; disk scan correctly finds checkpoint-04 as predecessor
+    expect(parsed.reason).toMatch(/checkpoint-05\.md since checkpoint-04$/);
+  });
+
+  it('pending_stub in state → delegates to handlePostcompact, not disk scan', async () => {
+    const stubFilename = `${date}-${TOKEN}-checkpoint-02.md`;
+    writeState(TOKEN, { count: 0, last_ts: 0, last_stop_nn: '01', pending_stub: stubFilename }, tmpDir);
+    const cap = captureStdout();
+    postcompactFallback(TOKEN, vaultDir, now, tmpDir);
+    const out = cap.stop();
+    const parsed = JSON.parse(out.trim());
+    expect(parsed.reason).toMatch(/fill-checkpoint:.*checkpoint-02\.md since checkpoint-01$/);
   });
 });
 

--- a/packages/cli/src/internal/checkpoint.test.ts
+++ b/packages/cli/src/internal/checkpoint.test.ts
@@ -714,33 +714,43 @@ describe('handlePrecompact', () => {
 
 describe('handlePostcompact', () => {
   let tmpDir: string;
+  let vaultDir: string;
+  // Use date consistent with now=1700001000 (2023-11-14) so disk paths align
+  const now = 1700001000;
+  const stubDate = '2023-11-14';
+  const logsDir = () => join(vaultDir, '07-logs', '2023', '11');
 
   beforeEach(async () => {
     tmpDir = await makeTmpDir();
+    vaultDir = await makeTmpDir();
+    await writeFile(join(vaultDir, 'vault.yml'), VALID_VAULT_YML, 'utf8');
   });
   afterEach(async () => {
     await rm(tmpDir, { recursive: true, force: true });
+    await rm(vaultDir, { recursive: true, force: true });
   });
 
+  async function writeCheckpointOnDisk(nn: string) {
+    await mkdir(logsDir(), { recursive: true });
+    await writeFile(join(logsDir(), `${stubDate}-${TOKEN}-checkpoint-${nn}.md`), `---\ntrigger: stop\nmerged: false\n---\n`, 'utf8');
+  }
+
   it('no pending stub (3-field state) → preserve last_ts, write 3-field, no stdout', async () => {
-    const now = 1700001000;
     const ts = 1699999000;
     writeState(TOKEN, { count: 2, last_ts: ts, last_stop_nn: '02' }, tmpDir);
 
     const cap = captureStdout();
-    handlePostcompact(TOKEN, now, tmpDir);
+    handlePostcompact(TOKEN, vaultDir, now, tmpDir);
     const out = cap.stop();
 
     expect(out).toBe('');
     const raw = await readStateRaw(tmpDir, TOKEN);
-    // 3-field, last_ts preserved
     expect(raw).toBe(`0:${ts}:02`);
   });
 
   it('no state file → write 3-field with last_ts=0, no stdout', () => {
-    const now = 1700001000;
     const cap = captureStdout();
-    handlePostcompact(TOKEN, now, tmpDir);
+    handlePostcompact(TOKEN, vaultDir, now, tmpDir);
     const out = cap.stop();
     expect(out).toBe('');
     const state = readState(TOKEN, tmpDir);
@@ -749,21 +759,12 @@ describe('handlePostcompact', () => {
   });
 
   it('pending stub found → emit fill-checkpoint block, clear pending_stub, last_ts=now', async () => {
-    const now = 1700001000;
     const ts = 1699999000;
-    writeState(
-      TOKEN,
-      {
-        count: 0,
-        last_ts: ts,
-        last_stop_nn: '02',
-        pending_stub: '2026-04-23-41928-checkpoint-03.md',
-      },
-      tmpDir,
-    );
+    await writeCheckpointOnDisk('02'); // predecessor on disk
+    writeState(TOKEN, { count: 0, last_ts: ts, last_stop_nn: '02', pending_stub: `${stubDate}-${TOKEN}-checkpoint-03.md` }, tmpDir);
 
     const cap = captureStdout();
-    handlePostcompact(TOKEN, now, tmpDir);
+    handlePostcompact(TOKEN, vaultDir, now, tmpDir);
     const out = cap.stop();
 
     const parsed = JSON.parse(out.trim());
@@ -772,26 +773,15 @@ describe('handlePostcompact', () => {
     expect(parsed.reason).toContain('checkpoint-03.md');
     expect(parsed.reason).toMatch(/since checkpoint-02$/);
 
-    // State cleared: last_ts=now (protects recency guard), last_stop_nn advanced to stubNn (03)
     const raw = await readStateRaw(tmpDir, TOKEN);
     expect(raw).toBe(`0:${now}:03`);
   });
 
-  it('"since start" format when last_stop_nn="00" → advances last_stop_nn to 01', async () => {
-    const now = 1700001000;
-    writeState(
-      TOKEN,
-      {
-        count: 0,
-        last_ts: 1699999000,
-        last_stop_nn: '00',
-        pending_stub: '2026-04-23-41928-checkpoint-01.md',
-      },
-      tmpDir,
-    );
+  it('"since start" format when no predecessor on disk → advances last_stop_nn to 01', async () => {
+    writeState(TOKEN, { count: 0, last_ts: 1699999000, last_stop_nn: '00', pending_stub: `${stubDate}-${TOKEN}-checkpoint-01.md` }, tmpDir);
 
     const cap = captureStdout();
-    handlePostcompact(TOKEN, now, tmpDir);
+    handlePostcompact(TOKEN, vaultDir, now, tmpDir);
     const out = cap.stop();
 
     const parsed = JSON.parse(out.trim());
@@ -800,21 +790,12 @@ describe('handlePostcompact', () => {
     expect(raw).toBe(`0:${now}:01`);
   });
 
-  it('"since checkpoint-NN" format when last_stop_nn non-zero → advances last_stop_nn to 04', async () => {
-    const now = 1700001000;
-    writeState(
-      TOKEN,
-      {
-        count: 0,
-        last_ts: 1699999000,
-        last_stop_nn: '03',
-        pending_stub: '2026-04-23-41928-checkpoint-04.md',
-      },
-      tmpDir,
-    );
+  it('"since checkpoint-NN" format → predecessor derived from disk, not arithmetic', async () => {
+    await writeCheckpointOnDisk('03'); // predecessor on disk
+    writeState(TOKEN, { count: 0, last_ts: 1699999000, last_stop_nn: '03', pending_stub: `${stubDate}-${TOKEN}-checkpoint-04.md` }, tmpDir);
 
     const cap = captureStdout();
-    handlePostcompact(TOKEN, now, tmpDir);
+    handlePostcompact(TOKEN, vaultDir, now, tmpDir);
     const out = cap.stop();
 
     const parsed = JSON.parse(out.trim());
@@ -823,21 +804,24 @@ describe('handlePostcompact', () => {
     expect(raw).toBe(`0:${now}:04`);
   });
 
-  it('missing stub file on disk → still emit fill-checkpoint (Claude creates it)', () => {
-    // Stub filename referenced in state but no actual file on disk
-    writeState(
-      TOKEN,
-      {
-        count: 0,
-        last_ts: 1699999000,
-        last_stop_nn: '01',
-        pending_stub: 'nonexistent-checkpoint-02.md',
-      },
-      tmpDir,
-    );
+  it('gap in disk: stub is checkpoint-04 but only checkpoint-02 exists → since checkpoint-02', async () => {
+    await writeCheckpointOnDisk('02'); // checkpoint-03 was never written
+    writeState(TOKEN, { count: 0, last_ts: 1699999000, last_stop_nn: '02', pending_stub: `${stubDate}-${TOKEN}-checkpoint-04.md` }, tmpDir);
 
     const cap = captureStdout();
-    handlePostcompact(TOKEN, 1700001000, tmpDir);
+    handlePostcompact(TOKEN, vaultDir, now, tmpDir);
+    const out = cap.stop();
+
+    const parsed = JSON.parse(out.trim());
+    // arithmetic would say checkpoint-03 (which doesn't exist); disk scan correctly says checkpoint-02
+    expect(parsed.reason).toMatch(/since checkpoint-02$/);
+  });
+
+  it('missing stub file on disk → still emit fill-checkpoint (Claude creates it)', () => {
+    writeState(TOKEN, { count: 0, last_ts: 1699999000, last_stop_nn: '01', pending_stub: `${stubDate}-${TOKEN}-checkpoint-02.md` }, tmpDir);
+
+    const cap = captureStdout();
+    handlePostcompact(TOKEN, vaultDir, now, tmpDir);
     const out = cap.stop();
 
     const parsed = JSON.parse(out.trim());
@@ -846,66 +830,45 @@ describe('handlePostcompact', () => {
   });
 
   it('4-field state with empty pending_stub → treat as no pending stub', async () => {
-    // Manually write edge case: 4-field with empty 4th
     await writeFile(stateFile(tmpDir, TOKEN), '0:1699999000:02:', 'utf8');
 
     const cap = captureStdout();
-    handlePostcompact(TOKEN, 1700001000, tmpDir);
+    handlePostcompact(TOKEN, vaultDir, now, tmpDir);
     const out = cap.stop();
 
     expect(out).toBe('');
   });
 
   it('pending_stub NN inconsistent with last_stop_nn → uses NN from filename (authoritative)', async () => {
-    // State corruption: last_stop_nn says 02 but stub filename says checkpoint-04
-    writeState(
-      TOKEN,
-      {
-        count: 0,
-        last_ts: 1699999000,
-        last_stop_nn: '02',
-        pending_stub: '2026-04-23-41928-checkpoint-04.md',
-      },
-      tmpDir,
-    );
+    writeState(TOKEN, { count: 0, last_ts: 1699999000, last_stop_nn: '02', pending_stub: `${stubDate}-${TOKEN}-checkpoint-04.md` }, tmpDir);
 
     const cap = captureStdout();
-    handlePostcompact(TOKEN, 1700001000, tmpDir);
+    handlePostcompact(TOKEN, vaultDir, now, tmpDir);
     cap.stop();
 
-    // Filename wins: last_stop_nn advances to 04 (from filename), not 03 (from last_stop_nn+1)
-    const now = 1700001000;
     const raw = await readStateRaw(tmpDir, TOKEN);
     expect(raw).toBe(`0:${now}:04`);
   });
 
   it('postcompact last_ts=now blocks precompact re-fire within 5 min', async () => {
-    // Postcompact sets last_ts=now; immediate second precompact must be blocked by recency guard
-    const now = 1700001000;
-    const vaultDir = await makeTmpDir();
-    await writeFile(join(vaultDir, 'vault.yml'), VALID_VAULT_YML, 'utf8');
-    try {
-      writeState(TOKEN, { count: 0, last_ts: 1699999000, last_stop_nn: '01', pending_stub: '2023-11-14-41928-checkpoint-02.md' }, tmpDir);
+    writeState(TOKEN, { count: 0, last_ts: 1699999000, last_stop_nn: '01', pending_stub: `${stubDate}-${TOKEN}-checkpoint-02.md` }, tmpDir);
 
-      const cap = captureStdout();
-      handlePostcompact(TOKEN, now, tmpDir);
-      cap.stop();
+    const cap = captureStdout();
+    handlePostcompact(TOKEN, vaultDir, now, tmpDir);
+    cap.stop();
 
-      const stateAfterPost = readState(TOKEN, tmpDir);
-      expect(stateAfterPost.last_ts).toBe(now);
-      expect(stateAfterPost.pending_stub).toBeUndefined();
+    const stateAfterPost = readState(TOKEN, tmpDir);
+    expect(stateAfterPost.last_ts).toBe(now);
+    expect(stateAfterPost.pending_stub).toBeUndefined();
 
-      // Precompact fires 30s later (within PRECOMPACT_RECENCY=300s) — must be no-op
-      const cap2 = captureStdout();
-      await handlePrecompact(TOKEN, vaultDir, now + 30, tmpDir);
-      const out2 = cap2.stop();
+    // Precompact fires 30s later (within PRECOMPACT_RECENCY=300s) — must be no-op
+    const cap2 = captureStdout();
+    await handlePrecompact(TOKEN, vaultDir, now + 30, tmpDir);
+    const out2 = cap2.stop();
 
-      expect(out2).toBe('');
-      const stateAfterPre = readState(TOKEN, tmpDir);
-      expect(stateAfterPre.pending_stub).toBeUndefined();
-    } finally {
-      await rm(vaultDir, { recursive: true, force: true });
-    }
+    expect(out2).toBe('');
+    const stateAfterPre = readState(TOKEN, tmpDir);
+    expect(stateAfterPre.pending_stub).toBeUndefined();
   });
 });
 
@@ -1023,12 +986,18 @@ describe('postcompactFallback', () => {
 
   it('pending_stub in state → delegates to handlePostcompact, not disk scan', async () => {
     const stubFilename = `${date}-${TOKEN}-checkpoint-02.md`;
+    await writeStubFile('01', 'stop', 'true'); // predecessor on disk
     writeState(TOKEN, { count: 0, last_ts: 0, last_stop_nn: '01', pending_stub: stubFilename }, tmpDir);
     const cap = captureStdout();
     postcompactFallback(TOKEN, vaultDir, now, tmpDir);
     const out = cap.stop();
     const parsed = JSON.parse(out.trim());
     expect(parsed.reason).toMatch(/fill-checkpoint:.*checkpoint-02\.md since checkpoint-01$/);
+    // State must be cleared: pending_stub gone, last_ts=now
+    const state = readState(TOKEN, tmpDir);
+    expect(state.pending_stub).toBeUndefined();
+    expect(state.last_ts).toBe(now);
+    expect(state.last_stop_nn).toBe('02');
   });
 });
 

--- a/packages/cli/src/internal/checkpoint.test.ts
+++ b/packages/cli/src/internal/checkpoint.test.ts
@@ -12,6 +12,7 @@ import {
   handleReset,
   handleStop,
   maxCheckpointNnSync,
+  postcompactFallback,
   readState,
   writeState,
 } from './checkpoint.js';
@@ -905,6 +906,104 @@ describe('handlePostcompact', () => {
     } finally {
       await rm(vaultDir, { recursive: true, force: true });
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// postcompactFallback
+// ---------------------------------------------------------------------------
+
+describe('postcompactFallback', () => {
+  let tmpDir: string;
+  let vaultDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await makeTmpDir();
+    vaultDir = await makeTmpDir();
+    await mkdir(join(vaultDir, 'vault.yml', '..'), { recursive: true });
+  });
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+    await rm(vaultDir, { recursive: true, force: true });
+  });
+
+  const now = 1700002000;
+  const date = '2023-11-14';
+  const logsDir = () => join(vaultDir, '07-logs', '2023', '11');
+
+  async function writeStubFile(nn: string, trigger: string, merged: string | false = false) {
+    await mkdir(logsDir(), { recursive: true });
+    const mergedLine = merged === false ? 'merged: false' : `merged: ${merged}`;
+    await writeFile(
+      join(logsDir(), `${date}-${TOKEN}-checkpoint-${nn}.md`),
+      `---\ntrigger: ${trigger}\n${mergedLine}\n---\n`,
+      'utf8',
+    );
+  }
+
+  it('no stubs on disk → writes clean 3-field state, no emit', () => {
+    writeState(TOKEN, { count: 0, last_ts: 999, last_stop_nn: '02' }, tmpDir);
+    const cap = captureStdout();
+    postcompactFallback(TOKEN, vaultDir, now, tmpDir);
+    const out = cap.stop();
+    expect(out).toBe('');
+    const state = readState(TOKEN, tmpDir);
+    expect(state.count).toBe(0);
+    expect(state.last_ts).toBe(999); // preserved
+    expect(state.last_stop_nn).toBe('02');
+  });
+
+  it('unmerged precompact stub found → emits fill-checkpoint, writes state', async () => {
+    await writeStubFile('02', 'precompact', false);
+    writeState(TOKEN, { count: 0, last_ts: 0, last_stop_nn: '01' }, tmpDir);
+    const cap = captureStdout();
+    postcompactFallback(TOKEN, vaultDir, now, tmpDir);
+    const out = cap.stop();
+    const parsed = JSON.parse(out.trim());
+    expect(parsed.decision).toBe('block');
+    expect(parsed.reason).toMatch(/fill-checkpoint:.*checkpoint-02\.md since checkpoint-01$/);
+    const state = readState(TOKEN, tmpDir);
+    expect(state.last_ts).toBe(now);
+    expect(state.last_stop_nn).toBe('02');
+  });
+
+  it('stop-triggered stub → ignored, no emit', async () => {
+    await writeStubFile('02', 'stop', false);
+    writeState(TOKEN, { count: 0, last_ts: 500, last_stop_nn: '01' }, tmpDir);
+    const cap = captureStdout();
+    postcompactFallback(TOKEN, vaultDir, now, tmpDir);
+    const out = cap.stop();
+    expect(out).toBe('');
+  });
+
+  it('merged precompact stub → ignored, no emit', async () => {
+    await writeStubFile('02', 'precompact', 'true');
+    writeState(TOKEN, { count: 0, last_ts: 500, last_stop_nn: '01' }, tmpDir);
+    const cap = captureStdout();
+    postcompactFallback(TOKEN, vaultDir, now, tmpDir);
+    const out = cap.stop();
+    expect(out).toBe('');
+  });
+
+  it('multiple stubs → processes latest (highest NN)', async () => {
+    await writeStubFile('01', 'precompact', false);
+    await writeStubFile('03', 'precompact', false);
+    writeState(TOKEN, { count: 0, last_ts: 0, last_stop_nn: '00' }, tmpDir);
+    const cap = captureStdout();
+    postcompactFallback(TOKEN, vaultDir, now, tmpDir);
+    const out = cap.stop();
+    const parsed = JSON.parse(out.trim());
+    expect(parsed.reason).toMatch(/checkpoint-03\.md since checkpoint-02$/);
+  });
+
+  it('first stub (NN=01) → since reference is "start"', async () => {
+    await writeStubFile('01', 'precompact', false);
+    writeState(TOKEN, { count: 0, last_ts: 0, last_stop_nn: '00' }, tmpDir);
+    const cap = captureStdout();
+    postcompactFallback(TOKEN, vaultDir, now, tmpDir);
+    const out = cap.stop();
+    const parsed = JSON.parse(out.trim());
+    expect(parsed.reason).toMatch(/since start$/);
   });
 });
 

--- a/packages/cli/src/internal/checkpoint.test.ts
+++ b/packages/cli/src/internal/checkpoint.test.ts
@@ -661,12 +661,12 @@ describe('handlePostcompact', () => {
     expect(parsed.reason).toContain('checkpoint-03.md');
     expect(parsed.reason).toMatch(/since checkpoint-02$/);
 
-    // State cleared: last_ts=0, pending_stub gone
+    // State cleared: last_ts=0, pending_stub gone, last_stop_nn advanced to stubNn (03)
     const raw = await readStateRaw(tmpDir, TOKEN);
-    expect(raw).toBe('0:0:02');
+    expect(raw).toBe('0:0:03');
   });
 
-  it('"since start" format when last_stop_nn="00"', () => {
+  it('"since start" format when last_stop_nn="00" → advances last_stop_nn to 01', async () => {
     writeState(
       TOKEN,
       {
@@ -684,9 +684,11 @@ describe('handlePostcompact', () => {
 
     const parsed = JSON.parse(out.trim());
     expect(parsed.reason).toMatch(/since start$/);
+    const raw = await readStateRaw(tmpDir, TOKEN);
+    expect(raw).toBe('0:0:01');
   });
 
-  it('"since checkpoint-NN" format when last_stop_nn non-zero', () => {
+  it('"since checkpoint-NN" format when last_stop_nn non-zero → advances last_stop_nn to 04', async () => {
     writeState(
       TOKEN,
       {
@@ -704,6 +706,8 @@ describe('handlePostcompact', () => {
 
     const parsed = JSON.parse(out.trim());
     expect(parsed.reason).toMatch(/since checkpoint-03$/);
+    const raw = await readStateRaw(tmpDir, TOKEN);
+    expect(raw).toBe('0:0:04');
   });
 
   it('missing stub file on disk → still emit fill-checkpoint (Claude creates it)', () => {

--- a/packages/cli/src/internal/checkpoint.test.ts
+++ b/packages/cli/src/internal/checkpoint.test.ts
@@ -11,6 +11,7 @@ import {
   handlePrecompact,
   handleReset,
   handleStop,
+  maxCheckpointNnSync,
   readState,
   writeState,
 } from './checkpoint.js';
@@ -43,6 +44,27 @@ function stateFile(tmpDir: string, token: string): string {
 
 async function readStateRaw(tmpDir: string, token: string): Promise<string> {
   return readFile(stateFile(tmpDir, token), 'utf8');
+}
+
+async function createCheckpointFile(
+  vaultDir: string,
+  now: number,
+  token: string,
+  nn: number,
+): Promise<void> {
+  const d = new Date(now * 1000);
+  const yyyy = d.getFullYear().toString();
+  const mm = String(d.getMonth() + 1).padStart(2, '0');
+  const dd = String(d.getDate()).padStart(2, '0');
+  const date = `${yyyy}-${mm}-${dd}`;
+  const dir = join(vaultDir, '07-logs', yyyy, mm);
+  await mkdir(dir, { recursive: true });
+  const nnStr = String(nn).padStart(2, '0');
+  await writeFile(
+    join(dir, `${date}-${token}-checkpoint-${nnStr}.md`),
+    `---\ndate: ${date}\ncheckpoint: ${nnStr}\nmerged: false\n---\n`,
+    'utf8',
+  );
 }
 
 // Capture stdout written via process.stdout.write
@@ -309,10 +331,13 @@ describe('handleStop', () => {
     expect(String(parsed.reason)).toMatch(/-checkpoint-\d{2}\.md since /);
   });
 
-  it('threshold met by elapsed time, emits block JSON', () => {
+  it('threshold met by elapsed time, emits block JSON', async () => {
     // elapsed > minutes_threshold (10 min = 600s), count >= 2
     const now = 1700001000;
     const oldTs = now - 700; // 700s elapsed
+    // Create 2 existing checkpoints so disk scan returns maxNn=2 → next NN=03
+    await createCheckpointFile(vaultDir, now, TOKEN, 1);
+    await createCheckpointFile(vaultDir, now, TOKEN, 2);
     writeState(TOKEN, { count: 2, last_ts: oldTs, last_stop_nn: '02' }, tmpDir);
 
     const cap = captureStdout();
@@ -339,8 +364,12 @@ describe('handleStop', () => {
     expect(parsed.reason).toMatch(/since start$/);
   });
 
-  it('"since checkpoint-NN" format when last_stop_nn is non-zero', () => {
+  it('"since checkpoint-NN" format when last_stop_nn is non-zero', async () => {
     const now = 1700001000;
+    // Create 3 existing checkpoints so disk scan returns maxNn=3 → next NN=04
+    await createCheckpointFile(vaultDir, now, TOKEN, 1);
+    await createCheckpointFile(vaultDir, now, TOKEN, 2);
+    await createCheckpointFile(vaultDir, now, TOKEN, 3);
     writeState(TOKEN, { count: 4, last_ts: now - 10, last_stop_nn: '03' }, tmpDir);
 
     const cap = captureStdout();
@@ -351,6 +380,24 @@ describe('handleStop', () => {
     expect(parsed.reason).toMatch(/since checkpoint-03$/);
     // next NN should be 04
     expect(parsed.reason).toMatch(/checkpoint-04\.md/);
+  });
+
+  it('disk scan wins over state: last_stop_nn="02" but only checkpoint-01 on disk → creates checkpoint-02', async () => {
+    const now = 1700001000;
+    // Only checkpoint-01 exists on disk — state says last_stop_nn='02' but disk is authoritative
+    await createCheckpointFile(vaultDir, now, TOKEN, 1);
+    writeState(TOKEN, { count: 4, last_ts: now - 10, last_stop_nn: '02' }, tmpDir);
+
+    const cap = captureStdout();
+    handleStop(TOKEN, vaultDir, now, tmpDir);
+    const out = cap.stop();
+
+    const parsed = JSON.parse(out.trim());
+    expect(parsed.decision).toBe('block');
+    // disk maxNn=1 → next NN=02 (not 03 from state)
+    expect(parsed.reason).toMatch(/checkpoint-02\.md since checkpoint-01$/);
+    const state = readState(TOKEN, tmpDir);
+    expect(state.last_stop_nn).toBe('02');
   });
 
   it('elapsed calc: last_ts=0 → elapsed=0, never triggers time threshold alone', () => {
@@ -392,9 +439,12 @@ describe('handleStop', () => {
     expect(state.count).toBe(1);
   });
 
-  it('last_ts=0 + count=4 (below threshold=5 after increment to 5) → decision:block, last_ts updated, last_stop_nn incremented', () => {
+  it('last_ts=0 + count=4 (below threshold=5 after increment to 5) → decision:block, last_ts updated, last_stop_nn incremented', async () => {
     // messagesThreshold is 5 from vault.yml; count=4 → increment to 5 = threshold → emit
     const now = 1700000800;
+    // Create 2 existing checkpoints so disk scan returns maxNn=2 → next NN=03
+    await createCheckpointFile(vaultDir, now, TOKEN, 1);
+    await createCheckpointFile(vaultDir, now, TOKEN, 2);
     writeState(TOKEN, { count: 4, last_ts: 0, last_stop_nn: '02' }, tmpDir);
 
     const cap = captureStdout();
@@ -480,6 +530,9 @@ describe('handlePrecompact', () => {
   it('no recent checkpoint → writes stub file and updates state to 4-field format', async () => {
     const now = 1700001000;
     const oldTs = now - 600; // 600s > 300s
+    // Create 2 existing checkpoints so disk scan returns maxNn=2 → next NN=03
+    await createCheckpointFile(vaultDir, now, TOKEN, 1);
+    await createCheckpointFile(vaultDir, now, TOKEN, 2);
     writeState(TOKEN, { count: 3, last_ts: oldTs, last_stop_nn: '02' }, tmpDir);
 
     const cap = captureStdout();
@@ -493,12 +546,15 @@ describe('handlePrecompact', () => {
     expect(state.last_ts).toBe(oldTs); // NOT updated by precompact
     expect(state.last_stop_nn).toBe('02'); // NOT incremented
     expect(state.pending_stub).toBeTruthy();
-    // stub NN should be 03 (last_stop_nn '02' + 1)
+    // stub NN should be 03 (disk scan maxNn=2 → next=03)
     expect(state.pending_stub).toMatch(/checkpoint-03\.md$/);
   });
 
-  it('NN derivation: last_stop_nn="02" → stub NN="03"', async () => {
+  it('NN derivation: disk scan maxNn=2 → stub NN="03"', async () => {
     const now = 1700001000;
+    // Create 2 existing checkpoints so disk scan returns maxNn=2 → next NN=03
+    await createCheckpointFile(vaultDir, now, TOKEN, 1);
+    await createCheckpointFile(vaultDir, now, TOKEN, 2);
     writeState(TOKEN, { count: 2, last_ts: now - 600, last_stop_nn: '02' }, tmpDir);
 
     await handlePrecompact(TOKEN, vaultDir, now, tmpDir);
@@ -531,7 +587,9 @@ describe('handlePrecompact', () => {
     const date = new Date(now * 1000);
     const yyyy = date.getFullYear().toString();
     const mm = String(date.getMonth() + 1).padStart(2, '0');
-    // last_stop_nn='02' → stub NN='03'
+    // Create 2 existing checkpoints so disk scan returns maxNn=2 → stub NN='03'
+    await createCheckpointFile(vaultDir, now, TOKEN, 1);
+    await createCheckpointFile(vaultDir, now, TOKEN, 2);
     writeState(TOKEN, { count: 2, last_ts: now - 600, last_stop_nn: '02' }, tmpDir);
 
     await handlePrecompact(TOKEN, vaultDir, now, tmpDir);
@@ -547,6 +605,10 @@ describe('handlePrecompact', () => {
 
   it('last_stop_nn NOT updated (stays same in state after precompact)', async () => {
     const now = 1700001000;
+    // Create 3 existing checkpoints so disk scan returns maxNn=3 → stub NN=04
+    await createCheckpointFile(vaultDir, now, TOKEN, 1);
+    await createCheckpointFile(vaultDir, now, TOKEN, 2);
+    await createCheckpointFile(vaultDir, now, TOKEN, 3);
     writeState(TOKEN, { count: 2, last_ts: now - 600, last_stop_nn: '03' }, tmpDir);
 
     await handlePrecompact(TOKEN, vaultDir, now, tmpDir);
@@ -741,5 +803,74 @@ describe('handlePostcompact', () => {
     const out = cap.stop();
 
     expect(out).toBe('');
+  });
+
+  it('pending_stub NN inconsistent with last_stop_nn → uses NN from filename (authoritative)', async () => {
+    // State corruption: last_stop_nn says 02 but stub filename says checkpoint-04
+    writeState(
+      TOKEN,
+      {
+        count: 0,
+        last_ts: 1699999000,
+        last_stop_nn: '02',
+        pending_stub: '2026-04-23-41928-checkpoint-04.md',
+      },
+      tmpDir,
+    );
+
+    const cap = captureStdout();
+    handlePostcompact(TOKEN, 1700001000, tmpDir);
+    cap.stop();
+
+    // Filename wins: last_stop_nn advances to 04 (from filename), not 03 (from last_stop_nn+1)
+    const raw = await readStateRaw(tmpDir, TOKEN);
+    expect(raw).toBe('0:0:04');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// maxCheckpointNnSync
+// ---------------------------------------------------------------------------
+
+describe('maxCheckpointNnSync', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await makeTmpDir();
+  });
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  const VAULT = () => tmpDir;
+  const DATE = '2023-11-14';
+  const LOGS = '07-logs';
+
+  it('returns 0 when directory does not exist', () => {
+    expect(maxCheckpointNnSync(VAULT(), DATE, TOKEN, LOGS)).toBe(0);
+  });
+
+  it('returns 0 when directory has no checkpoint files', async () => {
+    await mkdir(join(VAULT(), LOGS, '2023', '11'), { recursive: true });
+    await writeFile(join(VAULT(), LOGS, '2023', '11', '2023-11-14-session-01.md'), '', 'utf8');
+    expect(maxCheckpointNnSync(VAULT(), DATE, TOKEN, LOGS)).toBe(0);
+  });
+
+  it('returns the highest NN from matching checkpoint files', async () => {
+    const dir = join(VAULT(), LOGS, '2023', '11');
+    await mkdir(dir, { recursive: true });
+    await writeFile(join(dir, `${DATE}-${TOKEN}-checkpoint-01.md`), '', 'utf8');
+    await writeFile(join(dir, `${DATE}-${TOKEN}-checkpoint-03.md`), '', 'utf8');
+    await writeFile(join(dir, `${DATE}-${TOKEN}-checkpoint-02.md`), '', 'utf8');
+    expect(maxCheckpointNnSync(VAULT(), DATE, TOKEN, LOGS)).toBe(3);
+  });
+
+  it('ignores files with wrong token or wrong format', async () => {
+    const dir = join(VAULT(), LOGS, '2023', '11');
+    await mkdir(dir, { recursive: true });
+    await writeFile(join(dir, `${DATE}-99999-checkpoint-05.md`), '', 'utf8'); // wrong token
+    await writeFile(join(dir, `${DATE}-${TOKEN}-checkpoint-01.md`), '', 'utf8'); // correct
+    await writeFile(join(dir, `${DATE}-${TOKEN}-session-01.md`), '', 'utf8'); // not checkpoint
+    expect(maxCheckpointNnSync(VAULT(), DATE, TOKEN, LOGS)).toBe(1);
   });
 });

--- a/packages/cli/src/internal/checkpoint.test.ts
+++ b/packages/cli/src/internal/checkpoint.test.ts
@@ -211,7 +211,11 @@ describe('handleReset', () => {
   });
 
   it('clears pending_stub from 4-field state', async () => {
-    writeState(TOKEN, { count: 3, last_ts: 999, last_stop_nn: '02', pending_stub: 'some-checkpoint.md' }, tmpDir);
+    writeState(
+      TOKEN,
+      { count: 3, last_ts: 999, last_stop_nn: '02', pending_stub: 'some-checkpoint.md' },
+      tmpDir,
+    );
     handleReset(TOKEN, 1700000000, tmpDir);
     const raw = await readStateRaw(tmpDir, TOKEN);
     expect(raw).toBe('0:1700000000:00');
@@ -415,7 +419,11 @@ describe('handleStop', () => {
     const stubFile = '2023-11-14-41928-checkpoint-03.md';
     // State has pending_stub set (precompact wrote stub, postcompact hasn't run yet)
     await createCheckpointFile(vaultDir, now, TOKEN, 3);
-    writeState(TOKEN, { count: 4, last_ts: now - 10, last_stop_nn: '03', pending_stub: stubFile }, tmpDir);
+    writeState(
+      TOKEN,
+      { count: 4, last_ts: now - 10, last_stop_nn: '03', pending_stub: stubFile },
+      tmpDir,
+    );
 
     const cap = captureStdout();
     handleStop(TOKEN, vaultDir, now, tmpDir);
@@ -732,7 +740,11 @@ describe('handlePostcompact', () => {
 
   async function writeCheckpointOnDisk(nn: string) {
     await mkdir(logsDir(), { recursive: true });
-    await writeFile(join(logsDir(), `${stubDate}-${TOKEN}-checkpoint-${nn}.md`), `---\ntrigger: stop\nmerged: false\n---\n`, 'utf8');
+    await writeFile(
+      join(logsDir(), `${stubDate}-${TOKEN}-checkpoint-${nn}.md`),
+      '---\ntrigger: stop\nmerged: false\n---\n',
+      'utf8',
+    );
   }
 
   it('no pending stub (3-field state) → preserve last_ts, write 3-field, no stdout', async () => {
@@ -761,7 +773,16 @@ describe('handlePostcompact', () => {
   it('pending stub found → emit fill-checkpoint block, clear pending_stub, last_ts=now', async () => {
     const ts = 1699999000;
     await writeCheckpointOnDisk('02'); // predecessor on disk
-    writeState(TOKEN, { count: 0, last_ts: ts, last_stop_nn: '02', pending_stub: `${stubDate}-${TOKEN}-checkpoint-03.md` }, tmpDir);
+    writeState(
+      TOKEN,
+      {
+        count: 0,
+        last_ts: ts,
+        last_stop_nn: '02',
+        pending_stub: `${stubDate}-${TOKEN}-checkpoint-03.md`,
+      },
+      tmpDir,
+    );
 
     const cap = captureStdout();
     handlePostcompact(TOKEN, vaultDir, now, tmpDir);
@@ -778,7 +799,16 @@ describe('handlePostcompact', () => {
   });
 
   it('"since start" format when no predecessor on disk → advances last_stop_nn to 01', async () => {
-    writeState(TOKEN, { count: 0, last_ts: 1699999000, last_stop_nn: '00', pending_stub: `${stubDate}-${TOKEN}-checkpoint-01.md` }, tmpDir);
+    writeState(
+      TOKEN,
+      {
+        count: 0,
+        last_ts: 1699999000,
+        last_stop_nn: '00',
+        pending_stub: `${stubDate}-${TOKEN}-checkpoint-01.md`,
+      },
+      tmpDir,
+    );
 
     const cap = captureStdout();
     handlePostcompact(TOKEN, vaultDir, now, tmpDir);
@@ -792,7 +822,16 @@ describe('handlePostcompact', () => {
 
   it('"since checkpoint-NN" format → predecessor derived from disk, not arithmetic', async () => {
     await writeCheckpointOnDisk('03'); // predecessor on disk
-    writeState(TOKEN, { count: 0, last_ts: 1699999000, last_stop_nn: '03', pending_stub: `${stubDate}-${TOKEN}-checkpoint-04.md` }, tmpDir);
+    writeState(
+      TOKEN,
+      {
+        count: 0,
+        last_ts: 1699999000,
+        last_stop_nn: '03',
+        pending_stub: `${stubDate}-${TOKEN}-checkpoint-04.md`,
+      },
+      tmpDir,
+    );
 
     const cap = captureStdout();
     handlePostcompact(TOKEN, vaultDir, now, tmpDir);
@@ -806,7 +845,16 @@ describe('handlePostcompact', () => {
 
   it('gap in disk: stub is checkpoint-04 but only checkpoint-02 exists → since checkpoint-02', async () => {
     await writeCheckpointOnDisk('02'); // checkpoint-03 was never written
-    writeState(TOKEN, { count: 0, last_ts: 1699999000, last_stop_nn: '02', pending_stub: `${stubDate}-${TOKEN}-checkpoint-04.md` }, tmpDir);
+    writeState(
+      TOKEN,
+      {
+        count: 0,
+        last_ts: 1699999000,
+        last_stop_nn: '02',
+        pending_stub: `${stubDate}-${TOKEN}-checkpoint-04.md`,
+      },
+      tmpDir,
+    );
 
     const cap = captureStdout();
     handlePostcompact(TOKEN, vaultDir, now, tmpDir);
@@ -818,7 +866,16 @@ describe('handlePostcompact', () => {
   });
 
   it('missing stub file on disk → still emit fill-checkpoint (Claude creates it)', () => {
-    writeState(TOKEN, { count: 0, last_ts: 1699999000, last_stop_nn: '01', pending_stub: `${stubDate}-${TOKEN}-checkpoint-02.md` }, tmpDir);
+    writeState(
+      TOKEN,
+      {
+        count: 0,
+        last_ts: 1699999000,
+        last_stop_nn: '01',
+        pending_stub: `${stubDate}-${TOKEN}-checkpoint-02.md`,
+      },
+      tmpDir,
+    );
 
     const cap = captureStdout();
     handlePostcompact(TOKEN, vaultDir, now, tmpDir);
@@ -840,7 +897,16 @@ describe('handlePostcompact', () => {
   });
 
   it('pending_stub NN inconsistent with last_stop_nn → uses NN from filename (authoritative)', async () => {
-    writeState(TOKEN, { count: 0, last_ts: 1699999000, last_stop_nn: '02', pending_stub: `${stubDate}-${TOKEN}-checkpoint-04.md` }, tmpDir);
+    writeState(
+      TOKEN,
+      {
+        count: 0,
+        last_ts: 1699999000,
+        last_stop_nn: '02',
+        pending_stub: `${stubDate}-${TOKEN}-checkpoint-04.md`,
+      },
+      tmpDir,
+    );
 
     const cap = captureStdout();
     handlePostcompact(TOKEN, vaultDir, now, tmpDir);
@@ -851,7 +917,16 @@ describe('handlePostcompact', () => {
   });
 
   it('postcompact last_ts=now blocks precompact re-fire within 5 min', async () => {
-    writeState(TOKEN, { count: 0, last_ts: 1699999000, last_stop_nn: '01', pending_stub: `${stubDate}-${TOKEN}-checkpoint-02.md` }, tmpDir);
+    writeState(
+      TOKEN,
+      {
+        count: 0,
+        last_ts: 1699999000,
+        last_stop_nn: '01',
+        pending_stub: `${stubDate}-${TOKEN}-checkpoint-02.md`,
+      },
+      tmpDir,
+    );
 
     const cap = captureStdout();
     handlePostcompact(TOKEN, vaultDir, now, tmpDir);
@@ -987,7 +1062,11 @@ describe('postcompactFallback', () => {
   it('pending_stub in state → delegates to handlePostcompact, not disk scan', async () => {
     const stubFilename = `${date}-${TOKEN}-checkpoint-02.md`;
     await writeStubFile('01', 'stop', 'true'); // predecessor on disk
-    writeState(TOKEN, { count: 0, last_ts: 0, last_stop_nn: '01', pending_stub: stubFilename }, tmpDir);
+    writeState(
+      TOKEN,
+      { count: 0, last_ts: 0, last_stop_nn: '01', pending_stub: stubFilename },
+      tmpDir,
+    );
     const cap = captureStdout();
     postcompactFallback(TOKEN, vaultDir, now, tmpDir);
     const out = cap.stop();

--- a/packages/cli/src/internal/checkpoint.test.ts
+++ b/packages/cli/src/internal/checkpoint.test.ts
@@ -722,7 +722,7 @@ describe('handlePostcompact', () => {
     expect(state.last_ts).toBe(0);
   });
 
-  it('pending stub found → emit fill-checkpoint block, clear pending_stub, last_ts=0', async () => {
+  it('pending stub found → emit fill-checkpoint block, clear pending_stub, last_ts=now', async () => {
     const now = 1700001000;
     const ts = 1699999000;
     writeState(
@@ -746,12 +746,13 @@ describe('handlePostcompact', () => {
     expect(parsed.reason).toContain('checkpoint-03.md');
     expect(parsed.reason).toMatch(/since checkpoint-02$/);
 
-    // State cleared: last_ts=0, pending_stub gone, last_stop_nn advanced to stubNn (03)
+    // State cleared: last_ts=now (protects recency guard), last_stop_nn advanced to stubNn (03)
     const raw = await readStateRaw(tmpDir, TOKEN);
-    expect(raw).toBe('0:0:03');
+    expect(raw).toBe(`0:${now}:03`);
   });
 
   it('"since start" format when last_stop_nn="00" → advances last_stop_nn to 01', async () => {
+    const now = 1700001000;
     writeState(
       TOKEN,
       {
@@ -764,16 +765,17 @@ describe('handlePostcompact', () => {
     );
 
     const cap = captureStdout();
-    handlePostcompact(TOKEN, 1700001000, tmpDir);
+    handlePostcompact(TOKEN, now, tmpDir);
     const out = cap.stop();
 
     const parsed = JSON.parse(out.trim());
     expect(parsed.reason).toMatch(/since start$/);
     const raw = await readStateRaw(tmpDir, TOKEN);
-    expect(raw).toBe('0:0:01');
+    expect(raw).toBe(`0:${now}:01`);
   });
 
   it('"since checkpoint-NN" format when last_stop_nn non-zero → advances last_stop_nn to 04', async () => {
+    const now = 1700001000;
     writeState(
       TOKEN,
       {
@@ -786,13 +788,13 @@ describe('handlePostcompact', () => {
     );
 
     const cap = captureStdout();
-    handlePostcompact(TOKEN, 1700001000, tmpDir);
+    handlePostcompact(TOKEN, now, tmpDir);
     const out = cap.stop();
 
     const parsed = JSON.parse(out.trim());
     expect(parsed.reason).toMatch(/since checkpoint-03$/);
     const raw = await readStateRaw(tmpDir, TOKEN);
-    expect(raw).toBe('0:0:04');
+    expect(raw).toBe(`0:${now}:04`);
   });
 
   it('missing stub file on disk → still emit fill-checkpoint (Claude creates it)', () => {
@@ -846,8 +848,38 @@ describe('handlePostcompact', () => {
     cap.stop();
 
     // Filename wins: last_stop_nn advances to 04 (from filename), not 03 (from last_stop_nn+1)
+    const now = 1700001000;
     const raw = await readStateRaw(tmpDir, TOKEN);
-    expect(raw).toBe('0:0:04');
+    expect(raw).toBe(`0:${now}:04`);
+  });
+
+  it('postcompact last_ts=now blocks precompact re-fire within 5 min', async () => {
+    // Postcompact sets last_ts=now; immediate second precompact must be blocked by recency guard
+    const now = 1700001000;
+    const vaultDir = await makeTmpDir();
+    await writeFile(join(vaultDir, 'vault.yml'), VALID_VAULT_YML, 'utf8');
+    try {
+      writeState(TOKEN, { count: 0, last_ts: 1699999000, last_stop_nn: '01', pending_stub: '2023-11-14-41928-checkpoint-02.md' }, tmpDir);
+
+      const cap = captureStdout();
+      handlePostcompact(TOKEN, now, tmpDir);
+      cap.stop();
+
+      const stateAfterPost = readState(TOKEN, tmpDir);
+      expect(stateAfterPost.last_ts).toBe(now);
+      expect(stateAfterPost.pending_stub).toBeUndefined();
+
+      // Precompact fires 30s later (within PRECOMPACT_RECENCY=300s) — must be no-op
+      const cap2 = captureStdout();
+      await handlePrecompact(TOKEN, vaultDir, now + 30, tmpDir);
+      const out2 = cap2.stop();
+
+      expect(out2).toBe('');
+      const stateAfterPre = readState(TOKEN, tmpDir);
+      expect(stateAfterPre.pending_stub).toBeUndefined();
+    } finally {
+      await rm(vaultDir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/packages/cli/src/internal/checkpoint.test.ts
+++ b/packages/cli/src/internal/checkpoint.test.ts
@@ -618,6 +618,29 @@ describe('handlePrecompact', () => {
     expect(state.pending_stub).toMatch(/-checkpoint-04\.md$/);
   });
 
+  it('double-compact guard: pending_stub already set → no-op, existing stub preserved', async () => {
+    const now = 1700001000;
+    writeState(
+      TOKEN,
+      {
+        count: 0,
+        last_ts: now - 600,
+        last_stop_nn: '01',
+        pending_stub: '2023-11-14-41928-checkpoint-02.md',
+      },
+      tmpDir,
+    );
+
+    const cap = captureStdout();
+    await handlePrecompact(TOKEN, vaultDir, now, tmpDir);
+    const out = cap.stop();
+
+    expect(out).toBe('');
+    // State unchanged — pending_stub still points to original stub
+    const state = readState(TOKEN, tmpDir);
+    expect(state.pending_stub).toBe('2023-11-14-41928-checkpoint-02.md');
+  });
+
   it('no state file (last_ts=0) → recency check fails → writes stub for new session', async () => {
     // No state file → readState returns last_ts=0 → recency guard (last_ts > 0) is false
     // → precompact proceeds and writes a stub (correct: compact on brand-new session)

--- a/packages/cli/src/internal/checkpoint.ts
+++ b/packages/cli/src/internal/checkpoint.ts
@@ -449,11 +449,12 @@ export function handlePostcompact(
 // ---------------------------------------------------------------------------
 
 /**
- * Fallback for postcompact when state has no pending_stub (e.g. state was lost
- * or stop hook fired before compact cleared pending_stub from an older session).
- * Scans disk for unmerged precompact stubs belonging to this session today.
- * If found: emits fill-checkpoint for the latest one.
- * If not found: writes clean 3-field state preserving last_ts.
+ * Postcompact entry point: reads state once and dispatches to the correct path.
+ * - pending_stub present → delegates to handlePostcompact (fills known stub)
+ * - pending_stub absent  → scans disk for unmerged precompact stubs (state lost/expired)
+ *
+ * Single state read here; handlePostcompact also reads state internally (benign
+ * double-read — postcompact is never called concurrently).
  * Sync.
  */
 export function postcompactFallback(
@@ -463,6 +464,13 @@ export function postcompactFallback(
   tmpDir: string = osTmpdir(),
 ): void {
   const state = readState(token, tmpDir);
+
+  if (state.pending_stub) {
+    handlePostcompact(token, now, tmpDir);
+    return;
+  }
+
+  // No pending_stub — scan disk for unmerged precompact stubs for this session today.
   const { logsFolder } = loadVaultSettings(vaultRoot);
   const date = formatDate(now);
   const yyyy = date.slice(0, 4);
@@ -471,9 +479,13 @@ export function postcompactFallback(
   const prefix = `${date}-${token}-checkpoint-`;
 
   const stubs: string[] = [];
+  let allNns: number[] = [];
   try {
     for (const f of readdirSync(dir)) {
       if (!f.startsWith(prefix) || !f.endsWith('.md')) continue;
+      const m = f.match(/-checkpoint-(\d{2})\.md$/);
+      if (!m) continue;
+      allNns.push(Number(m[1]));
       const content = readFileSync(join(dir, f), 'utf8');
       if (/^trigger:\s*precompact/m.test(content) && !/^merged:\s*true/m.test(content)) {
         stubs.push(f);
@@ -492,8 +504,10 @@ export function postcompactFallback(
   const stubFilename = stubs[stubs.length - 1];
   const stubNnMatch = stubFilename.match(/-checkpoint-(\d{2})\.md$/);
   const stubNn = stubNnMatch?.[1] ?? '01';
-  const prevNn = Number(stubNn) - 1;
-  const since = prevNn === 0 ? ' since start' : ` since checkpoint-${String(prevNn).padStart(2, '0')}`;
+  const stubNnNum = Number(stubNn);
+  // Derive predecessor from disk — correct even when there are gaps in numbering
+  const predecessorNn = allNns.filter((n) => n < stubNnNum).reduce((max, n) => Math.max(max, n), 0);
+  const since = predecessorNn === 0 ? ' since start' : ` since checkpoint-${String(predecessorNn).padStart(2, '0')}`;
   emitBlock(`fill-checkpoint: ${stubFilename}${since}`);
   writeState(token, { count: 0, last_ts: now, last_stop_nn: stubNn }, tmpDir);
 }
@@ -519,15 +533,9 @@ export async function checkpointCommand(
       case 'precompact':
         await handlePrecompact(token, vaultRoot);
         break;
-      case 'postcompact': {
-        const { pending_stub } = readState(token);
-        if (pending_stub) {
-          handlePostcompact(token);
-        } else {
-          postcompactFallback(token, vaultRoot);
-        }
+      case 'postcompact':
+        postcompactFallback(token, vaultRoot);
         break;
-      }
       case 'reset':
         handleReset(token);
         break;

--- a/packages/cli/src/internal/checkpoint.ts
+++ b/packages/cli/src/internal/checkpoint.ts
@@ -298,8 +298,8 @@ export function handleStop(
   const filename = `${date}-${token}-checkpoint-${nextNn}.md`;
   emitBlock(`${filename}${since}`);
 
-  // Reset state (last_stop_nn recorded for debugging; not used for NN computation)
-  writeState(token, { count: 0, last_ts: now, last_stop_nn: nextNn }, tmpDir);
+  // Reset state; preserve pending_stub so postcompact can still fill the precompact stub
+  writeState(token, { count: 0, last_ts: now, last_stop_nn: nextNn, pending_stub: state.pending_stub }, tmpDir);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/cli/src/internal/checkpoint.ts
+++ b/packages/cli/src/internal/checkpoint.ts
@@ -361,7 +361,9 @@ export async function handlePrecompact(
 /**
  * Postcompact hook: handle pending stub from precompact.
  * If no pending stub: preserve last_ts, write clean 3-field state.
- * If pending stub: emit fill-checkpoint block, clear pending_stub, set last_ts=0.
+ * If pending stub: emit fill-checkpoint block, advance last_stop_nn to stubNn,
+ * clear pending_stub, set last_ts=0. Advancing last_stop_nn prevents subsequent
+ * stop hooks from reusing the stub's NN and overwriting the filled file.
  * Sync.
  */
 export function handlePostcompact(
@@ -387,8 +389,12 @@ export function handlePostcompact(
     state.last_stop_nn === '00' ? ' since start' : ` since checkpoint-${state.last_stop_nn}`;
   emitBlock(`fill-checkpoint: ${state.pending_stub}${since}`);
 
+  // Advance last_stop_nn to the stub's NN so subsequent stop checkpoints
+  // don't reuse the same number and overwrite the filled stub.
+  const stubNn = String(Number(state.last_stop_nn) + 1).padStart(2, '0');
+
   // Clear pending_stub, set last_ts=0 sentinel
-  writeState(token, { count: 0, last_ts: 0, last_stop_nn: state.last_stop_nn }, tmpDir);
+  writeState(token, { count: 0, last_ts: 0, last_stop_nn: stubNn }, tmpDir);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/cli/src/internal/checkpoint.ts
+++ b/packages/cli/src/internal/checkpoint.ts
@@ -294,12 +294,17 @@ export function handleStop(
   const date = formatDate(now);
   const maxNn = maxCheckpointNnSync(vaultRoot, date, token, logsFolder);
   const nextNn = String(maxNn + 1).padStart(2, '0');
-  const since = maxNn === 0 ? ' since start' : ` since checkpoint-${String(maxNn).padStart(2, '0')}`;
+  const since =
+    maxNn === 0 ? ' since start' : ` since checkpoint-${String(maxNn).padStart(2, '0')}`;
   const filename = `${date}-${token}-checkpoint-${nextNn}.md`;
   emitBlock(`${filename}${since}`);
 
   // Reset state; preserve pending_stub so postcompact can still fill the precompact stub
-  writeState(token, { count: 0, last_ts: now, last_stop_nn: nextNn, pending_stub: state.pending_stub }, tmpDir);
+  writeState(
+    token,
+    { count: 0, last_ts: now, last_stop_nn: nextNn, pending_stub: state.pending_stub },
+    tmpDir,
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -431,7 +436,11 @@ export function handlePostcompact(
   const state = readState(token, tmpDir);
 
   if (!state.pending_stub) {
-    writeState(token, { count: 0, last_ts: state.last_ts, last_stop_nn: state.last_stop_nn }, tmpDir);
+    writeState(
+      token,
+      { count: 0, last_ts: state.last_ts, last_stop_nn: state.last_stop_nn },
+      tmpDir,
+    );
     return;
   }
 
@@ -460,7 +469,10 @@ export function handlePostcompact(
     // dir missing or unreadable — predecessorNn stays 0 → 'since start'
   }
 
-  const since = predecessorNn === 0 ? ' since start' : ` since checkpoint-${String(predecessorNn).padStart(2, '0')}`;
+  const since =
+    predecessorNn === 0
+      ? ' since start'
+      : ` since checkpoint-${String(predecessorNn).padStart(2, '0')}`;
   emitBlock(`fill-checkpoint: ${state.pending_stub}${since}`);
 
   // last_ts=now: recency guard in handlePrecompact blocks re-fire within 5 min
@@ -502,7 +514,7 @@ export function postcompactFallback(
   const prefix = `${date}-${token}-checkpoint-`;
 
   const stubs: string[] = [];
-  let allNns: number[] = [];
+  const allNns: number[] = [];
   try {
     for (const f of readdirSync(dir)) {
       if (!f.startsWith(prefix) || !f.endsWith('.md')) continue;
@@ -519,7 +531,11 @@ export function postcompactFallback(
   }
 
   if (stubs.length === 0) {
-    writeState(token, { count: 0, last_ts: state.last_ts, last_stop_nn: state.last_stop_nn }, tmpDir);
+    writeState(
+      token,
+      { count: 0, last_ts: state.last_ts, last_stop_nn: state.last_stop_nn },
+      tmpDir,
+    );
     return;
   }
 
@@ -530,7 +546,10 @@ export function postcompactFallback(
   const stubNnNum = Number(stubNn);
   // Derive predecessor from disk — correct even when there are gaps in numbering
   const predecessorNn = allNns.filter((n) => n < stubNnNum).reduce((max, n) => Math.max(max, n), 0);
-  const since = predecessorNn === 0 ? ' since start' : ` since checkpoint-${String(predecessorNn).padStart(2, '0')}`;
+  const since =
+    predecessorNn === 0
+      ? ' since start'
+      : ` since checkpoint-${String(predecessorNn).padStart(2, '0')}`;
   emitBlock(`fill-checkpoint: ${stubFilename}${since}`);
   writeState(token, { count: 0, last_ts: now, last_stop_nn: stubNn }, tmpDir);
 }

--- a/packages/cli/src/internal/checkpoint.ts
+++ b/packages/cli/src/internal/checkpoint.ts
@@ -419,10 +419,12 @@ export async function handlePrecompact(
 /**
  * Postcompact hook: handle pending stub from precompact.
  * If pending stub: emit fill-checkpoint block, set last_ts=now.
+ * Predecessor NN derived from disk scan — correct even when there are gaps.
  * Sync. Called only when state has pending_stub set.
  */
 export function handlePostcompact(
   token: string,
+  vaultRoot: string,
   now: number = Math.floor(Date.now() / 1000),
   tmpDir: string = osTmpdir(),
 ): void {
@@ -433,11 +435,32 @@ export function handlePostcompact(
     return;
   }
 
-  // Derive "since" reference from stub filename (NN - 1)
   const stubNnMatch = state.pending_stub.match(/-checkpoint-(\d{2})\.md$/);
   const stubNn = stubNnMatch?.[1] ?? '01';
-  const prevNn = Number(stubNn) - 1;
-  const since = prevNn === 0 ? ' since start' : ` since checkpoint-${String(prevNn).padStart(2, '0')}`;
+  const stubNnNum = Number(stubNn);
+
+  // Derive predecessor from disk — correct even when there are gaps in numbering
+  const { logsFolder } = loadVaultSettings(vaultRoot);
+  const date = state.pending_stub.slice(0, 10); // YYYY-MM-DD prefix
+  const yyyy = date.slice(0, 4);
+  const mm = date.slice(5, 7);
+  const dir = join(vaultRoot, logsFolder, yyyy, mm);
+  const prefix = `${date}-${token}-checkpoint-`;
+  let predecessorNn = 0;
+  try {
+    for (const f of readdirSync(dir)) {
+      if (!f.startsWith(prefix) || !f.endsWith('.md')) continue;
+      const m = f.match(/-checkpoint-(\d{2})\.md$/);
+      if (m) {
+        const nn = Number(m[1]);
+        if (nn < stubNnNum) predecessorNn = Math.max(predecessorNn, nn);
+      }
+    }
+  } catch {
+    // dir missing or unreadable — predecessorNn stays 0 → 'since start'
+  }
+
+  const since = predecessorNn === 0 ? ' since start' : ` since checkpoint-${String(predecessorNn).padStart(2, '0')}`;
   emitBlock(`fill-checkpoint: ${state.pending_stub}${since}`);
 
   // last_ts=now: recency guard in handlePrecompact blocks re-fire within 5 min
@@ -466,7 +489,7 @@ export function postcompactFallback(
   const state = readState(token, tmpDir);
 
   if (state.pending_stub) {
-    handlePostcompact(token, now, tmpDir);
+    handlePostcompact(token, vaultRoot, now, tmpDir);
     return;
   }
 

--- a/packages/cli/src/internal/checkpoint.ts
+++ b/packages/cli/src/internal/checkpoint.ts
@@ -150,7 +150,7 @@ function loadVaultSettings(vaultRoot: string): {
 
     const foldersBlock = raw.match(/^folders:\s*\n((?:[ \t]+[^\n]+\n?)*)/m);
     if (foldersBlock?.[1]) {
-      const logsMatch = foldersBlock[1].match(/logs:\s*(\S+)/);
+      const logsMatch = foldersBlock[1].match(/logs:\s*['"]?([^'"\s]+)['"]?/);
       if (logsMatch?.[1]) logsFolder = logsMatch[1];
     }
 

--- a/packages/cli/src/internal/checkpoint.ts
+++ b/packages/cli/src/internal/checkpoint.ts
@@ -358,6 +358,11 @@ export async function handlePrecompact(
     return; // no-op
   }
 
+  // Double-compact guard: if a stub is already pending postcompact will fill it
+  if (state.pending_stub) {
+    return; // no-op — prevents orphaning the existing stub
+  }
+
   const date = formatDate(now);
 
   // Determine logs folder from vault.yml (fallback to '07-logs')

--- a/packages/cli/src/internal/checkpoint.ts
+++ b/packages/cli/src/internal/checkpoint.ts
@@ -418,11 +418,8 @@ export async function handlePrecompact(
 
 /**
  * Postcompact hook: handle pending stub from precompact.
- * If no pending stub: preserve last_ts, write clean 3-field state.
- * If pending stub: emit fill-checkpoint block (since reference derived from stub
- * filename), clear pending_stub, set last_ts=now so precompact recency guard
- * protects the 5-minute window after a compact cycle completes.
- * Sync.
+ * If pending stub: emit fill-checkpoint block, set last_ts=now.
+ * Sync. Called only when state has pending_stub set.
  */
 export function handlePostcompact(
   token: string,
@@ -432,17 +429,11 @@ export function handlePostcompact(
   const state = readState(token, tmpDir);
 
   if (!state.pending_stub) {
-    // No pending stub — preserve last_ts, write 3-field
-    writeState(
-      token,
-      { count: 0, last_ts: state.last_ts, last_stop_nn: state.last_stop_nn },
-      tmpDir,
-    );
+    writeState(token, { count: 0, last_ts: state.last_ts, last_stop_nn: state.last_stop_nn }, tmpDir);
     return;
   }
 
-  // Pending stub found — derive "since" reference from stub filename (NN - 1)
-  // No dependency on last_stop_nn: stop hooks now compute NN from disk too.
+  // Derive "since" reference from stub filename (NN - 1)
   const stubNnMatch = state.pending_stub.match(/-checkpoint-(\d{2})\.md$/);
   const stubNn = stubNnMatch?.[1] ?? '01';
   const prevNn = Number(stubNn) - 1;
@@ -450,6 +441,60 @@ export function handlePostcompact(
   emitBlock(`fill-checkpoint: ${state.pending_stub}${since}`);
 
   // last_ts=now: recency guard in handlePrecompact blocks re-fire within 5 min
+  writeState(token, { count: 0, last_ts: now, last_stop_nn: stubNn }, tmpDir);
+}
+
+// ---------------------------------------------------------------------------
+// postcompact fallback
+// ---------------------------------------------------------------------------
+
+/**
+ * Fallback for postcompact when state has no pending_stub (e.g. state was lost
+ * or stop hook fired before compact cleared pending_stub from an older session).
+ * Scans disk for unmerged precompact stubs belonging to this session today.
+ * If found: emits fill-checkpoint for the latest one.
+ * If not found: writes clean 3-field state preserving last_ts.
+ * Sync.
+ */
+export function postcompactFallback(
+  token: string,
+  vaultRoot: string,
+  now: number = Math.floor(Date.now() / 1000),
+  tmpDir: string = osTmpdir(),
+): void {
+  const state = readState(token, tmpDir);
+  const { logsFolder } = loadVaultSettings(vaultRoot);
+  const date = formatDate(now);
+  const yyyy = date.slice(0, 4);
+  const mm = date.slice(5, 7);
+  const dir = join(vaultRoot, logsFolder, yyyy, mm);
+  const prefix = `${date}-${token}-checkpoint-`;
+
+  const stubs: string[] = [];
+  try {
+    for (const f of readdirSync(dir)) {
+      if (!f.startsWith(prefix) || !f.endsWith('.md')) continue;
+      const content = readFileSync(join(dir, f), 'utf8');
+      if (/^trigger:\s*precompact/m.test(content) && !/^merged:\s*true/m.test(content)) {
+        stubs.push(f);
+      }
+    }
+  } catch {
+    // dir missing or unreadable — fall through to clean state write
+  }
+
+  if (stubs.length === 0) {
+    writeState(token, { count: 0, last_ts: state.last_ts, last_stop_nn: state.last_stop_nn }, tmpDir);
+    return;
+  }
+
+  stubs.sort();
+  const stubFilename = stubs[stubs.length - 1];
+  const stubNnMatch = stubFilename.match(/-checkpoint-(\d{2})\.md$/);
+  const stubNn = stubNnMatch?.[1] ?? '01';
+  const prevNn = Number(stubNn) - 1;
+  const since = prevNn === 0 ? ' since start' : ` since checkpoint-${String(prevNn).padStart(2, '0')}`;
+  emitBlock(`fill-checkpoint: ${stubFilename}${since}`);
   writeState(token, { count: 0, last_ts: now, last_stop_nn: stubNn }, tmpDir);
 }
 
@@ -474,9 +519,15 @@ export async function checkpointCommand(
       case 'precompact':
         await handlePrecompact(token, vaultRoot);
         break;
-      case 'postcompact':
-        handlePostcompact(token);
+      case 'postcompact': {
+        const { pending_stub } = readState(token);
+        if (pending_stub) {
+          handlePostcompact(token);
+        } else {
+          postcompactFallback(token, vaultRoot);
+        }
         break;
+      }
       case 'reset':
         handleReset(token);
         break;

--- a/packages/cli/src/internal/checkpoint.ts
+++ b/packages/cli/src/internal/checkpoint.ts
@@ -420,14 +420,13 @@ export async function handlePrecompact(
  * Postcompact hook: handle pending stub from precompact.
  * If no pending stub: preserve last_ts, write clean 3-field state.
  * If pending stub: emit fill-checkpoint block (since reference derived from stub
- * filename), clear pending_stub, set last_ts=0.
- * Subsequent stop/precompact hooks compute NN from disk — no special advancement needed.
+ * filename), clear pending_stub, set last_ts=now so precompact recency guard
+ * protects the 5-minute window after a compact cycle completes.
  * Sync.
  */
 export function handlePostcompact(
   token: string,
-  // _now kept for API symmetry with handleStop/handlePrecompact so call sites can pass now as 2nd arg
-  _now: number = Math.floor(Date.now() / 1000),
+  now: number = Math.floor(Date.now() / 1000),
   tmpDir: string = osTmpdir(),
 ): void {
   const state = readState(token, tmpDir);
@@ -450,8 +449,8 @@ export function handlePostcompact(
   const since = prevNn === 0 ? ' since start' : ` since checkpoint-${String(prevNn).padStart(2, '0')}`;
   emitBlock(`fill-checkpoint: ${state.pending_stub}${since}`);
 
-  // Clear pending_stub, set last_ts=0 sentinel, record stub NN for debugging
-  writeState(token, { count: 0, last_ts: 0, last_stop_nn: stubNn }, tmpDir);
+  // last_ts=now: recency guard in handlePrecompact blocks re-fire within 5 min
+  writeState(token, { count: 0, last_ts: now, last_stop_nn: stubNn }, tmpDir);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/cli/src/internal/checkpoint.ts
+++ b/packages/cli/src/internal/checkpoint.ts
@@ -6,12 +6,16 @@
  * State file: $TMPDIR/onebrain-{session_token}.state
  * Format: count:last_ts:last_stop_nn[:pending_stub_filename]
  *
+ * Note: last_stop_nn is kept for backward compat/debugging only.
+ * Checkpoint NN is always derived from actual files on disk — this guarantees
+ * sequential numbering even when Claude fails to write a file (e.g. context full).
+ *
  * Exit code always 0. Errors go to stderr only.
  * JSON decision blocks go to process.stdout.write (no console.log).
  */
 
-import { readFileSync, writeFileSync } from 'node:fs';
-import { mkdir, writeFile } from 'node:fs/promises';
+import { readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import { mkdir, readdir, writeFile } from 'node:fs/promises';
 import { tmpdir as osTmpdir } from 'node:os';
 import { join } from 'node:path';
 import { loadVaultConfig } from '@onebrain/core';
@@ -116,22 +120,26 @@ export function writeState(
 // Config helper
 // ---------------------------------------------------------------------------
 
+const DEFAULT_LOGS_FOLDER = '07-logs';
+
 /**
- * Load messages and minutes thresholds from vault.yml.
+ * Load vault settings from vault.yml (thresholds + logs folder).
  * Returns defaults if vault.yml is missing or throws.
- * Sync via readFileSync + yaml inline parse — avoids async in hot path.
+ * Sync via readFileSync + regex parse — avoids async in stop hook hot path.
  */
-function loadThresholds(vaultRoot: string): {
+function loadVaultSettings(vaultRoot: string): {
   messagesThreshold: number;
   minutesThreshold: number;
+  logsFolder: string;
 } {
   try {
     const vaultYml = join(vaultRoot, 'vault.yml');
     const raw = readFileSync(vaultYml, 'utf8');
-    // Find checkpoint block then parse keys within it
-    const checkpointBlock = raw.match(/^checkpoint:\s*\n((?:[ \t]+[^\n]+\n?)*)/m);
     let messages = DEFAULT_MESSAGES_THRESHOLD;
     let minutes = DEFAULT_MINUTES_THRESHOLD;
+    let logsFolder = DEFAULT_LOGS_FOLDER;
+
+    const checkpointBlock = raw.match(/^checkpoint:\s*\n((?:[ \t]+[^\n]+\n?)*)/m);
     if (checkpointBlock?.[1]) {
       const block = checkpointBlock[1];
       const msgMatch = block.match(/messages:\s*(\d+)/);
@@ -140,12 +148,47 @@ function loadThresholds(vaultRoot: string): {
       if (minMatch?.[1]) minutes = Number(minMatch[1]);
     }
 
-    return { messagesThreshold: messages, minutesThreshold: minutes };
+    const foldersBlock = raw.match(/^folders:\s*\n((?:[ \t]+[^\n]+\n?)*)/m);
+    if (foldersBlock?.[1]) {
+      const logsMatch = foldersBlock[1].match(/logs:\s*(\S+)/);
+      if (logsMatch?.[1]) logsFolder = logsMatch[1];
+    }
+
+    return { messagesThreshold: messages, minutesThreshold: minutes, logsFolder };
   } catch {
     return {
       messagesThreshold: DEFAULT_MESSAGES_THRESHOLD,
       minutesThreshold: DEFAULT_MINUTES_THRESHOLD,
+      logsFolder: DEFAULT_LOGS_FOLDER,
     };
+  }
+}
+
+/**
+ * Scan the logs directory and return the highest checkpoint NN for this session.
+ * Returns 0 if no checkpoint files exist (i.e. next NN should be 01).
+ * Sync — safe to use in handleStop's hot path.
+ */
+export function maxCheckpointNnSync(
+  vaultRoot: string,
+  date: string,
+  token: string,
+  logsFolder: string,
+): number {
+  const yyyy = date.slice(0, 4);
+  const mm = date.slice(5, 7);
+  const dir = join(vaultRoot, logsFolder, yyyy, mm);
+  const prefix = `${date}-${token}-checkpoint-`;
+  try {
+    let max = 0;
+    for (const f of readdirSync(dir)) {
+      if (!f.startsWith(prefix) || !f.endsWith('.md')) continue;
+      const m = f.match(/-checkpoint-(\d{2})\.md$/);
+      if (m) max = Math.max(max, Number(m[1]));
+    }
+    return max;
+  } catch {
+    return 0;
   }
 }
 
@@ -217,7 +260,7 @@ export function handleStop(
   // Increment count
   state.count += 1;
 
-  const { messagesThreshold, minutesThreshold } = loadThresholds(vaultRoot);
+  const { messagesThreshold, minutesThreshold, logsFolder } = loadVaultSettings(vaultRoot);
   const timeThreshold = minutesThreshold * 60;
 
   // Elapsed: last_ts=0 is post-compact sentinel → treat as 0 elapsed
@@ -246,15 +289,16 @@ export function handleStop(
     return;
   }
 
-  // Emit checkpoint
-  const nextNn = String(Number(state.last_stop_nn) + 1).padStart(2, '0');
+  // Derive NN from disk — guarantees sequential numbering even if a previous
+  // checkpoint block fired but Claude never wrote the file.
   const date = formatDate(now);
+  const maxNn = maxCheckpointNnSync(vaultRoot, date, token, logsFolder);
+  const nextNn = String(maxNn + 1).padStart(2, '0');
+  const since = maxNn === 0 ? ' since start' : ` since checkpoint-${String(maxNn).padStart(2, '0')}`;
   const filename = `${date}-${token}-checkpoint-${nextNn}.md`;
-  const since =
-    state.last_stop_nn === '00' ? ' since start' : ` since checkpoint-${state.last_stop_nn}`;
   emitBlock(`${filename}${since}`);
 
-  // Reset state
+  // Reset state (last_stop_nn recorded for debugging; not used for NN computation)
   writeState(token, { count: 0, last_ts: now, last_stop_nn: nextNn }, tmpDir);
 }
 
@@ -314,13 +358,10 @@ export async function handlePrecompact(
     return; // no-op
   }
 
-  // Compute stub NN (last_stop_nn + 1, does NOT update last_stop_nn in state)
-  const stubNn = String(Number(state.last_stop_nn) + 1).padStart(2, '0');
   const date = formatDate(now);
-  const stubFilename = `${date}-${token}-checkpoint-${stubNn}.md`;
 
   // Determine logs folder from vault.yml (fallback to '07-logs')
-  let logsFolder = '07-logs';
+  let logsFolder = DEFAULT_LOGS_FOLDER;
   try {
     const config = await loadVaultConfig(vaultRoot);
     logsFolder = config.folders.logs;
@@ -331,6 +372,18 @@ export async function handlePrecompact(
   const yyyy = formatYYYY(now);
   const mm = formatMM(now);
   const stubDir = join(vaultRoot, logsFolder, yyyy, mm);
+
+  // Derive stub NN from disk — same guarantee as handleStop: sequential, no gaps
+  const existingFiles = await readdir(stubDir).catch(() => [] as string[]);
+  const prefix = `${date}-${token}-checkpoint-`;
+  const maxNn = existingFiles.reduce((max, f) => {
+    if (!f.startsWith(prefix) || !f.endsWith('.md')) return max;
+    const m = f.match(/-checkpoint-(\d{2})\.md$/);
+    return m ? Math.max(max, Number(m[1])) : max;
+  }, 0);
+  const stubNn = String(maxNn + 1).padStart(2, '0');
+
+  const stubFilename = `${date}-${token}-checkpoint-${stubNn}.md`;
   const stubPath = join(stubDir, stubFilename);
 
   try {
@@ -361,9 +414,9 @@ export async function handlePrecompact(
 /**
  * Postcompact hook: handle pending stub from precompact.
  * If no pending stub: preserve last_ts, write clean 3-field state.
- * If pending stub: emit fill-checkpoint block, advance last_stop_nn to stubNn,
- * clear pending_stub, set last_ts=0. Advancing last_stop_nn prevents subsequent
- * stop hooks from reusing the stub's NN and overwriting the filled file.
+ * If pending stub: emit fill-checkpoint block (since reference derived from stub
+ * filename), clear pending_stub, set last_ts=0.
+ * Subsequent stop/precompact hooks compute NN from disk — no special advancement needed.
  * Sync.
  */
 export function handlePostcompact(
@@ -384,16 +437,15 @@ export function handlePostcompact(
     return;
   }
 
-  // Pending stub found — emit fill-checkpoint block
-  const since =
-    state.last_stop_nn === '00' ? ' since start' : ` since checkpoint-${state.last_stop_nn}`;
+  // Pending stub found — derive "since" reference from stub filename (NN - 1)
+  // No dependency on last_stop_nn: stop hooks now compute NN from disk too.
+  const stubNnMatch = state.pending_stub.match(/-checkpoint-(\d{2})\.md$/);
+  const stubNn = stubNnMatch?.[1] ?? '01';
+  const prevNn = Number(stubNn) - 1;
+  const since = prevNn === 0 ? ' since start' : ` since checkpoint-${String(prevNn).padStart(2, '0')}`;
   emitBlock(`fill-checkpoint: ${state.pending_stub}${since}`);
 
-  // Advance last_stop_nn to the stub's NN so subsequent stop checkpoints
-  // don't reuse the same number and overwrite the filled stub.
-  const stubNn = String(Number(state.last_stop_nn) + 1).padStart(2, '0');
-
-  // Clear pending_stub, set last_ts=0 sentinel
+  // Clear pending_stub, set last_ts=0 sentinel, record stub NN for debugging
   writeState(token, { count: 0, last_ts: 0, last_stop_nn: stubNn }, tmpDir);
 }
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onebrain/core",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "type": "module",
   "main": "src/index.ts",
   "exports": {


### PR DESCRIPTION
## Summary

- **fix(update):** `backfill-recapped.sh` adds optional `[cutoff_date]` arg; migration Step 6 reads `stats.last_recap` from vault.yml and passes it as cutoff — prevents `/update` from re-marking sessions that `/recap` hasn't processed yet on every run
- **fix(checkpoint):** `handlePostcompact` now advances `last_stop_nn` to the stub's NN (parsed from filename) after emitting `fill-checkpoint` block — previously `last_stop_nn` was unchanged, causing subsequent stop hooks to reuse the same NN and overwrite the filled stub
- **fix(wrapup):** `reset-checkpoint-counter.sh` writes 3-field state (`0:<epoch>:00`) instead of 2-field v1 format, which bypassed the 60-second skip window after `/wrapup`
- **fix(update):** `backfill-recapped.sh` uses `awk` instead of `sed` for inserting `recapped:` — BSD `sed` on macOS inserts a blank line with the heredoc continuation form

## Test plan

- [ ] `bun test packages/cli/src/internal/checkpoint.test.ts` — 41 tests pass (added: postcompact NN advancement, "since start"/"since checkpoint-NN" state assertions, filename-authoritative NN mismatch test)
- [ ] Manual: run `/update` on a vault with `stats.last_recap` set — verify only logs on or before that date get backfilled
- [ ] Manual: trigger compact mid-session, verify postcompact fills stub and next stop checkpoint uses NN+1

🤖 Generated with [Claude Code](https://claude.com/claude-code)