### PR TITLE
fix: vault skill fixes — grep encoding, PostCompact auto-wrapup, /update CLI migration, auto-summary routing (v2.0.5)

### DIFF
--- a/.claude/plugins/onebrain/.claude-plugin/plugin.json
+++ b/.claude/plugins/onebrain/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "onebrain",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "OneBrain — Where human and AI thinking become one. A powerful thinking partner powered by AI synergy.",
   "author": {
     "name": "OneBrain Contributors"

--- a/.claude/plugins/onebrain/INSTRUCTIONS.md
+++ b/.claude/plugins/onebrain/INSTRUCTIONS.md
@@ -340,14 +340,16 @@ Keep under 250 words.
 
 **PostCompact auto-wrapup:** When block reason matches `auto-wrapup: <token>`:
 1. Parse `<token>` from the block reason
-2. Find all unmerged checkpoint files for this token:
+2. Glob candidate checkpoint files:
    - Current month: `[logs_folder]/YYYY/MM/*-{token}-checkpoint-*.md` (using today's YYYY/MM)
    - Previous month: decrement MM (if MM=01, also decrement YYYY and set MM=12)
+   - After globbing, parse the token segment from each filename (`YYYY-MM-DD-{token}-checkpoint-NN.md`) and discard files where the parsed token does not exactly equal `<token>`
    - Keep only files where frontmatter `merged` is absent or not `true`
 3. If no files found → no-op; output nothing
-4. Determine session date from earliest checkpoint filename date prefix (YYYY-MM-DD)
-5. Determine next free session slot: count existing `YYYY-MM-DD-session-*.md` for that date; NN = count + 1 (zero-padded); verify slot is free
-6. Write recovered session log at `[logs_folder]/YYYY/MM/YYYY-MM-DD-session-NN.md`:
+4. Read all matched checkpoint files and extract their content for synthesis in step 6
+5. Determine session date from earliest checkpoint filename date prefix (YYYY-MM-DD); extract `YYYY` and `MM` from this date for all path construction below
+6. Determine next free session slot: count existing `YYYY-MM-DD-session-*.md` in `[logs_folder]/YYYY/MM/` (using session YYYY/MM); NN = count + 1 (zero-padded); verify slot is free
+7. Write recovered session log at `[logs_folder]/YYYY/MM/YYYY-MM-DD-session-NN.md` (using session YYYY/MM):
 
 ```markdown
 ---
@@ -379,9 +381,11 @@ auto-recovered: true
 - [Open questions from checkpoints]
 ```
 
-7. Mark each checkpoint file `merged: true` (handle all variants: `merged: false`, `merged: null`, absent → set `merged: true`)
-8. Delete checkpoint files — only AFTER session log write confirmed AND all files marked merged
-9. Silent — no output to user
+8. Verify the session log file exists and is non-empty before continuing
+9. Reset the checkpoint hook counter: `bash ".claude/plugins/onebrain/skills/wrapup/scripts/reset-checkpoint-counter.sh"`
+10. Mark each checkpoint file `merged: true` (handle all variants: `merged: false`, `merged: null`, absent → set `merged: true`). If any individual write fails, do not delete that file — skip it and continue
+11. Delete checkpoint files — only AFTER session log write confirmed (step 8) AND file successfully marked merged (step 10); never delete a file whose `merged: true` write failed
+12. Silent — no output to user
 
 **Post-checkpoint recovery (stop only):** After silently writing a stop checkpoint:
 1. Look at the last user message in conversation history

--- a/.claude/plugins/onebrain/INSTRUCTIONS.md
+++ b/.claude/plugins/onebrain/INSTRUCTIONS.md
@@ -223,7 +223,7 @@ On weekends: lighter, less task-focused tone. **No-repeat rule:** don't ask abou
 - Read `[agent_folder]/MEMORY-INDEX.md` → load memory file index for lazy-loading
 - Load `memory/` files matching active project keywords from MEMORY-INDEX.md Topics column (`status: active` or `needs-review` only). Also match user's first message once it arrives.
 - Glob `[inbox_folder]/*.md` → count files as `inbox_count`
-- Grep `[projects_folder]/**/*.md` and `[inbox_folder]/*.md` for `- \[ \] .*📅 \d{4}-\d{2}-\d{2}` → keep only tasks where date ≤ today; group overdue first, then due today
+- Grep `[projects_folder]/**/*.md` and `[inbox_folder]/*.md` for `- \[ \] .*📅 [0-9]{4}-[0-9]{2}-[0-9]{2}` → keep only tasks where date ≤ today; group overdue first, then due today
 - Run `onebrain orphan-scan "[logs_folder]" "[session_token]"` (from vault root) → parse JSON output; read `orphan_count` field. JSON shape: `{"orphan_count":N}`. If the command fails or is unavailable, fall back to: Glob `[logs_folder]/**/*-checkpoint-*.md`, read frontmatter of each, discard `merged: true` and files whose date has a non-auto-saved session log, then count distinct session tokens among remaining files.
 
 **Step 4 — Send startup status (after Step 3 completes):**
@@ -291,18 +291,15 @@ If the user closes the session without any end-of-session signal, AUTO-SUMMARY d
 
 When a hook sends a message matching `YYYY-MM-DD-{session_token}-checkpoint-NN.md` (no slashes — a date, an alphanumeric session token, the literal word "checkpoint", and a zero-padded NN), silently write a checkpoint. Parse session_token and NN directly from the trigger filename — no extra Bash call needed. Write to `[logs_folder]/YYYY/MM/YYYY-MM-DD-{session_token}-checkpoint-NN.md`. Extract `YYYY` and `MM` from the trigger filename to construct the path. Create parent directories if missing. No output to user.
 
-Stop and PostCompact hooks trigger checkpoint writes. Determine `trigger` from the system-reminder header: `Stop hook blocking error` → `trigger: stop`; `PostCompact` with block reason starting `fill-checkpoint:` → `trigger: postcompact`. PreCompact no longer sends a block to Claude (the binary writes a stub file directly and exits 0). If the header is ambiguous, default to `trigger: stop`. If a PostCompact block arrives with a block reason that does not start with `fill-checkpoint:`, treat it as a no-op — write nothing and output nothing.
+Stop hooks write checkpoint files silently. PostCompact hooks trigger auto-wrapup for the previous session. Determine action from the system-reminder header:
+- `Stop hook blocking error` → write stop checkpoint (format below)
+- `PostCompact` with block reason starting `auto-wrapup:` → run auto-wrapup for that session token (see below)
+- `PostCompact` with any other block reason → no-op; write nothing and output nothing
+- Ambiguous header → default to stop checkpoint
 
-**PostCompact fill-checkpoint (trigger: postcompact):** When block reason matches `fill-checkpoint: <filename> since <reference>` (where reference is `start` or `checkpoint-NN`):
-1. Extract `YYYY` and `MM` from `<filename>` (format: `YYYY-MM-DD-{token}-checkpoint-NN.md`). Read the existing stub file at `[logs_folder]/YYYY/MM/<filename>` if it exists; if missing, create it at that path using `trigger: postcompact` in frontmatter (not `trigger: precompact`)
-2. Fill in all 6 content sections covering events **since `<reference>` only** — not the full session
-3. Preserve all frontmatter fields exactly as written — do not overwrite `trigger`, `date`, `checkpoint`, or `merged`
-4. Write back to the same file path
-5. Silent — no output to user
+PreCompact no longer sends a block to Claude (the binary writes a stub file directly and exits 0).
 
-Write:
-
-> **Note:** For stop-triggered checkpoints use `trigger: stop`; for new files created in the fill-checkpoint path use `trigger: postcompact`.
+**Stop checkpoint format:**
 
 ```markdown
 ---
@@ -340,6 +337,51 @@ merged: false
 ```
 
 Keep under 250 words.
+
+**PostCompact auto-wrapup:** When block reason matches `auto-wrapup: <token>`:
+1. Parse `<token>` from the block reason
+2. Find all unmerged checkpoint files for this token:
+   - Current month: `[logs_folder]/YYYY/MM/*-{token}-checkpoint-*.md` (using today's YYYY/MM)
+   - Previous month: decrement MM (if MM=01, also decrement YYYY and set MM=12)
+   - Keep only files where frontmatter `merged` is absent or not `true`
+3. If no files found → no-op; output nothing
+4. Determine session date from earliest checkpoint filename date prefix (YYYY-MM-DD)
+5. Determine next free session slot: count existing `YYYY-MM-DD-session-*.md` for that date; NN = count + 1 (zero-padded); verify slot is free
+6. Write recovered session log at `[logs_folder]/YYYY/MM/YYYY-MM-DD-session-NN.md`:
+
+```markdown
+---
+tags: [session-log]
+date: YYYY-MM-DD
+session: NN
+synthesized_from_checkpoints: true
+auto-recovered: true
+---
+
+# Session Summary : [Month DD, YYYY] (Session N)
+
+## What We Worked On
+[1-3 sentences synthesized from checkpoint content]
+
+## Key Decisions
+- [All key decisions from checkpoints]
+
+## Insights & Learnings
+- [Insights from checkpoints]
+
+## What Worked / Didn't Work
+- ✅ / ❌ [From checkpoints — omit section if none noted]
+
+## Action Items
+- [ ] [Action items from checkpoints] 📅 YYYY-MM-DD
+
+## Open Questions
+- [Open questions from checkpoints]
+```
+
+7. Mark each checkpoint file `merged: true` (handle all variants: `merged: false`, `merged: null`, absent → set `merged: true`)
+8. Delete checkpoint files — only AFTER session log write confirmed AND all files marked merged
+9. Silent — no output to user
 
 **Post-checkpoint recovery (stop only):** After silently writing a stop checkpoint:
 1. Look at the last user message in conversation history

--- a/.claude/plugins/onebrain/skills/startup/AUTO-SUMMARY.md
+++ b/.claude/plugins/onebrain/skills/startup/AUTO-SUMMARY.md
@@ -29,8 +29,8 @@ If conditions are met:
   4. Group assigned tasks by target file. For each target file:
      - Read the file once.
      - Dedup: strip `📅 YYYY-MM-DD` suffix from candidate and existing `- [ ]`/`- [x]` lines before comparing; skip if same text already exists (open or completed).
-     - Insert at first available point: after last `- [ ]` in `## Action Items` section → or before `## Open Questions` → or before `## Related` → or at end of file.
-     - Write the file once. On write error, skip all tasks for this file silently.
+     - Insert at first available point: after last `- [ ]` in `## Action Items` section (or after the `## Action Items` heading if the section exists but is empty) → or before `## Open Questions` → or before `## Related` → or at end of file.
+     - Write the file once. On write error, skip all tasks for this file silently and continue to the next target file.
 - Mark as `merged: true` the checkpoint files that were read and incorporated above. Handle all frontmatter variants: `merged: false` → replace with `merged: true`; `merged: null` or bare `merged:` → replace with `merged: true`; key absent → add `merged: true`.
 - Guard: only delete checkpoint files AFTER confirming the session log file was successfully written. Never delete before or during the write.
 - After confirming the session log was written, reset the checkpoint hook counter to prevent spurious post-summary checkpoints:

--- a/.claude/plugins/onebrain/skills/startup/AUTO-SUMMARY.md
+++ b/.claude/plugins/onebrain/skills/startup/AUTO-SUMMARY.md
@@ -22,6 +22,15 @@ If conditions are met:
   ```
   **Never add `recapped:` or `topics:` to this frontmatter.** These fields are set exclusively by /recap. Writing them here causes /recap to silently skip the log.
   The log must include all sections: `## What We Worked On`, `## Key Decisions`, `## Insights & Learnings`, `## What Worked / Didn't Work`, `## Action Items`, `## Open Questions`. Omit `## What Worked / Didn't Work` only if the session had no notable friction or technique worth logging. **Do not write the session log if any unmerged checkpoint's content is absent from the relevant sections** : every checkpoint's Key Decisions, Action Items, and Open Questions must appear explicitly in the output.
+- **Route action items to project notes** — after the session log is written, automatically move action items so the startup task scan picks them up. This step must never fail the auto-summary; all errors are silently skipped.
+  1. Parse `## Action Items` from the session log just written. Collect all `- [ ] ...` lines. If none, skip entirely.
+  2. Glob `[projects_folder]/**/*.md`. For each file, collect the folder name and filename stem as candidate keywords.
+  3. For each task: split folder name and filename stem on hyphens/underscores into tokens; count tokens that appear as case-insensitive whole-word matches in the task text. Require score ≥ 1 and a unique winner (no tie). If score = 0 or tie → skip this task.
+  4. Group assigned tasks by target file. For each target file:
+     - Read the file once.
+     - Dedup: strip `📅 YYYY-MM-DD` suffix from candidate and existing `- [ ]`/`- [x]` lines before comparing; skip if same text already exists (open or completed).
+     - Insert at first available point: after last `- [ ]` in `## Action Items` section → or before `## Open Questions` → or before `## Related` → or at end of file.
+     - Write the file once. On write error, skip all tasks for this file silently.
 - Mark as `merged: true` the checkpoint files that were read and incorporated above. Handle all frontmatter variants: `merged: false` → replace with `merged: true`; `merged: null` or bare `merged:` → replace with `merged: true`; key absent → add `merged: true`.
 - Guard: only delete checkpoint files AFTER confirming the session log file was successfully written. Never delete before or during the write.
 - After confirming the session log was written, reset the checkpoint hook counter to prevent spurious post-summary checkpoints:

--- a/.claude/plugins/onebrain/skills/update/SKILL.md
+++ b/.claude/plugins/onebrain/skills/update/SKILL.md
@@ -58,6 +58,7 @@ After confirming the vault update (step 7 above), also check if the installed `o
       - Both bun and npm available: options `npm / bun / skip` (npm as default)
       - Only bun: options `bun / skip`
       - Only npm: options `npm / skip`
+      - Neither available: output `⚠️ CLI v{installed} is outdated (latest: v{latest}) — install npm or bun to update.` and skip
    c. If `npm` selected: run `npm install -g @onebrain-ai/cli`
    d. If `bun` selected: run `bun install -g @onebrain-ai/cli`
    e. Verify: run `onebrain --version` → confirm output matches `{latest}`

--- a/.claude/plugins/onebrain/skills/update/SKILL.md
+++ b/.claude/plugins/onebrain/skills/update/SKILL.md
@@ -45,6 +45,23 @@ Minor/patch bumps (1.10.0 → 1.10.1, 1.10.0 → 1.11.0): proceed without major 
    Options: `update / cancel`
 7. If confirmed → proceed to bootstrap below
 
+## CLI Version Check
+
+After confirming the vault update (step 7 above), also check if the installed `onebrain` CLI is up to date.
+
+1. Run `onebrain --version 2>/dev/null` → parse installed version (e.g. `2.0.4`). If command not found → skip this section entirely.
+2. Fetch latest from npm: `npm view @onebrain-ai/cli version 2>/dev/null` → parse version string. If npm unavailable or fetch fails → skip.
+3. If installed = latest → skip (no output needed).
+4. If newer version available:
+   a. Detect available package managers: `which bun 2>/dev/null` and `which npm 2>/dev/null`
+   b. AskUserQuestion: "Update onebrain CLI from v{installed} to v{latest}?"
+      - Both bun and npm available: options `npm / bun / skip` (npm as default)
+      - Only bun: options `bun / skip`
+      - Only npm: options `npm / skip`
+   c. If `npm` selected: run `npm install -g @onebrain-ai/cli`
+   d. If `bun` selected: run `bun install -g @onebrain-ai/cli`
+   e. Verify: run `onebrain --version` → confirm output matches `{latest}`
+
 ## Self-Update Bootstrap (Read-New, Execute-In-Place)
 
 Skills are markdown instructions — the agent can read the new SKILL.md from GitHub and
@@ -59,10 +76,9 @@ Steps:
 
    Raw URL: `https://raw.githubusercontent.com/kengio/onebrain/{branch}/.claude/plugins/onebrain/{path}`
 
-   Download and write all six files:
+   Download and write all five files:
    - `skills/update/SKILL.md`
    - `skills/update/scripts/vault-sync.sh`
-   - `skills/update/scripts/register-hooks.sh`
    - `skills/update/scripts/backfill-recapped.sh`
    - `skills/update/scripts/clean-plugin-cache.sh`
    - `skills/update/scripts/pin-to-vault.sh`

--- a/.claude/plugins/onebrain/skills/update/references/migration-steps.md
+++ b/.claude/plugins/onebrain/skills/update/references/migration-steps.md
@@ -99,9 +99,9 @@ Always: update `updated:` frontmatter to today.
 
 **Step 7: Register OneBrain hooks in `[vault]/.claude/settings.json`**
 
-Runs every /update — idempotent. Ensures all 3 hooks point to the correct script.
+Runs every /update — idempotent. Ensures all hooks point to the correct script.
 
-- Run `bash ".claude/plugins/onebrain/skills/update/scripts/register-hooks.sh" ".claude/settings.json"` — registers Stop, PreCompact, PostCompact hooks; never removes user-added hooks in the same event key
+- Run `onebrain register-hooks` — registers Stop, PreCompact, PostCompact, and SessionStart hooks; never removes user-added hooks in the same event key
 - Check output: "all hooks already registered" → ✅ done; "added X" → ✅ registered
 
 **PostToolUse qmd hook (only when `qmd_collection` is set in vault.yml):**
@@ -110,7 +110,7 @@ Runs every /update — idempotent. Ensures all 3 hooks point to the correct scri
   - Check output: "all hooks already registered" → ✅ done; "added PostToolUse" → ✅ registered
 
 **Bash permission for onebrain CLI:**
-- Read `[vault]/.claude/settings.json` fresh (after the register-hooks.sh calls above have written to it); check `permissions.allow` contains `"Bash(onebrain *)"` — if missing, add it using an inline Python snippet or targeted JSON edit. Never rewrite the entire file. Example:
+- Read `[vault]/.claude/settings.json` fresh (after `onebrain register-hooks` has written to it); check `permissions.allow` contains `"Bash(onebrain *)"` — if missing, add it using an inline Python snippet or targeted JSON edit. Never rewrite the entire file. Example:
   ```python
   import json
   path = ".claude/settings.json"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - fix(startup): task scan grep pattern — replaced `\d` with `[0-9]` for POSIX grep compatibility on macOS
 - fix(checkpoint): replace fill-checkpoint PostCompact handler with auto-wrapup — when block reason matches `auto-wrapup: <token>`, recover orphan checkpoints for that token into a session log
-- fix(update): migrate Step 7 register-hooks call from bash script to `onebrain register-hooks` CLI command
+- fix(update): Step 7 standard hooks now use `onebrain register-hooks` CLI; qmd PostToolUse hook still via register-hooks.sh (no CLI support yet)
 - feat(update): CLI version check — after vault update, compare installed `onebrain` CLI against npm latest; prompt to update via npm or bun if newer is available
 - feat(auto-summary): add action item routing (Step 4b parity with /wrapup) — after writing session log, route tasks to matching project notes via keyword scoring
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ---
-latest_version: 2.0.4
-released: 2026-04-25
+latest_version: 2.0.5
+released: 2026-04-26
 ---
 
 # Changelog
@@ -13,6 +13,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 > `/update` tracks plugin version only — CLI updates happen via `npm install -g @onebrain-ai/cli`.
 
 ## [Unreleased]
+
+## v2.0.5 — fix: vault skill fixes (grep encoding, PostCompact, /update CLI migration, auto-summary routing)
+
+- fix(startup): task scan grep pattern — replaced `\d` with `[0-9]` for POSIX grep compatibility on macOS
+- fix(checkpoint): replace fill-checkpoint PostCompact handler with auto-wrapup — when block reason matches `auto-wrapup: <token>`, recover orphan checkpoints for that token into a session log
+- fix(update): migrate Step 7 register-hooks call from bash script to `onebrain register-hooks` CLI command
+- feat(update): CLI version check — after vault update, compare installed `onebrain` CLI against npm latest; prompt to update via npm or bun if newer is available
+- feat(auto-summary): add action item routing (Step 4b parity with /wrapup) — after writing session log, route tasks to matching project notes via keyword scoring
 
 ## v2.0.4 — feat: /wrapup auto-routes action items to project notes
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onebrain-ai/cli",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "CLI for OneBrain — personal AI OS for Obsidian with persistent memory, 24+ skills, and Claude Code integration",
   "keywords": [
     "onebrain",

--- a/packages/cli/src/commands/update.test.ts
+++ b/packages/cli/src/commands/update.test.ts
@@ -522,3 +522,16 @@ describe('runUpdate', () => {
     expect(calls).toContain('install:v2.0.0'); // binary install called
   });
 });
+
+describe('defaultValidateBinary regex', () => {
+  const regex = /v\d+\.\d+/;
+
+  it('matches actual onebrain --version output format', () => {
+    expect(regex.test('OneBrain v2.0.7 — released 2026-04-26')).toBe(true);
+  });
+
+  it('old regex /^\\d+\\.\\d+/ would not match the same output', () => {
+    const oldRegex = /^\d+\.\d+/;
+    expect(oldRegex.test('OneBrain v2.0.7 — released 2026-04-26')).toBe(false);
+  });
+});

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -163,7 +163,7 @@ async function defaultValidateBinary(): Promise<boolean> {
     const exitCode = await proc.exited;
     if (exitCode !== 0) return false;
     const stdout = await new Response(proc.stdout).text();
-    return /^\d+\.\d+/.test(stdout.trim());
+    return /v\d+\.\d+/.test(stdout.trim());
   } catch {
     return false;
   }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onebrain/core",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "type": "module",
   "main": "src/index.ts",
   "exports": {


### PR DESCRIPTION
## Summary

- **fix(startup):** task scan grep pattern — `\d` → `[0-9]` for POSIX grep compatibility on macOS (tasks were not appearing at startup)
- **fix(checkpoint):** replace fill-checkpoint PostCompact handler with `auto-wrapup: <token>` handler — recovers orphan checkpoints into a session log when the CLI sends a PostCompact block after a compact event
- **fix(update):** Step 7 standard hooks registration migrated from `bash register-hooks.sh` to `onebrain register-hooks` CLI; qmd PostToolUse hook still via bash script (no CLI support yet)
- **feat(update):** CLI version check — after vault update, compare installed `onebrain` against npm latest and prompt to update via npm or bun (with "neither" fallback)
- **feat(auto-summary):** action item routing (Step 4b parity with /wrapup) — after writing session log, routes tasks to matching project notes via keyword scoring
- **fix(update):** `defaultValidateBinary` regex `^\d+\.\d+` → `v\d+\.\d+` — `onebrain --version` outputs `"OneBrain v2.0.6 — ..."` which does not start with a digit; old regex caused `register-hooks` to be silently skipped on every `/update` run (CLI v2.0.7)
- **test(update):** add unit tests documenting the regex fix and the old regex failure case

## Review fixes (commit 2)

- auto-wrapup: explicit read-checkpoints step before synthesis
- auto-wrapup: use session YYYY/MM (from checkpoint date) for log path, not today's date
- auto-wrapup: checkpoint counter reset after writing recovered session log
- auto-wrapup: exact token equality check after glob to prevent false positives
- auto-wrapup: per-file guard — skip delete if `merged: true` write failed
- auto-summary: insertion point handles empty `## Action Items` section correctly
- auto-summary: per-file error handling — continue to next file on write error
- update: add "neither npm nor bun" fallback in CLI version check

## Dependencies

~~Depends on PR2~~ — PR2 merged ✅

## Test plan

- [ ] Startup: create a task with `📅 YYYY-MM-DD` in a project note, verify it appears in startup status
- [ ] PostCompact auto-wrapup: verify recovered session log written correctly when CLI sends `auto-wrapup: <token>` block
- [ ] /update: verify `onebrain register-hooks` is called instead of bash script; verify CLI version check prompts correctly
- [ ] /update: verify `register-hooks` is now called correctly after binary validation fix
- [ ] Auto-summary: say "bye" at end of session, verify action items from session are routed to project notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)