### PR TITLE
fix(cli): postcompact auto-wrapup, update vault guard, vault root auto-detect (v2.0.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,6 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
-## v2.0.5 — fix: Windows compatibility — PowerShell spawn, permission format, Unicode stdout (#110)
-
 ## v2.0.4 — feat: /wrapup auto-routes action items to project notes
 
 - feat(wrapup): Step 4b — after writing the session log, extract `- [ ]` action items and route each to the most relevant project note via keyword scoring (folder name + filename stem match against task text)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-latest_version: 2.0.6
+latest_version: 2.0.4
 released: 2026-04-26
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ---
 latest_version: 2.0.4
-released: 2026-04-26
+released: 2026-04-25
 ---
 
 # Changelog
@@ -13,16 +13,6 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 > `/update` tracks plugin version only — CLI updates happen via `npm install -g @onebrain-ai/cli`.
 
 ## [Unreleased]
-
-## v2.0.6 — fix: postcompact auto-wrapup, update vault guard, vault root auto-detect
-
-- fix(checkpoint): replace `fill-checkpoint` with `auto-wrapup: <token>` in postcompact — emits block so Claude runs wrapup synthesis while compact summary is fresh
-- fix(checkpoint): precompact no longer writes stub files — just resets message count; postcompact uses same recency guard (5 min) to skip emit if stop checkpoint was very recent
-- fix(checkpoint): remove `pending_stub` from state format — 3-field only; legacy 4-field files silently ignored on read
-- fix(update): vault.yml existence guard — exits 1 with clear error if `vault.yml` not found; prevents running outside a vault
-- fix(update): skip binary install step when `latestVersion === currentVersion` — vault-sync and hook registration still run
-- fix(update): add spinners (TTY) for vault-sync and binary install steps
-- fix(cli): `session-init` and `checkpoint` auto-detect vault root by walking up from cwd — no `cd` to vault required; `--vault-dir` option added for explicit override
 
 ## v2.0.5 — fix: Windows compatibility — PowerShell spawn, permission format, Unicode stdout (#110)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ---
-latest_version: 2.0.4
-released: 2026-04-25
+latest_version: 2.0.6
+released: 2026-04-26
 ---
 
 # Changelog
@@ -13,6 +13,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 > `/update` tracks plugin version only — CLI updates happen via `npm install -g @onebrain-ai/cli`.
 
 ## [Unreleased]
+
+## v2.0.6 — fix: postcompact auto-wrapup, update vault guard, vault root auto-detect
+
+- fix(checkpoint): replace `fill-checkpoint` with `auto-wrapup: <token>` in postcompact — emits block so Claude runs wrapup synthesis while compact summary is fresh
+- fix(checkpoint): precompact no longer writes stub files — just resets message count; postcompact uses same recency guard (5 min) to skip emit if stop checkpoint was very recent
+- fix(checkpoint): remove `pending_stub` from state format — 3-field only; legacy 4-field files silently ignored on read
+- fix(update): vault.yml existence guard — exits 1 with clear error if `vault.yml` not found; prevents running outside a vault
+- fix(update): skip binary install step when `latestVersion === currentVersion` — vault-sync and hook registration still run
+- fix(update): add spinners (TTY) for vault-sync and binary install steps
+- fix(cli): `session-init` and `checkpoint` auto-detect vault root by walking up from cwd — no `cd` to vault required; `--vault-dir` option added for explicit override
+
+## v2.0.5 — fix: Windows compatibility — PowerShell spawn, permission format, Unicode stdout (#110)
 
 ## v2.0.4 — feat: /wrapup auto-routes action items to project notes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -167,7 +167,7 @@ Hooks run shell commands automatically when Claude performs certain actions. Hoo
 
 Most hooks support a `matcher` field to filter by tool name or event subtype. `UserPromptSubmit`, `Stop`, `TeammateIdle`, `TaskCompleted`, `WorktreeCreate`, and `WorktreeRemove` fire on every occurrence and do not support matchers.
 
-**Example — checkpoint system:** OneBrain's built-in `checkpoint-hook.sh` uses the `Stop` hook to auto-save session snapshots. It fires after every response, tracks message count + elapsed time against configurable thresholds, and writes a checkpoint file when either threshold is reached. State is kept in `/tmp/onebrain-{PPID}.state` (format: `COUNT:LAST_TS`) so the hook can accumulate counts across responses without forking a long-running process.
+**Example — checkpoint system:** OneBrain's checkpoint system uses the `Stop`, `PreCompact`, and `PostCompact` hooks to auto-save session snapshots. Each hook calls `onebrain checkpoint <mode>` (the CLI binary). The binary tracks message count + elapsed time against configurable thresholds and emits a `decision:block` JSON payload when a checkpoint is due. State is kept in `$TMPDIR/onebrain-{session_token}.state` (format: `count:last_ts:last_stop_nn`) so counts accumulate across responses.
 
 **To add a hook:**
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onebrain-ai/cli",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "CLI for OneBrain — personal AI OS for Obsidian with persistent memory, 24+ skills, and Claude Code integration",
   "keywords": [
     "onebrain",

--- a/packages/cli/src/commands/update.test.ts
+++ b/packages/cli/src/commands/update.test.ts
@@ -419,28 +419,30 @@ describe('runUpdate', () => {
     );
     await mkdir(emptyDir, { recursive: true });
 
-    let fetchCalled = false;
-    const opts: UpdateOptions = {
-      vaultDir: emptyDir,
-      isTTY: false,
-      fetchFn: async (...args) => {
-        fetchCalled = true;
-        return makeMockFetch('v2.0.0')(...args);
-      },
-      vaultSyncFn: noopVaultSync,
-      installBinaryFn: noopInstallBinary,
-      validateBinaryFn: noopValidateBinary,
-      registerHooksFn: noopRegisterHooks,
-    };
+    try {
+      let fetchCalled = false;
+      const opts: UpdateOptions = {
+        vaultDir: emptyDir,
+        isTTY: false,
+        fetchFn: async (...args) => {
+          fetchCalled = true;
+          return makeMockFetch('v2.0.0')(...args);
+        },
+        vaultSyncFn: noopVaultSync,
+        installBinaryFn: noopInstallBinary,
+        validateBinaryFn: noopValidateBinary,
+        registerHooksFn: noopRegisterHooks,
+      };
 
-    const result = await runUpdate(opts);
+      const result = await runUpdate(opts);
 
-    expect(result.ok).toBe(false);
-    expect(result.exitCode).toBe(1);
-    expect(result.error).toMatch(/vault\.yml not found/);
-    expect(fetchCalled).toBe(false); // guard fires before fetch
-
-    await rm(emptyDir, { recursive: true, force: true });
+      expect(result.ok).toBe(false);
+      expect(result.exitCode).toBe(1);
+      expect(result.error).toMatch(/vault\.yml not found/);
+      expect(fetchCalled).toBe(false); // guard fires before fetch
+    } finally {
+      await rm(emptyDir, { recursive: true, force: true });
+    }
   });
 
   it('same version — vault-sync runs, binary install skipped', async () => {

--- a/packages/cli/src/commands/update.test.ts
+++ b/packages/cli/src/commands/update.test.ts
@@ -410,4 +410,113 @@ describe('runUpdate', () => {
     const vaultYml = await readVaultYml(tempDir);
     expect(vaultYml.onebrain_version).toBe('v1.10.18');
   });
+
+  it('vault.yml missing → exits 1 with clear error before any network call', async () => {
+    // Use a directory with no vault.yml
+    const emptyDir = join(
+      tmpdir(),
+      `onebrain-update-test-novault-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    await mkdir(emptyDir, { recursive: true });
+
+    let fetchCalled = false;
+    const opts: UpdateOptions = {
+      vaultDir: emptyDir,
+      isTTY: false,
+      fetchFn: async (...args) => {
+        fetchCalled = true;
+        return makeMockFetch('v2.0.0')(...args);
+      },
+      vaultSyncFn: noopVaultSync,
+      installBinaryFn: noopInstallBinary,
+      validateBinaryFn: noopValidateBinary,
+      registerHooksFn: noopRegisterHooks,
+    };
+
+    const result = await runUpdate(opts);
+
+    expect(result.ok).toBe(false);
+    expect(result.exitCode).toBe(1);
+    expect(result.error).toMatch(/vault\.yml not found/);
+    expect(fetchCalled).toBe(false); // guard fires before fetch
+
+    await rm(emptyDir, { recursive: true, force: true });
+  });
+
+  it('same version — vault-sync runs, binary install skipped', async () => {
+    // Set vault.yml currentVersion to match latestVersion
+    await writeVaultYml(tempDir, {
+      method: 'onebrain',
+      update_channel: 'stable',
+      onebrain_version: 'v2.0.0',
+    });
+
+    const calls: string[] = [];
+
+    const opts: UpdateOptions = {
+      vaultDir: tempDir,
+      isTTY: false,
+      fetchFn: makeMockFetch('v2.0.0'),
+      vaultSyncFn: async (vaultDir, syncOpts) => {
+        calls.push('vault-sync');
+        return noopVaultSync(vaultDir, syncOpts);
+      },
+      installBinaryFn: async (version) => {
+        calls.push(`install:${version}`);
+      },
+      validateBinaryFn: async () => {
+        calls.push('validate');
+        return true;
+      },
+      registerHooksFn: async (vaultDir) => {
+        calls.push('register-hooks');
+        return noopRegisterHooks(vaultDir);
+      },
+    };
+
+    const result = await runUpdate(opts);
+
+    expect(result.ok).toBe(true);
+    expect(result.latestVersion).toBe('v2.0.0');
+    expect(result.currentVersion).toBe('v2.0.0');
+
+    // vault-sync ran; binary install did NOT
+    expect(calls).toContain('vault-sync');
+    expect(calls).not.toContain('install:v2.0.0');
+
+    // validate and register-hooks still ran
+    expect(calls).toContain('validate');
+    expect(calls).toContain('register-hooks');
+  });
+
+  it('different versions — binary install IS called', async () => {
+    // tempDir already has onebrain_version: 'v1.10.18', latest is 'v2.0.0'
+    const calls: string[] = [];
+
+    const opts: UpdateOptions = {
+      vaultDir: tempDir,
+      isTTY: false,
+      fetchFn: makeMockFetch('v2.0.0'),
+      vaultSyncFn: async (vaultDir, syncOpts) => {
+        calls.push('vault-sync');
+        return noopVaultSync(vaultDir, syncOpts);
+      },
+      installBinaryFn: async (version) => {
+        calls.push(`install:${version}`);
+      },
+      validateBinaryFn: async () => {
+        calls.push('validate');
+        return true;
+      },
+      registerHooksFn: async (vaultDir) => {
+        calls.push('register-hooks');
+        return noopRegisterHooks(vaultDir);
+      },
+    };
+
+    const result = await runUpdate(opts);
+
+    expect(result.ok).toBe(true);
+    expect(calls).toContain('install:v2.0.0'); // binary install called
+  });
 });

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -2,23 +2,25 @@
  * update — Atomic OneBrain update sequence
  *
  * Steps:
+ *   0. Guard: vault.yml must exist (prevents running outside a vault)
  *   1. Fetch latest release from GitHub (parse tag_name)
  *   2. Sync plugin files (vault-sync)
  *   3. (Handled by vault-sync Step 4 — merge harness files)
- *   4. Install binary (bun install -g / npm install -g on Windows)
+ *   4. Install binary — skipped if already at latest version
  *   4b. Validate binary (ATOMIC GATE — register-hooks blocked if this fails)
  *   5. Register hooks (only if 4b passed)
  *   6. Write onebrain_version to vault.yml
  *
- * TTY:     uses @clack/prompts layout
+ * TTY:     uses @clack/prompts layout with spinners for slow steps
  * Non-TTY: plain text lines
  *
  * Exit code: 0 on success, 1 on failure.
  */
 
+import { existsSync } from 'node:fs';
 import { readFile, rename, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
-import { intro, log, outro } from '@clack/prompts';
+import { spinner as createSpinner, intro, log, outro } from '@clack/prompts';
 import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
 
 // ---------------------------------------------------------------------------
@@ -223,6 +225,20 @@ export async function runUpdate(opts: UpdateOptions = {}): Promise<UpdateResult>
     writeLine('OneBrain Update');
   }
 
+  // ── Step 0: Guard — vault.yml must exist ─────────────────────────────────
+
+  if (!existsSync(join(vaultDir, 'vault.yml'))) {
+    const msg = `vault.yml not found in ${vaultDir}. Run 'onebrain update' from inside an OneBrain vault.`;
+    if (isTTY) {
+      log.error(msg);
+    } else {
+      writeLine(`error: ${msg}`);
+    }
+    result.error = msg;
+    result.exitCode = 1;
+    return result;
+  }
+
   // ── Step 1: Fetch latest release ──────────────────────────────────────────
 
   let latestVersion: string;
@@ -271,33 +287,49 @@ export async function runUpdate(opts: UpdateOptions = {}): Promise<UpdateResult>
 
   let filesAdded = 0;
   let filesRemoved = 0;
+  const syncSpinner = isTTY ? createSpinner() : null;
+  syncSpinner?.start('Syncing plugin files…');
   try {
     const syncResult = await vaultSyncFn(vaultDir, { branch });
     filesAdded = syncResult.filesAdded;
     filesRemoved = syncResult.filesRemoved;
+    syncSpinner?.stop(`Synced — ${filesAdded} added, ${filesRemoved} removed`);
+    if (!isTTY) {
+      writeLine(`syncing: ${filesAdded} files synced, ${filesRemoved} removed`);
+    }
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
+    syncSpinner?.stop('Sync failed');
     result.error = `vault-sync failed: ${msg}`;
     result.exitCode = 1;
     process.stderr.write(`update: ${result.error}\n`);
     return result;
   }
 
-  noteStep('syncing', `${filesAdded} files synced, ${filesRemoved} removed`);
+  // ── Step 4: Install binary (skipped if already at latest version) ─────────
 
-  // ── Step 4: Install binary ────────────────────────────────────────────────
+  const needsBinaryUpdate = latestVersion !== currentVersion;
 
-  try {
-    await installBinaryFn(latestVersion);
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    result.error = `Binary install failed: ${msg}`;
-    result.exitCode = 1;
-    process.stderr.write(`update: ${result.error}\n`);
-    return result;
+  if (needsBinaryUpdate) {
+    const installSpinner = isTTY ? createSpinner() : null;
+    installSpinner?.start(`Installing @onebrain-ai/cli ${latestVersion}…`);
+    try {
+      await installBinaryFn(latestVersion);
+      installSpinner?.stop(`Installed @onebrain-ai/cli ${latestVersion}`);
+      if (!isTTY) {
+        writeLine(`upgrading: @onebrain-ai/cli ${latestVersion} installed`);
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      installSpinner?.stop('Install failed');
+      result.error = `Binary install failed: ${msg}`;
+      result.exitCode = 1;
+      process.stderr.write(`update: ${result.error}\n`);
+      return result;
+    }
+  } else {
+    noteStep('binary', `@onebrain-ai/cli ${latestVersion} already up to date`);
   }
-
-  noteStep('upgrading', `@onebrain-ai/cli ${latestVersion} installed`);
 
   // ── Step 4b: Validate binary (ATOMIC GATE) ────────────────────────────────
 

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -4,8 +4,7 @@
  * Steps:
  *   0. Guard: vault.yml must exist (prevents running outside a vault)
  *   1. Fetch latest release from GitHub (parse tag_name)
- *   2. Sync plugin files (vault-sync)
- *   3. (Handled by vault-sync Step 4 — merge harness files)
+ *   2. Sync plugin files (vault-sync, includes harness file merge)
  *   4. Install binary — skipped if already at latest version
  *   4b. Validate binary (ATOMIC GATE — register-hooks blocked if this fails)
  *   5. Register hooks (only if 4b passed)

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -17,8 +17,7 @@
  * Exit code: 0 on success, 1 on failure.
  */
 
-import { existsSync } from 'node:fs';
-import { readFile, rename, writeFile } from 'node:fs/promises';
+import { access, readFile, rename, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { spinner as createSpinner, intro, log, outro } from '@clack/prompts';
 import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
@@ -227,7 +226,9 @@ export async function runUpdate(opts: UpdateOptions = {}): Promise<UpdateResult>
 
   // ── Step 0: Guard — vault.yml must exist ─────────────────────────────────
 
-  if (!existsSync(join(vaultDir, 'vault.yml'))) {
+  try {
+    await access(join(vaultDir, 'vault.yml'));
+  } catch {
     const msg = `vault.yml not found in ${vaultDir}. Run 'onebrain update' from inside an OneBrain vault.`;
     if (isTTY) {
       log.error(msg);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,4 +1,6 @@
 #!/usr/bin/env bun
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
 import { Command } from 'commander';
 import { doctorCommand } from './commands/doctor.js';
 import { initCommand } from './commands/init.js';
@@ -37,6 +39,28 @@ if (process.argv.slice(2).length === 0) {
   console.log('Run `onebrain help` for available commands.');
   process.exit(0);
 }
+
+// ---------------------------------------------------------------------------
+// Vault root auto-detect
+// ---------------------------------------------------------------------------
+
+/**
+ * Walk up from startDir looking for vault.yml.
+ * Returns the first directory containing vault.yml, or startDir if not found.
+ */
+function findVaultRoot(startDir: string): string {
+  let dir = startDir;
+  while (true) {
+    if (existsSync(join(dir, 'vault.yml'))) return dir;
+    const parent = dirname(dir);
+    if (parent === dir) return startDir; // filesystem root — fall back to startDir
+    dir = parent;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
 
 const program = new Command();
 
@@ -93,8 +117,9 @@ program
 program
   .command('session-init', { hidden: true })
   .description('Emit session token and datetime (called by Claude Code hook)')
-  .action(async () => {
-    const vaultRoot = process.cwd();
+  .option('--vault-dir <path>', 'vault root directory (default: auto-detect from cwd)')
+  .action(async (opts: { vaultDir?: string }) => {
+    const vaultRoot = opts.vaultDir ?? findVaultRoot(process.cwd());
     await sessionInitCommand(vaultRoot);
   });
 
@@ -111,9 +136,11 @@ program
   .command('checkpoint', { hidden: true })
   .description('Handle checkpoint lifecycle (stop/precompact/postcompact/reset)')
   .argument('<mode>', 'stop | precompact | postcompact | reset')
-  .action(async (mode: string) => {
+  .option('--vault-dir <path>', 'vault root directory (default: auto-detect from cwd)')
+  .action(async (mode: string, opts: { vaultDir?: string }) => {
     const token = await resolveSessionToken();
-    await checkpointCommand(mode, token, process.cwd());
+    const vaultRoot = opts.vaultDir ?? findVaultRoot(process.cwd());
+    await checkpointCommand(mode, token, vaultRoot);
   });
 
 program

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -49,6 +49,7 @@ if (process.argv.slice(2).length === 0) {
  * Returns the first directory containing vault.yml, or startDir if not found.
  */
 function findVaultRoot(startDir: string): string {
+  if (!startDir) return process.cwd();
   let dir = startDir;
   while (true) {
     if (existsSync(join(dir, 'vault.yml'))) return dir;
@@ -90,8 +91,10 @@ program
   .description('Update OneBrain plugin files from GitHub')
   .option('--check', 'show what would change and exit without making changes')
   .option('--channel <channel>', 'update channel: stable | next')
-  .action(async (opts: { check?: boolean; channel?: string }) => {
+  .option('--vault-dir <path>', 'vault root directory (default: auto-detect from cwd)')
+  .action(async (opts: { check?: boolean; channel?: string; vaultDir?: string }) => {
     await updateCommand({
+      vaultDir: opts.vaultDir ?? findVaultRoot(process.cwd()),
       check: opts.check,
       channel: opts.channel as 'stable' | 'next' | undefined,
     });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -104,7 +104,7 @@ program
   .command('doctor')
   .description('Run vault health checks and report issues')
   .action(async () => {
-    const vaultRoot = process.cwd();
+    const vaultRoot = findVaultRoot(process.cwd());
     await doctorCommand({ vaultDir: vaultRoot, binaryVersion: VERSION });
   });
 

--- a/packages/cli/src/internal/checkpoint.test.ts
+++ b/packages/cli/src/internal/checkpoint.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
-import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
@@ -41,10 +41,6 @@ checkpoint:
 
 function stateFile(tmpDir: string, token: string): string {
   return join(tmpDir, `onebrain-${token}.state`);
-}
-
-async function readStateRaw(tmpDir: string, token: string): Promise<string> {
-  return readFile(stateFile(tmpDir, token), 'utf8');
 }
 
 async function createCheckpointFile(
@@ -103,7 +99,6 @@ describe('readState / writeState', () => {
     expect(state.count).toBe(0);
     expect(state.last_ts).toBe(0);
     expect(state.last_stop_nn).toBe('00');
-    expect(state.pending_stub).toBeUndefined();
   });
 
   it('reads 3-field state correctly', async () => {
@@ -112,10 +107,9 @@ describe('readState / writeState', () => {
     expect(state.count).toBe(3);
     expect(state.last_ts).toBe(1000000);
     expect(state.last_stop_nn).toBe('02');
-    expect(state.pending_stub).toBeUndefined();
   });
 
-  it('reads 4-field state (pending_stub) correctly', async () => {
+  it('reads 4-field legacy state — ignores pending_stub field', async () => {
     await writeFile(
       stateFile(tmpDir, TOKEN),
       '0:1000000:03:2026-04-23-41928-checkpoint-04.md',
@@ -125,7 +119,6 @@ describe('readState / writeState', () => {
     expect(state.count).toBe(0);
     expect(state.last_ts).toBe(1000000);
     expect(state.last_stop_nn).toBe('03');
-    expect(state.pending_stub).toBe('2026-04-23-41928-checkpoint-04.md');
   });
 
   it('treats v1 2-field state as parse error → resets to 0:0:00', async () => {
@@ -150,24 +143,12 @@ describe('readState / writeState', () => {
     expect(raw).toMatch(/^0:\d+:00$/);
   });
 
-  it('writeState writes 3-field format when no pending_stub', () => {
+  it('writeState writes 3-field format', () => {
     writeState(TOKEN, { count: 2, last_ts: 999, last_stop_nn: '01' }, tmpDir);
     const state = readState(TOKEN, tmpDir);
     expect(state.count).toBe(2);
     expect(state.last_ts).toBe(999);
     expect(state.last_stop_nn).toBe('01');
-    expect(state.pending_stub).toBeUndefined();
-  });
-
-  it('writeState writes 4-field format when pending_stub is set', () => {
-    writeState(
-      TOKEN,
-      { count: 0, last_ts: 999, last_stop_nn: '02', pending_stub: 'some-file.md' },
-      tmpDir,
-    );
-    const state = readState(TOKEN, tmpDir);
-    expect(state.pending_stub).toBe('some-file.md');
-    expect(state.last_stop_nn).toBe('02');
   });
 });
 
@@ -190,7 +171,7 @@ describe('handleReset', () => {
     const cap = captureStdout();
     handleReset(TOKEN, now, tmpDir);
     const out = cap.stop();
-    const raw = await readStateRaw(tmpDir, TOKEN);
+    const raw = await Bun.file(stateFile(tmpDir, TOKEN)).text();
     expect(raw).toBe(`0:${now}:00`);
     expect(out).toBe('');
   });
@@ -199,7 +180,7 @@ describe('handleReset', () => {
     await writeFile(stateFile(tmpDir, TOKEN), '99:123456789', 'utf8');
     const now = 1700000001;
     handleReset(TOKEN, now, tmpDir);
-    const raw = await readStateRaw(tmpDir, TOKEN);
+    const raw = await Bun.file(stateFile(tmpDir, TOKEN)).text();
     expect(raw).toBe(`0:${now}:00`);
   });
 
@@ -208,19 +189,6 @@ describe('handleReset', () => {
     handleReset(TOKEN, 1000000, tmpDir);
     const out = cap.stop();
     expect(out).toBe('');
-  });
-
-  it('clears pending_stub from 4-field state', async () => {
-    writeState(
-      TOKEN,
-      { count: 3, last_ts: 999, last_stop_nn: '02', pending_stub: 'some-checkpoint.md' },
-      tmpDir,
-    );
-    handleReset(TOKEN, 1700000000, tmpDir);
-    const raw = await readStateRaw(tmpDir, TOKEN);
-    expect(raw).toBe('0:1700000000:00');
-    const state = readState(TOKEN, tmpDir);
-    expect(state.pending_stub).toBeUndefined();
   });
 });
 
@@ -252,7 +220,6 @@ describe('handleStop', () => {
     const out = cap.stop();
 
     expect(out).toBe('');
-    // State should be unchanged
     const state = readState(TOKEN, tmpDir);
     expect(state.count).toBe(0);
     expect(state.last_ts).toBe(recentTs);
@@ -267,14 +234,12 @@ describe('handleStop', () => {
     handleStop(TOKEN, vaultDir, now, tmpDir);
     cap.stop();
 
-    // count should be 1 (below MIN_ACTIVITY=2, no emit, but state updated)
     const state = readState(TOKEN, tmpDir);
     expect(state.count).toBe(1);
     expect(state.last_ts).toBe(oldTs); // preserved when threshold not met / min_activity guard
   });
 
   it('threshold not met → no stdout, state updated with incremented count', () => {
-    // messages_threshold=5, count=2, elapsed small
     const now = 1700000100;
     writeState(TOKEN, { count: 2, last_ts: now - 10, last_stop_nn: '00' }, tmpDir);
 
@@ -288,8 +253,6 @@ describe('handleStop', () => {
   });
 
   it('MIN_ACTIVITY guard: count increments to 1, threshold met by time, but no emit', () => {
-    // Even if elapsed > threshold, count < 2 → no emit
-    // messages_threshold=5, minutes_threshold=10min=600s
     const now = 1700001000;
     const oldTs = now - 700; // 700s > 600s threshold
     writeState(TOKEN, { count: 0, last_ts: oldTs, last_stop_nn: '01' }, tmpDir);
@@ -300,13 +263,13 @@ describe('handleStop', () => {
 
     expect(out).toBe('');
     const state = readState(TOKEN, tmpDir);
-    expect(state.count).toBe(1); // incremented but no emit
+    expect(state.count).toBe(1);
   });
 
-  it('threshold met by count (count reaches messages_threshold), emits block JSON', () => {
-    // count=4, after increment = 5 = messages_threshold
-    const now = 1700000500;
-    writeState(TOKEN, { count: 4, last_ts: now - 10, last_stop_nn: '00' }, tmpDir);
+  it('threshold met (messages) → emits block with correct filename', async () => {
+    const now = 1700001000;
+    await createCheckpointFile(vaultDir, now, TOKEN, 1);
+    writeState(TOKEN, { count: 4, last_ts: now - 10, last_stop_nn: '01' }, tmpDir);
 
     const cap = captureStdout();
     handleStop(TOKEN, vaultDir, now, tmpDir);
@@ -314,91 +277,24 @@ describe('handleStop', () => {
 
     const parsed = JSON.parse(out.trim());
     expect(parsed.decision).toBe('block');
-    // reason contains filename "since start" (last_stop_nn was '00')
-    expect(parsed.reason).toMatch(/checkpoint-01\.md since start$/);
+    expect(parsed.reason).toMatch(/checkpoint-02\.md since checkpoint-01$/);
+  });
 
-    // State reset: count=0, last_ts=now, last_stop_nn='01'
+  it('threshold met → state reset (count=0, last_ts=now)', async () => {
+    const now = 1700001000;
+    writeState(TOKEN, { count: 4, last_ts: now - 10, last_stop_nn: '00' }, tmpDir);
+
+    const cap = captureStdout();
+    handleStop(TOKEN, vaultDir, now, tmpDir);
+    cap.stop();
+
     const state = readState(TOKEN, tmpDir);
     expect(state.count).toBe(0);
     expect(state.last_ts).toBe(now);
-    expect(state.last_stop_nn).toBe('01');
   });
 
-  // Update snapshots: bun test --update-snapshots
-  it('stop block JSON shape matches snapshot { decision: "block", reason: "...-checkpoint-NN.md since ..." }', () => {
-    // count=4 → increment to 5 = messages_threshold → emit block
-    const now = 1700001500;
-    writeState(TOKEN, { count: 4, last_ts: now - 10, last_stop_nn: '00' }, tmpDir);
-
-    const cap = captureStdout();
-    handleStop(TOKEN, vaultDir, now, tmpDir);
-    const out = cap.stop();
-
-    const parsed = JSON.parse(out.trim()) as Record<string, unknown>;
-
-    // Lock the field names of the block decision shape.
-    expect(Object.keys(parsed).sort()).toMatchSnapshot();
-    // Lock the decision value ("block" is the only valid value).
-    expect(parsed.decision).toMatchSnapshot();
-    // Lock the reason pattern: must contain a checkpoint filename and a "since" clause.
-    expect(typeof parsed.reason).toMatchSnapshot();
-    expect(String(parsed.reason)).toMatch(/-checkpoint-\d{2}\.md since /);
-  });
-
-  it('threshold met by elapsed time, emits block JSON', async () => {
-    // elapsed > minutes_threshold (10 min = 600s), count >= 2
+  it('NN derivation: disk scan is authoritative over state last_stop_nn', async () => {
     const now = 1700001000;
-    const oldTs = now - 700; // 700s elapsed
-    // Create 2 existing checkpoints so disk scan returns maxNn=2 → next NN=03
-    await createCheckpointFile(vaultDir, now, TOKEN, 1);
-    await createCheckpointFile(vaultDir, now, TOKEN, 2);
-    writeState(TOKEN, { count: 2, last_ts: oldTs, last_stop_nn: '02' }, tmpDir);
-
-    const cap = captureStdout();
-    handleStop(TOKEN, vaultDir, now, tmpDir);
-    const out = cap.stop();
-
-    const parsed = JSON.parse(out.trim());
-    expect(parsed.decision).toBe('block');
-    expect(parsed.reason).toMatch(/checkpoint-03\.md since checkpoint-02$/);
-
-    const state = readState(TOKEN, tmpDir);
-    expect(state.last_stop_nn).toBe('03');
-  });
-
-  it('"since start" format when last_stop_nn is "00"', () => {
-    const now = 1700001000;
-    writeState(TOKEN, { count: 4, last_ts: now - 10, last_stop_nn: '00' }, tmpDir);
-
-    const cap = captureStdout();
-    handleStop(TOKEN, vaultDir, now, tmpDir);
-    const out = cap.stop();
-
-    const parsed = JSON.parse(out.trim());
-    expect(parsed.reason).toMatch(/since start$/);
-  });
-
-  it('"since checkpoint-NN" format when last_stop_nn is non-zero', async () => {
-    const now = 1700001000;
-    // Create 3 existing checkpoints so disk scan returns maxNn=3 → next NN=04
-    await createCheckpointFile(vaultDir, now, TOKEN, 1);
-    await createCheckpointFile(vaultDir, now, TOKEN, 2);
-    await createCheckpointFile(vaultDir, now, TOKEN, 3);
-    writeState(TOKEN, { count: 4, last_ts: now - 10, last_stop_nn: '03' }, tmpDir);
-
-    const cap = captureStdout();
-    handleStop(TOKEN, vaultDir, now, tmpDir);
-    const out = cap.stop();
-
-    const parsed = JSON.parse(out.trim());
-    expect(parsed.reason).toMatch(/since checkpoint-03$/);
-    // next NN should be 04
-    expect(parsed.reason).toMatch(/checkpoint-04\.md/);
-  });
-
-  it('disk scan wins over state: last_stop_nn="02" but only checkpoint-01 on disk → creates checkpoint-02', async () => {
-    const now = 1700001000;
-    // Only checkpoint-01 exists on disk — state says last_stop_nn='02' but disk is authoritative
     await createCheckpointFile(vaultDir, now, TOKEN, 1);
     writeState(TOKEN, { count: 4, last_ts: now - 10, last_stop_nn: '02' }, tmpDir);
 
@@ -408,51 +304,27 @@ describe('handleStop', () => {
 
     const parsed = JSON.parse(out.trim());
     expect(parsed.decision).toBe('block');
-    // disk maxNn=1 → next NN=02 (not 03 from state)
     expect(parsed.reason).toMatch(/checkpoint-02\.md since checkpoint-01$/);
     const state = readState(TOKEN, tmpDir);
     expect(state.last_stop_nn).toBe('02');
   });
 
-  it('preserves pending_stub when stop fires while precompact stub is waiting for postcompact', async () => {
-    const now = 1700001000;
-    const stubFile = '2023-11-14-41928-checkpoint-03.md';
-    // State has pending_stub set (precompact wrote stub, postcompact hasn't run yet)
-    await createCheckpointFile(vaultDir, now, TOKEN, 3);
-    writeState(
-      TOKEN,
-      { count: 4, last_ts: now - 10, last_stop_nn: '03', pending_stub: stubFile },
-      tmpDir,
-    );
-
-    const cap = captureStdout();
-    handleStop(TOKEN, vaultDir, now, tmpDir);
-    cap.stop();
-
-    const state = readState(TOKEN, tmpDir);
-    // pending_stub must survive so postcompact can still fill stub-03
-    expect(state.pending_stub).toBe(stubFile);
-  });
-
   it('elapsed calc: last_ts=0 → elapsed=0, never triggers time threshold alone', () => {
     const now = 1700001000;
-    // last_ts=0 sentinel (post-compact), count=1 (below min_activity)
     writeState(TOKEN, { count: 1, last_ts: 0, last_stop_nn: '00' }, tmpDir);
 
     const cap = captureStdout();
     handleStop(TOKEN, vaultDir, now, tmpDir);
     const out = cap.stop();
 
-    // count becomes 2, but elapsed=0 so time threshold not met, count=2 < 5 messages threshold
     expect(out).toBe('');
     const state = readState(TOKEN, tmpDir);
     expect(state.count).toBe(2);
   });
 
   it('precompact-then-stop same turn: count=0, not in SKIP_WINDOW → count=1, below MIN_ACTIVITY, no emit', () => {
-    // precompact sets count=0 but does NOT update last_ts; last_ts is old
     const now = 1700002000;
-    const oldTs = now - 900; // old, not in skip window
+    const oldTs = now - 900;
     writeState(TOKEN, { count: 0, last_ts: oldTs, last_stop_nn: '02' }, tmpDir);
 
     const cap = captureStdout();
@@ -473,10 +345,8 @@ describe('handleStop', () => {
     expect(state.count).toBe(1);
   });
 
-  it('last_ts=0 + count=4 (below threshold=5 after increment to 5) → decision:block, last_ts updated, last_stop_nn incremented', async () => {
-    // messagesThreshold is 5 from vault.yml; count=4 → increment to 5 = threshold → emit
+  it('last_ts=0 + count=4 → decision:block, last_ts updated, last_stop_nn incremented', async () => {
     const now = 1700000800;
-    // Create 2 existing checkpoints so disk scan returns maxNn=2 → next NN=03
     await createCheckpointFile(vaultDir, now, TOKEN, 1);
     await createCheckpointFile(vaultDir, now, TOKEN, 2);
     writeState(TOKEN, { count: 4, last_ts: 0, last_stop_nn: '02' }, tmpDir);
@@ -489,14 +359,11 @@ describe('handleStop', () => {
     expect(parsed.decision).toBe('block');
 
     const state = readState(TOKEN, tmpDir);
-    // last_ts must have been updated (was 0, now should be `now`)
     expect(state.last_ts).toBe(now);
     expect(state.last_stop_nn).toBe('03');
   });
 
-  it('last_ts=0 + count=0 → SKIP_WINDOW does NOT fire (guard needs last_ts > 0), out is empty, count increments to 1, last_ts stays 0', () => {
-    // last_ts=0 → the SKIP_WINDOW guard (last_ts > 0 && elapsed < 60) does not fire
-    // count=0 increments to 1, below MIN_ACTIVITY=2 → no emit
+  it('last_ts=0 + count=0 → SKIP_WINDOW does NOT fire (guard needs last_ts > 0)', () => {
     const now = 1700001500;
     writeState(TOKEN, { count: 0, last_ts: 0, last_stop_nn: '00' }, tmpDir);
 
@@ -507,22 +374,18 @@ describe('handleStop', () => {
     expect(out).toBe('');
     const state = readState(TOKEN, tmpDir);
     expect(state.count).toBe(1);
-    // last_ts stays 0 when threshold not met
     expect(state.last_ts).toBe(0);
   });
 
   it('falls back to defaults when vault.yml is missing (messages=15, minutes=30)', () => {
-    // vaultDir has no vault.yml — use separate dir
     const emptyVault = tmpDir; // no vault.yml
     const now = 1700001000;
-    // count=14 → should NOT emit (threshold=15)
     writeState(TOKEN, { count: 14, last_ts: now - 10, last_stop_nn: '00' }, tmpDir);
 
     const cap = captureStdout();
     handleStop(TOKEN, emptyVault, now, tmpDir);
     const out = cap.stop();
 
-    // With default threshold=15, count=15 after increment → EMIT
     const parsed = JSON.parse(out.trim());
     expect(parsed.decision).toBe('block');
   });
@@ -546,173 +409,77 @@ describe('handlePrecompact', () => {
     await rm(vaultDir, { recursive: true, force: true });
   });
 
-  it('recent checkpoint (last_ts within 5min) → exit 0, no stub file, state unchanged', async () => {
+  it('recent checkpoint (last_ts within 5min) → no-op, state unchanged', () => {
     const now = 1700001000;
     const recentTs = now - 100; // 100s < 300s
-    writeState(TOKEN, { count: 0, last_ts: recentTs, last_stop_nn: '02' }, tmpDir);
+    writeState(TOKEN, { count: 3, last_ts: recentTs, last_stop_nn: '02' }, tmpDir);
 
     const cap = captureStdout();
-    await handlePrecompact(TOKEN, vaultDir, now, tmpDir);
+    handlePrecompact(TOKEN, vaultDir, now, tmpDir);
     const out = cap.stop();
 
     expect(out).toBe('');
     const state = readState(TOKEN, tmpDir);
     expect(state.last_stop_nn).toBe('02'); // unchanged
-    expect(state.pending_stub).toBeUndefined();
+    expect(state.count).toBe(3); // unchanged
   });
 
-  it('no recent checkpoint → writes stub file and updates state to 4-field format', async () => {
+  it('no recent checkpoint → resets count to 0, preserves last_ts and last_stop_nn', () => {
     const now = 1700001000;
     const oldTs = now - 600; // 600s > 300s
-    // Create 2 existing checkpoints so disk scan returns maxNn=2 → next NN=03
-    await createCheckpointFile(vaultDir, now, TOKEN, 1);
-    await createCheckpointFile(vaultDir, now, TOKEN, 2);
     writeState(TOKEN, { count: 3, last_ts: oldTs, last_stop_nn: '02' }, tmpDir);
 
     const cap = captureStdout();
-    await handlePrecompact(TOKEN, vaultDir, now, tmpDir);
+    handlePrecompact(TOKEN, vaultDir, now, tmpDir);
     const out = cap.stop();
 
     expect(out).toBe('');
-
     const state = readState(TOKEN, tmpDir);
     expect(state.count).toBe(0);
     expect(state.last_ts).toBe(oldTs); // NOT updated by precompact
-    expect(state.last_stop_nn).toBe('02'); // NOT incremented
-    expect(state.pending_stub).toBeTruthy();
-    // stub NN should be 03 (disk scan maxNn=2 → next=03)
-    expect(state.pending_stub).toMatch(/checkpoint-03\.md$/);
+    expect(state.last_stop_nn).toBe('02'); // NOT changed
   });
 
-  it('NN derivation: disk scan maxNn=2 → stub NN="03"', async () => {
-    const now = 1700001000;
-    // Create 2 existing checkpoints so disk scan returns maxNn=2 → next NN=03
-    await createCheckpointFile(vaultDir, now, TOKEN, 1);
-    await createCheckpointFile(vaultDir, now, TOKEN, 2);
-    writeState(TOKEN, { count: 2, last_ts: now - 600, last_stop_nn: '02' }, tmpDir);
-
-    await handlePrecompact(TOKEN, vaultDir, now, tmpDir);
-
-    const state = readState(TOKEN, tmpDir);
-    expect(state.pending_stub).toMatch(/-checkpoint-03\.md$/);
-  });
-
-  it('stub file is actually written to vault logs dir', async () => {
-    const now = 1700001000;
-    const date = new Date(now * 1000);
-    const yyyy = date.getFullYear().toString();
-    const mm = String(date.getMonth() + 1).padStart(2, '0');
-    writeState(TOKEN, { count: 2, last_ts: now - 600, last_stop_nn: '00' }, tmpDir);
-
-    await handlePrecompact(TOKEN, vaultDir, now, tmpDir);
-
-    const state = readState(TOKEN, tmpDir);
-    const stubFilename = state.pending_stub ?? '';
-    expect(stubFilename).toBeTruthy();
-    const stubPath = join(vaultDir, '07-logs', yyyy, mm, stubFilename);
-    const content = await readFile(stubPath, 'utf8');
-    expect(content).toContain('trigger: precompact');
-    expect(content).toContain('merged: false');
-    expect(content).toContain('## What We Worked On');
-  });
-
-  it('stub frontmatter checkpoint: field preserves zero-padding (e.g. "03" not 3)', async () => {
-    const now = 1700001000;
-    const date = new Date(now * 1000);
-    const yyyy = date.getFullYear().toString();
-    const mm = String(date.getMonth() + 1).padStart(2, '0');
-    // Create 2 existing checkpoints so disk scan returns maxNn=2 → stub NN='03'
-    await createCheckpointFile(vaultDir, now, TOKEN, 1);
-    await createCheckpointFile(vaultDir, now, TOKEN, 2);
-    writeState(TOKEN, { count: 2, last_ts: now - 600, last_stop_nn: '02' }, tmpDir);
-
-    await handlePrecompact(TOKEN, vaultDir, now, tmpDir);
-
-    const state = readState(TOKEN, tmpDir);
-    const stubFilename = state.pending_stub ?? '';
-    const stubPath = join(vaultDir, '07-logs', yyyy, mm, stubFilename);
-    const content = await readFile(stubPath, 'utf8');
-    // Must contain 'checkpoint: 03' (zero-padded), NOT 'checkpoint: 3'
-    expect(content).toContain('checkpoint: 03');
-    expect(content).not.toContain('checkpoint: 3\n');
-  });
-
-  it('last_stop_nn NOT updated (stays same in state after precompact)', async () => {
-    const now = 1700001000;
-    // Create 3 existing checkpoints so disk scan returns maxNn=3 → stub NN=04
-    await createCheckpointFile(vaultDir, now, TOKEN, 1);
-    await createCheckpointFile(vaultDir, now, TOKEN, 2);
-    await createCheckpointFile(vaultDir, now, TOKEN, 3);
-    writeState(TOKEN, { count: 2, last_ts: now - 600, last_stop_nn: '03' }, tmpDir);
-
-    await handlePrecompact(TOKEN, vaultDir, now, tmpDir);
-
-    const state = readState(TOKEN, tmpDir);
-    expect(state.last_stop_nn).toBe('03');
-    expect(state.pending_stub).toMatch(/-checkpoint-04\.md$/);
-  });
-
-  it('double-compact guard: pending_stub already set → no-op, existing stub preserved', async () => {
-    const now = 1700001000;
-    writeState(
-      TOKEN,
-      {
-        count: 0,
-        last_ts: now - 600,
-        last_stop_nn: '01',
-        pending_stub: '2023-11-14-41928-checkpoint-02.md',
-      },
-      tmpDir,
-    );
-
-    const cap = captureStdout();
-    await handlePrecompact(TOKEN, vaultDir, now, tmpDir);
-    const out = cap.stop();
-
-    expect(out).toBe('');
-    // State unchanged — pending_stub still points to original stub
-    const state = readState(TOKEN, tmpDir);
-    expect(state.pending_stub).toBe('2023-11-14-41928-checkpoint-02.md');
-  });
-
-  it('no state file (last_ts=0) → recency check fails → writes stub for new session', async () => {
-    // No state file → readState returns last_ts=0 → recency guard (last_ts > 0) is false
-    // → precompact proceeds and writes a stub (correct: compact on brand-new session)
+  it('no state file (last_ts=0) → recency guard fails → resets count', () => {
     const now = 1700001000;
     const cap = captureStdout();
-    await handlePrecompact(TOKEN, vaultDir, now, tmpDir);
+    handlePrecompact(TOKEN, vaultDir, now, tmpDir);
     const out = cap.stop();
     expect(out).toBe('');
     const state = readState(TOKEN, tmpDir);
-    expect(state.pending_stub).toBeTruthy();
-    expect(state.pending_stub).toMatch(/-checkpoint-01\.md$/);
+    expect(state.count).toBe(0);
   });
 
-  it('stop-then-autocompact: precompact no-ops within 5 min of stop checkpoint', async () => {
-    // Step 1: arrange state where stop threshold is met → stop writes checkpoint, last_ts = now
+  it('stop-then-autocompact: precompact no-ops within 5 min of stop checkpoint', () => {
     const now = 1700001000;
     writeState(TOKEN, { count: 4, last_ts: now - 10, last_stop_nn: '02' }, tmpDir);
 
-    // handleStop emits block JSON and resets state with last_ts = now
     const cap1 = captureStdout();
     handleStop(TOKEN, vaultDir, now, tmpDir);
-    cap1.stop(); // discard the block output
+    cap1.stop();
 
-    // Confirm stop updated last_ts to now
     const stateAfterStop = readState(TOKEN, tmpDir);
     expect(stateAfterStop.last_ts).toBe(now);
     expect(stateAfterStop.count).toBe(0);
 
-    // Step 2: precompact fires 60s later (still within PRECOMPACT_RECENCY = 300s)
     const nowPlus60 = now + 60;
     const cap2 = captureStdout();
-    await handlePrecompact(TOKEN, vaultDir, nowPlus60, tmpDir);
+    handlePrecompact(TOKEN, vaultDir, nowPlus60, tmpDir);
     const out2 = cap2.stop();
 
-    // Assert: precompact no-ops — no stdout, no stub written
     expect(out2).toBe('');
     const stateAfterPrecompact = readState(TOKEN, tmpDir);
-    expect(stateAfterPrecompact.pending_stub).toBeUndefined();
+    expect(stateAfterPrecompact.count).toBe(0);
+    expect(stateAfterPrecompact.last_ts).toBe(now); // unchanged
+  });
+
+  it('produces no stdout in any case', () => {
+    const now = 1700001000;
+    writeState(TOKEN, { count: 3, last_ts: now - 600, last_stop_nn: '01' }, tmpDir);
+    const cap = captureStdout();
+    handlePrecompact(TOKEN, vaultDir, now, tmpDir);
+    const out = cap.stop();
+    expect(out).toBe('');
   });
 });
 
@@ -723,10 +490,7 @@ describe('handlePrecompact', () => {
 describe('handlePostcompact', () => {
   let tmpDir: string;
   let vaultDir: string;
-  // Use date consistent with now=1700001000 (2023-11-14) so disk paths align
   const now = 1700001000;
-  const stubDate = '2023-11-14';
-  const logsDir = () => join(vaultDir, '07-logs', '2023', '11');
 
   beforeEach(async () => {
     tmpDir = await makeTmpDir();
@@ -738,51 +502,9 @@ describe('handlePostcompact', () => {
     await rm(vaultDir, { recursive: true, force: true });
   });
 
-  async function writeCheckpointOnDisk(nn: string) {
-    await mkdir(logsDir(), { recursive: true });
-    await writeFile(
-      join(logsDir(), `${stubDate}-${TOKEN}-checkpoint-${nn}.md`),
-      '---\ntrigger: stop\nmerged: false\n---\n',
-      'utf8',
-    );
-  }
-
-  it('no pending stub (3-field state) → preserve last_ts, write 3-field, no stdout', async () => {
-    const ts = 1699999000;
-    writeState(TOKEN, { count: 2, last_ts: ts, last_stop_nn: '02' }, tmpDir);
-
-    const cap = captureStdout();
-    handlePostcompact(TOKEN, vaultDir, now, tmpDir);
-    const out = cap.stop();
-
-    expect(out).toBe('');
-    const raw = await readStateRaw(tmpDir, TOKEN);
-    expect(raw).toBe(`0:${ts}:02`);
-  });
-
-  it('no state file → write 3-field with last_ts=0, no stdout', () => {
-    const cap = captureStdout();
-    handlePostcompact(TOKEN, vaultDir, now, tmpDir);
-    const out = cap.stop();
-    expect(out).toBe('');
-    const state = readState(TOKEN, tmpDir);
-    expect(state.count).toBe(0);
-    expect(state.last_ts).toBe(0);
-  });
-
-  it('pending stub found → emit fill-checkpoint block, clear pending_stub, last_ts=now', async () => {
-    const ts = 1699999000;
-    await writeCheckpointOnDisk('02'); // predecessor on disk
-    writeState(
-      TOKEN,
-      {
-        count: 0,
-        last_ts: ts,
-        last_stop_nn: '02',
-        pending_stub: `${stubDate}-${TOKEN}-checkpoint-03.md`,
-      },
-      tmpDir,
-    );
+  it('no recent checkpoint → emits auto-wrapup block with token', () => {
+    const oldTs = now - 600; // > 300s → not recent
+    writeState(TOKEN, { count: 0, last_ts: oldTs, last_stop_nn: '02' }, tmpDir);
 
     const cap = captureStdout();
     handlePostcompact(TOKEN, vaultDir, now, tmpDir);
@@ -790,143 +512,48 @@ describe('handlePostcompact', () => {
 
     const parsed = JSON.parse(out.trim());
     expect(parsed.decision).toBe('block');
-    expect(parsed.reason).toContain('fill-checkpoint:');
-    expect(parsed.reason).toContain('checkpoint-03.md');
-    expect(parsed.reason).toMatch(/since checkpoint-02$/);
-
-    const raw = await readStateRaw(tmpDir, TOKEN);
-    expect(raw).toBe(`0:${now}:03`);
+    expect(parsed.reason).toBe(`auto-wrapup: ${TOKEN}`);
   });
 
-  it('"since start" format when no predecessor on disk → advances last_stop_nn to 01', async () => {
-    writeState(
-      TOKEN,
-      {
-        count: 0,
-        last_ts: 1699999000,
-        last_stop_nn: '00',
-        pending_stub: `${stubDate}-${TOKEN}-checkpoint-01.md`,
-      },
-      tmpDir,
-    );
-
-    const cap = captureStdout();
-    handlePostcompact(TOKEN, vaultDir, now, tmpDir);
-    const out = cap.stop();
-
-    const parsed = JSON.parse(out.trim());
-    expect(parsed.reason).toMatch(/since start$/);
-    const raw = await readStateRaw(tmpDir, TOKEN);
-    expect(raw).toBe(`0:${now}:01`);
-  });
-
-  it('"since checkpoint-NN" format → predecessor derived from disk, not arithmetic', async () => {
-    await writeCheckpointOnDisk('03'); // predecessor on disk
-    writeState(
-      TOKEN,
-      {
-        count: 0,
-        last_ts: 1699999000,
-        last_stop_nn: '03',
-        pending_stub: `${stubDate}-${TOKEN}-checkpoint-04.md`,
-      },
-      tmpDir,
-    );
-
-    const cap = captureStdout();
-    handlePostcompact(TOKEN, vaultDir, now, tmpDir);
-    const out = cap.stop();
-
-    const parsed = JSON.parse(out.trim());
-    expect(parsed.reason).toMatch(/since checkpoint-03$/);
-    const raw = await readStateRaw(tmpDir, TOKEN);
-    expect(raw).toBe(`0:${now}:04`);
-  });
-
-  it('gap in disk: stub is checkpoint-04 but only checkpoint-02 exists → since checkpoint-02', async () => {
-    await writeCheckpointOnDisk('02'); // checkpoint-03 was never written
-    writeState(
-      TOKEN,
-      {
-        count: 0,
-        last_ts: 1699999000,
-        last_stop_nn: '02',
-        pending_stub: `${stubDate}-${TOKEN}-checkpoint-04.md`,
-      },
-      tmpDir,
-    );
-
-    const cap = captureStdout();
-    handlePostcompact(TOKEN, vaultDir, now, tmpDir);
-    const out = cap.stop();
-
-    const parsed = JSON.parse(out.trim());
-    // arithmetic would say checkpoint-03 (which doesn't exist); disk scan correctly says checkpoint-02
-    expect(parsed.reason).toMatch(/since checkpoint-02$/);
-  });
-
-  it('missing stub file on disk → still emit fill-checkpoint (Claude creates it)', () => {
-    writeState(
-      TOKEN,
-      {
-        count: 0,
-        last_ts: 1699999000,
-        last_stop_nn: '01',
-        pending_stub: `${stubDate}-${TOKEN}-checkpoint-02.md`,
-      },
-      tmpDir,
-    );
-
-    const cap = captureStdout();
-    handlePostcompact(TOKEN, vaultDir, now, tmpDir);
-    const out = cap.stop();
-
-    const parsed = JSON.parse(out.trim());
-    expect(parsed.decision).toBe('block');
-    expect(parsed.reason).toContain('fill-checkpoint:');
-  });
-
-  it('4-field state with empty pending_stub → treat as no pending stub', async () => {
-    await writeFile(stateFile(tmpDir, TOKEN), '0:1699999000:02:', 'utf8');
-
-    const cap = captureStdout();
-    handlePostcompact(TOKEN, vaultDir, now, tmpDir);
-    const out = cap.stop();
-
-    expect(out).toBe('');
-  });
-
-  it('pending_stub NN inconsistent with last_stop_nn → uses NN from filename (authoritative)', async () => {
-    writeState(
-      TOKEN,
-      {
-        count: 0,
-        last_ts: 1699999000,
-        last_stop_nn: '02',
-        pending_stub: `${stubDate}-${TOKEN}-checkpoint-04.md`,
-      },
-      tmpDir,
-    );
+  it('auto-wrapup emitted → state updated: count=0, last_ts=now, last_stop_nn preserved', () => {
+    writeState(TOKEN, { count: 0, last_ts: now - 600, last_stop_nn: '02' }, tmpDir);
 
     const cap = captureStdout();
     handlePostcompact(TOKEN, vaultDir, now, tmpDir);
     cap.stop();
 
-    const raw = await readStateRaw(tmpDir, TOKEN);
-    expect(raw).toBe(`0:${now}:04`);
+    const state = readState(TOKEN, tmpDir);
+    expect(state.count).toBe(0);
+    expect(state.last_ts).toBe(now);
+    expect(state.last_stop_nn).toBe('02'); // unchanged
   });
 
-  it('postcompact last_ts=now blocks precompact re-fire within 5 min', async () => {
-    writeState(
-      TOKEN,
-      {
-        count: 0,
-        last_ts: 1699999000,
-        last_stop_nn: '01',
-        pending_stub: `${stubDate}-${TOKEN}-checkpoint-02.md`,
-      },
-      tmpDir,
-    );
+  it('recent checkpoint (< 5 min) → no emit, last_ts preserved', () => {
+    const recentTs = now - 100; // < 300s
+    writeState(TOKEN, { count: 0, last_ts: recentTs, last_stop_nn: '03' }, tmpDir);
+
+    const cap = captureStdout();
+    handlePostcompact(TOKEN, vaultDir, now, tmpDir);
+    const out = cap.stop();
+
+    expect(out).toBe('');
+    const state = readState(TOKEN, tmpDir);
+    expect(state.last_ts).toBe(recentTs); // preserved
+    expect(state.last_stop_nn).toBe('03');
+  });
+
+  it('no state file (last_ts=0) → recency guard fails → emits auto-wrapup', () => {
+    const cap = captureStdout();
+    handlePostcompact(TOKEN, vaultDir, now, tmpDir);
+    const out = cap.stop();
+
+    const parsed = JSON.parse(out.trim());
+    expect(parsed.decision).toBe('block');
+    expect(parsed.reason).toBe(`auto-wrapup: ${TOKEN}`);
+  });
+
+  it('postcompact last_ts=now blocks precompact re-fire within 5 min', () => {
+    writeState(TOKEN, { count: 0, last_ts: now - 600, last_stop_nn: '01' }, tmpDir);
 
     const cap = captureStdout();
     handlePostcompact(TOKEN, vaultDir, now, tmpDir);
@@ -934,16 +561,31 @@ describe('handlePostcompact', () => {
 
     const stateAfterPost = readState(TOKEN, tmpDir);
     expect(stateAfterPost.last_ts).toBe(now);
-    expect(stateAfterPost.pending_stub).toBeUndefined();
 
-    // Precompact fires 30s later (within PRECOMPACT_RECENCY=300s) — must be no-op
     const cap2 = captureStdout();
-    await handlePrecompact(TOKEN, vaultDir, now + 30, tmpDir);
+    handlePrecompact(TOKEN, vaultDir, now + 30, tmpDir);
     const out2 = cap2.stop();
 
     expect(out2).toBe('');
     const stateAfterPre = readState(TOKEN, tmpDir);
-    expect(stateAfterPre.pending_stub).toBeUndefined();
+    expect(stateAfterPre.last_ts).toBe(now); // unchanged
+  });
+
+  it('4-field legacy state (pending_stub) → auto-wrapup still emitted', async () => {
+    const oldTs = now - 600;
+    await writeFile(
+      stateFile(tmpDir, TOKEN),
+      `0:${oldTs}:02:2026-04-23-${TOKEN}-checkpoint-03.md`,
+      'utf8',
+    );
+
+    const cap = captureStdout();
+    handlePostcompact(TOKEN, vaultDir, now, tmpDir);
+    const out = cap.stop();
+
+    const parsed = JSON.parse(out.trim());
+    expect(parsed.decision).toBe('block');
+    expect(parsed.reason).toBe(`auto-wrapup: ${TOKEN}`);
   });
 });
 
@@ -958,7 +600,6 @@ describe('postcompactFallback', () => {
   beforeEach(async () => {
     tmpDir = await makeTmpDir();
     vaultDir = await makeTmpDir();
-    await mkdir(join(vaultDir, 'vault.yml', '..'), { recursive: true });
   });
   afterEach(async () => {
     await rm(tmpDir, { recursive: true, force: true });
@@ -966,117 +607,23 @@ describe('postcompactFallback', () => {
   });
 
   const now = 1700002000;
-  const date = '2023-11-14';
-  const logsDir = () => join(vaultDir, '07-logs', '2023', '11');
 
-  async function writeStubFile(nn: string, trigger: string, merged: string | false = false) {
-    await mkdir(logsDir(), { recursive: true });
-    const mergedLine = merged === false ? 'merged: false' : `merged: ${merged}`;
-    await writeFile(
-      join(logsDir(), `${date}-${TOKEN}-checkpoint-${nn}.md`),
-      `---\ntrigger: ${trigger}\n${mergedLine}\n---\n`,
-      'utf8',
-    );
-  }
-
-  it('no stubs on disk → writes clean 3-field state, no emit', () => {
-    writeState(TOKEN, { count: 0, last_ts: 999, last_stop_nn: '02' }, tmpDir);
-    const cap = captureStdout();
-    postcompactFallback(TOKEN, vaultDir, now, tmpDir);
-    const out = cap.stop();
-    expect(out).toBe('');
-    const state = readState(TOKEN, tmpDir);
-    expect(state.count).toBe(0);
-    expect(state.last_ts).toBe(999); // preserved
-    expect(state.last_stop_nn).toBe('02');
-  });
-
-  it('unmerged precompact stub found → emits fill-checkpoint, writes state', async () => {
-    await writeStubFile('01', 'stop', 'true'); // prior merged checkpoint on disk
-    await writeStubFile('02', 'precompact', false);
-    writeState(TOKEN, { count: 0, last_ts: 0, last_stop_nn: '01' }, tmpDir);
+  it('emits auto-wrapup when not recent', () => {
+    writeState(TOKEN, { count: 0, last_ts: now - 600, last_stop_nn: '02' }, tmpDir);
     const cap = captureStdout();
     postcompactFallback(TOKEN, vaultDir, now, tmpDir);
     const out = cap.stop();
     const parsed = JSON.parse(out.trim());
     expect(parsed.decision).toBe('block');
-    expect(parsed.reason).toMatch(/fill-checkpoint:.*checkpoint-02\.md since checkpoint-01$/);
-    const state = readState(TOKEN, tmpDir);
-    expect(state.last_ts).toBe(now);
-    expect(state.last_stop_nn).toBe('02');
+    expect(parsed.reason).toBe(`auto-wrapup: ${TOKEN}`);
   });
 
-  it('stop-triggered stub → ignored, no emit', async () => {
-    await writeStubFile('02', 'stop', false);
-    writeState(TOKEN, { count: 0, last_ts: 500, last_stop_nn: '01' }, tmpDir);
+  it('no emit when recent (< 5 min since last checkpoint)', () => {
+    writeState(TOKEN, { count: 0, last_ts: now - 100, last_stop_nn: '02' }, tmpDir);
     const cap = captureStdout();
     postcompactFallback(TOKEN, vaultDir, now, tmpDir);
     const out = cap.stop();
     expect(out).toBe('');
-  });
-
-  it('merged precompact stub → ignored, no emit', async () => {
-    await writeStubFile('02', 'precompact', 'true');
-    writeState(TOKEN, { count: 0, last_ts: 500, last_stop_nn: '01' }, tmpDir);
-    const cap = captureStdout();
-    postcompactFallback(TOKEN, vaultDir, now, tmpDir);
-    const out = cap.stop();
-    expect(out).toBe('');
-  });
-
-  it('multiple stubs → processes latest (highest NN)', async () => {
-    await writeStubFile('01', 'precompact', false);
-    await writeStubFile('03', 'precompact', false);
-    writeState(TOKEN, { count: 0, last_ts: 0, last_stop_nn: '00' }, tmpDir);
-    const cap = captureStdout();
-    postcompactFallback(TOKEN, vaultDir, now, tmpDir);
-    const out = cap.stop();
-    const parsed = JSON.parse(out.trim());
-    // predecessor derived from disk: stub-01 is highest NN < 03
-    expect(parsed.reason).toMatch(/checkpoint-03\.md since checkpoint-01$/);
-  });
-
-  it('first stub (NN=01) → since reference is "start"', async () => {
-    await writeStubFile('01', 'precompact', false);
-    writeState(TOKEN, { count: 0, last_ts: 0, last_stop_nn: '00' }, tmpDir);
-    const cap = captureStdout();
-    postcompactFallback(TOKEN, vaultDir, now, tmpDir);
-    const out = cap.stop();
-    const parsed = JSON.parse(out.trim());
-    expect(parsed.reason).toMatch(/since start$/);
-  });
-
-  it('gap in checkpoint numbering → predecessor derived from disk, not arithmetic', async () => {
-    // checkpoint-03 was never written by Claude; stop-triggered -04 exists; stub is -05
-    await writeStubFile('04', 'stop', 'true'); // merged stop checkpoint
-    await writeStubFile('05', 'precompact', false); // unmerged precompact stub
-    writeState(TOKEN, { count: 0, last_ts: 0, last_stop_nn: '04' }, tmpDir);
-    const cap = captureStdout();
-    postcompactFallback(TOKEN, vaultDir, now, tmpDir);
-    const out = cap.stop();
-    const parsed = JSON.parse(out.trim());
-    // arithmetic would say checkpoint-04; disk scan correctly finds checkpoint-04 as predecessor
-    expect(parsed.reason).toMatch(/checkpoint-05\.md since checkpoint-04$/);
-  });
-
-  it('pending_stub in state → delegates to handlePostcompact, not disk scan', async () => {
-    const stubFilename = `${date}-${TOKEN}-checkpoint-02.md`;
-    await writeStubFile('01', 'stop', 'true'); // predecessor on disk
-    writeState(
-      TOKEN,
-      { count: 0, last_ts: 0, last_stop_nn: '01', pending_stub: stubFilename },
-      tmpDir,
-    );
-    const cap = captureStdout();
-    postcompactFallback(TOKEN, vaultDir, now, tmpDir);
-    const out = cap.stop();
-    const parsed = JSON.parse(out.trim());
-    expect(parsed.reason).toMatch(/fill-checkpoint:.*checkpoint-02\.md since checkpoint-01$/);
-    // State must be cleared: pending_stub gone, last_ts=now
-    const state = readState(TOKEN, tmpDir);
-    expect(state.pending_stub).toBeUndefined();
-    expect(state.last_ts).toBe(now);
-    expect(state.last_stop_nn).toBe('02');
   });
 });
 
@@ -1098,31 +645,33 @@ describe('maxCheckpointNnSync', () => {
   const DATE = '2023-11-14';
   const LOGS = '07-logs';
 
-  it('returns 0 when directory does not exist', () => {
-    expect(maxCheckpointNnSync(VAULT(), DATE, TOKEN, LOGS)).toBe(0);
+  it('returns 0 when no checkpoint files exist', () => {
+    const result = maxCheckpointNnSync(VAULT(), DATE, TOKEN, LOGS);
+    expect(result).toBe(0);
   });
 
-  it('returns 0 when directory has no checkpoint files', async () => {
-    await mkdir(join(VAULT(), LOGS, '2023', '11'), { recursive: true });
-    await writeFile(join(VAULT(), LOGS, '2023', '11', '2023-11-14-session-01.md'), '', 'utf8');
-    expect(maxCheckpointNnSync(VAULT(), DATE, TOKEN, LOGS)).toBe(0);
-  });
-
-  it('returns the highest NN from matching checkpoint files', async () => {
+  it('returns max NN from checkpoint files on disk', async () => {
     const dir = join(VAULT(), LOGS, '2023', '11');
     await mkdir(dir, { recursive: true });
     await writeFile(join(dir, `${DATE}-${TOKEN}-checkpoint-01.md`), '', 'utf8');
     await writeFile(join(dir, `${DATE}-${TOKEN}-checkpoint-03.md`), '', 'utf8');
-    await writeFile(join(dir, `${DATE}-${TOKEN}-checkpoint-02.md`), '', 'utf8');
-    expect(maxCheckpointNnSync(VAULT(), DATE, TOKEN, LOGS)).toBe(3);
+    const result = maxCheckpointNnSync(VAULT(), DATE, TOKEN, LOGS);
+    expect(result).toBe(3);
   });
 
-  it('ignores files with wrong token or wrong format', async () => {
+  it('ignores files for other tokens', async () => {
     const dir = join(VAULT(), LOGS, '2023', '11');
     await mkdir(dir, { recursive: true });
-    await writeFile(join(dir, `${DATE}-99999-checkpoint-05.md`), '', 'utf8'); // wrong token
-    await writeFile(join(dir, `${DATE}-${TOKEN}-checkpoint-01.md`), '', 'utf8'); // correct
-    await writeFile(join(dir, `${DATE}-${TOKEN}-session-01.md`), '', 'utf8'); // not checkpoint
-    expect(maxCheckpointNnSync(VAULT(), DATE, TOKEN, LOGS)).toBe(1);
+    await writeFile(join(dir, `${DATE}-99999-checkpoint-05.md`), '', 'utf8');
+    const result = maxCheckpointNnSync(VAULT(), DATE, TOKEN, LOGS);
+    expect(result).toBe(0);
+  });
+
+  it('ignores files for other dates', async () => {
+    const dir = join(VAULT(), LOGS, '2023', '11');
+    await mkdir(dir, { recursive: true });
+    await writeFile(join(dir, `2023-11-15-${TOKEN}-checkpoint-02.md`), '', 'utf8');
+    const result = maxCheckpointNnSync(VAULT(), DATE, TOKEN, LOGS);
+    expect(result).toBe(0);
   });
 });

--- a/packages/cli/src/internal/checkpoint.test.ts
+++ b/packages/cli/src/internal/checkpoint.test.ts
@@ -127,9 +127,9 @@ describe('readState / writeState', () => {
     expect(state.count).toBe(0);
     expect(state.last_ts).toBe(0);
     expect(state.last_stop_nn).toBe('00');
-    // Verify file was eagerly rewritten on disk with 3-field format
+    // Eager rewrite matches the returned last_ts=0 (not `now`) so disk/return stay in sync
     const raw = await Bun.file(stateFile(tmpDir, TOKEN)).text();
-    expect(raw).toMatch(/^0:\d+:00$/);
+    expect(raw).toBe('0:0:00');
   });
 
   it('treats malformed state as parse error → resets to 0:0:00', async () => {
@@ -138,9 +138,9 @@ describe('readState / writeState', () => {
     expect(state.count).toBe(0);
     expect(state.last_ts).toBe(0);
     expect(state.last_stop_nn).toBe('00');
-    // Verify file was eagerly rewritten on disk with 3-field format
+    // Eager rewrite matches the returned last_ts=0 (not `now`) so disk/return stay in sync
     const raw = await Bun.file(stateFile(tmpDir, TOKEN)).text();
-    expect(raw).toMatch(/^0:\d+:00$/);
+    expect(raw).toBe('0:0:00');
   });
 
   it('writeState writes 3-field format', () => {
@@ -440,7 +440,7 @@ describe('handlePrecompact', () => {
     expect(state.last_stop_nn).toBe('02'); // NOT changed
   });
 
-  it('no state file (last_ts=0) → recency guard fails → resets count', () => {
+  it('no state file (last_ts=0) → recency guard fails → resets count, last_ts stays 0', () => {
     const now = 1700001000;
     const cap = captureStdout();
     handlePrecompact(TOKEN, vaultDir, now, tmpDir);
@@ -448,6 +448,7 @@ describe('handlePrecompact', () => {
     expect(out).toBe('');
     const state = readState(TOKEN, tmpDir);
     expect(state.count).toBe(0);
+    expect(state.last_ts).toBe(0); // precompact preserves last_ts; default state has last_ts=0
   });
 
   it('stop-then-autocompact: precompact no-ops within 5 min of stop checkpoint', () => {

--- a/packages/cli/src/internal/checkpoint.ts
+++ b/packages/cli/src/internal/checkpoint.ts
@@ -4,7 +4,7 @@
  * Implements stop/precompact/postcompact/reset modes, replacing checkpoint-hook.sh.
  *
  * State file: $TMPDIR/onebrain-{session_token}.state
- * Format: count:last_ts:last_stop_nn[:pending_stub_filename]
+ * Format: count:last_ts:last_stop_nn
  *
  * Note: last_stop_nn is kept for backward compat/debugging only.
  * Checkpoint NN is always derived from actual files on disk — this guarantees
@@ -15,10 +15,8 @@
  */
 
 import { readFileSync, readdirSync, writeFileSync } from 'node:fs';
-import { mkdir, readdir, writeFile } from 'node:fs/promises';
 import { tmpdir as osTmpdir } from 'node:os';
 import { join } from 'node:path';
-import { loadVaultConfig } from '@onebrain/core';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -40,7 +38,6 @@ export interface CheckpointState {
   count: number;
   last_ts: number;
   last_stop_nn: string;
-  pending_stub?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -54,6 +51,7 @@ function stateFilePath(token: string, tmpDir: string): string {
 /**
  * Read state from $tmpDir/onebrain-{token}.state.
  * Returns default state if file is missing or malformed (v1 compat: < 3 fields → parse error).
+ * 4-field state (legacy pending_stub) is accepted — the 4th field is silently ignored.
  * Sync — checkpoint hooks must not add async latency.
  */
 export function readState(token: string, tmpDir: string = osTmpdir()): CheckpointState {
@@ -68,13 +66,13 @@ export function readState(token: string, tmpDir: string = osTmpdir()): Checkpoin
     const count = Number(parts[0]);
     const last_ts = Number(parts[1]);
     const last_stop_nn = parts[2] ?? '00';
-    const pending_stub = parts[3] && parts[3].length > 0 ? parts[3] : undefined;
+    // parts[3] (legacy pending_stub) silently ignored
 
     if (!Number.isInteger(count) || !Number.isInteger(last_ts) || !/^\d{2}$/.test(last_stop_nn)) {
       throw new Error('malformed state');
     }
 
-    return { count, last_ts, last_stop_nn, pending_stub };
+    return { count, last_ts, last_stop_nn };
   } catch {
     // Missing or malformed → fresh state
     // last_ts=0: avoids SKIP_WINDOW on first run (guard requires last_ts > 0)
@@ -97,8 +95,7 @@ export function readState(token: string, tmpDir: string = osTmpdir()): Checkpoin
 }
 
 /**
- * Write state to $tmpDir/onebrain-{token}.state.
- * 3-field when no pending_stub, 4-field when pending_stub is set.
+ * Write state to $tmpDir/onebrain-{token}.state (3-field format).
  * Sync.
  */
 export function writeState(
@@ -107,8 +104,7 @@ export function writeState(
   tmpDir: string = osTmpdir(),
 ): void {
   const path = stateFilePath(token, tmpDir);
-  const base = `${state.count}:${state.last_ts}:${state.last_stop_nn}`;
-  const content = state.pending_stub !== undefined ? `${base}:${state.pending_stub}` : base;
+  const content = `${state.count}:${state.last_ts}:${state.last_stop_nn}`;
   try {
     writeFileSync(path, content, 'utf8');
   } catch (err) {
@@ -204,14 +200,6 @@ function formatDate(epochSeconds: number): string {
   return `${yyyy}-${mm}-${dd}`;
 }
 
-function formatYYYY(epochSeconds: number): string {
-  return new Date(epochSeconds * 1000).getFullYear().toString();
-}
-
-function formatMM(epochSeconds: number): string {
-  return String(new Date(epochSeconds * 1000).getMonth() + 1).padStart(2, '0');
-}
-
 // ---------------------------------------------------------------------------
 // JSON output helper
 // ---------------------------------------------------------------------------
@@ -299,63 +287,24 @@ export function handleStop(
   const filename = `${date}-${token}-checkpoint-${nextNn}.md`;
   emitBlock(`${filename}${since}`);
 
-  // Reset state; preserve pending_stub so postcompact can still fill the precompact stub
-  writeState(
-    token,
-    { count: 0, last_ts: now, last_stop_nn: nextNn, pending_stub: state.pending_stub },
-    tmpDir,
-  );
+  writeState(token, { count: 0, last_ts: now, last_stop_nn: nextNn }, tmpDir);
 }
 
 // ---------------------------------------------------------------------------
 // precompact mode
 // ---------------------------------------------------------------------------
 
-const PRECOMPACT_STUB_TEMPLATE = (date: string, nn: string): string => `---
-tags: [checkpoint, session-log]
-date: ${date}
-checkpoint: ${nn}
-trigger: precompact
-merged: false
----
-
-## What We Worked On
-
-<!-- stub: written automatically before compact — fill in via postcompact -->
-
-## Key Decisions
-
--
-
-## Insights & Learnings
-
--
-
-## What Worked / Didn't Work
-
--
-
-## Action Items
-
--
-
-## Open Questions
-
--
-`;
-
 /**
- * Precompact hook: ensure a checkpoint exists before compact.
+ * Precompact hook: reset message count if no recent checkpoint.
  * If a checkpoint was written within the last 5 minutes, let compact proceed (no-op).
- * Otherwise write a stub file and update state to 4-field.
- * Async (file writes).
+ * Otherwise reset count so the stop hook doesn't re-trigger immediately post-compact.
  */
-export async function handlePrecompact(
+export function handlePrecompact(
   token: string,
-  vaultRoot: string,
+  _vaultRoot: string,
   now: number = Math.floor(Date.now() / 1000),
   tmpDir: string = osTmpdir(),
-): Promise<void> {
+): void {
   const state = readState(token, tmpDir);
 
   // Recency check: if last checkpoint < 5 minutes ago, let compact proceed
@@ -363,58 +312,8 @@ export async function handlePrecompact(
     return; // no-op
   }
 
-  // Double-compact guard: if a stub is already pending postcompact will fill it
-  if (state.pending_stub) {
-    return; // no-op — prevents orphaning the existing stub
-  }
-
-  const date = formatDate(now);
-
-  // Determine logs folder from vault.yml (fallback to '07-logs')
-  let logsFolder = DEFAULT_LOGS_FOLDER;
-  try {
-    const config = await loadVaultConfig(vaultRoot);
-    logsFolder = config.folders.logs;
-  } catch {
-    // use default
-  }
-
-  const yyyy = formatYYYY(now);
-  const mm = formatMM(now);
-  const stubDir = join(vaultRoot, logsFolder, yyyy, mm);
-
-  // Derive stub NN from disk — same guarantee as handleStop: sequential, no gaps
-  const existingFiles = await readdir(stubDir).catch(() => [] as string[]);
-  const prefix = `${date}-${token}-checkpoint-`;
-  const maxNn = existingFiles.reduce((max, f) => {
-    if (!f.startsWith(prefix) || !f.endsWith('.md')) return max;
-    const m = f.match(/-checkpoint-(\d{2})\.md$/);
-    return m ? Math.max(max, Number(m[1])) : max;
-  }, 0);
-  const stubNn = String(maxNn + 1).padStart(2, '0');
-
-  const stubFilename = `${date}-${token}-checkpoint-${stubNn}.md`;
-  const stubPath = join(stubDir, stubFilename);
-
-  try {
-    await mkdir(stubDir, { recursive: true });
-    await writeFile(stubPath, PRECOMPACT_STUB_TEMPLATE(date, stubNn), 'utf8');
-  } catch (err) {
-    process.stderr.write(`checkpoint: failed to write stub file ${stubPath}: ${err}\n`);
-    return;
-  }
-
-  // Update state: count=0, last_ts UNCHANGED, last_stop_nn UNCHANGED, pending_stub set
-  writeState(
-    token,
-    {
-      count: 0,
-      last_ts: state.last_ts,
-      last_stop_nn: state.last_stop_nn,
-      pending_stub: stubFilename,
-    },
-    tmpDir,
-  );
+  // Reset count (last_ts unchanged — postcompact uses it for recency guard)
+  writeState(token, { count: 0, last_ts: state.last_ts, last_stop_nn: state.last_stop_nn }, tmpDir);
 }
 
 // ---------------------------------------------------------------------------
@@ -422,20 +321,20 @@ export async function handlePrecompact(
 // ---------------------------------------------------------------------------
 
 /**
- * Postcompact hook: handle pending stub from precompact.
- * If pending stub: emit fill-checkpoint block, set last_ts=now.
- * Predecessor NN derived from disk scan — correct even when there are gaps.
- * Sync. Called only when state has pending_stub set.
+ * Postcompact hook: emit auto-wrapup block so Claude synthesizes the session.
+ * If the last checkpoint was very recent (compact followed a stop), skip to avoid
+ * double-wrapup — the stop checkpoint is already complete.
  */
 export function handlePostcompact(
   token: string,
-  vaultRoot: string,
+  _vaultRoot: string,
   now: number = Math.floor(Date.now() / 1000),
   tmpDir: string = osTmpdir(),
 ): void {
   const state = readState(token, tmpDir);
 
-  if (!state.pending_stub) {
+  // Recency guard: stop checkpoint written within 5 min → compact followed stop → skip
+  if (state.last_ts > 0 && now - state.last_ts < PRECOMPACT_RECENCY) {
     writeState(
       token,
       { count: 0, last_ts: state.last_ts, last_stop_nn: state.last_stop_nn },
@@ -444,53 +343,17 @@ export function handlePostcompact(
     return;
   }
 
-  const stubNnMatch = state.pending_stub.match(/-checkpoint-(\d{2})\.md$/);
-  const stubNn = stubNnMatch?.[1] ?? '01';
-  const stubNnNum = Number(stubNn);
-
-  // Derive predecessor from disk — correct even when there are gaps in numbering
-  const { logsFolder } = loadVaultSettings(vaultRoot);
-  const date = state.pending_stub.slice(0, 10); // YYYY-MM-DD prefix
-  const yyyy = date.slice(0, 4);
-  const mm = date.slice(5, 7);
-  const dir = join(vaultRoot, logsFolder, yyyy, mm);
-  const prefix = `${date}-${token}-checkpoint-`;
-  let predecessorNn = 0;
-  try {
-    for (const f of readdirSync(dir)) {
-      if (!f.startsWith(prefix) || !f.endsWith('.md')) continue;
-      const m = f.match(/-checkpoint-(\d{2})\.md$/);
-      if (m) {
-        const nn = Number(m[1]);
-        if (nn < stubNnNum) predecessorNn = Math.max(predecessorNn, nn);
-      }
-    }
-  } catch {
-    // dir missing or unreadable — predecessorNn stays 0 → 'since start'
-  }
-
-  const since =
-    predecessorNn === 0
-      ? ' since start'
-      : ` since checkpoint-${String(predecessorNn).padStart(2, '0')}`;
-  emitBlock(`fill-checkpoint: ${state.pending_stub}${since}`);
-
-  // last_ts=now: recency guard in handlePrecompact blocks re-fire within 5 min
-  writeState(token, { count: 0, last_ts: now, last_stop_nn: stubNn }, tmpDir);
+  emitBlock(`auto-wrapup: ${token}`);
+  writeState(token, { count: 0, last_ts: now, last_stop_nn: state.last_stop_nn }, tmpDir);
 }
 
 // ---------------------------------------------------------------------------
-// postcompact fallback
+// postcompact entry point
 // ---------------------------------------------------------------------------
 
 /**
- * Postcompact entry point: reads state once and dispatches to the correct path.
- * - pending_stub present → delegates to handlePostcompact (fills known stub)
- * - pending_stub absent  → scans disk for unmerged precompact stubs (state lost/expired)
- *
- * Single state read here; handlePostcompact also reads state internally (benign
- * double-read — postcompact is never called concurrently).
- * Sync.
+ * Postcompact entry point: delegates to handlePostcompact.
+ * Kept as a separate export for backward compat with existing test imports.
  */
 export function postcompactFallback(
   token: string,
@@ -498,60 +361,7 @@ export function postcompactFallback(
   now: number = Math.floor(Date.now() / 1000),
   tmpDir: string = osTmpdir(),
 ): void {
-  const state = readState(token, tmpDir);
-
-  if (state.pending_stub) {
-    handlePostcompact(token, vaultRoot, now, tmpDir);
-    return;
-  }
-
-  // No pending_stub — scan disk for unmerged precompact stubs for this session today.
-  const { logsFolder } = loadVaultSettings(vaultRoot);
-  const date = formatDate(now);
-  const yyyy = date.slice(0, 4);
-  const mm = date.slice(5, 7);
-  const dir = join(vaultRoot, logsFolder, yyyy, mm);
-  const prefix = `${date}-${token}-checkpoint-`;
-
-  const stubs: string[] = [];
-  const allNns: number[] = [];
-  try {
-    for (const f of readdirSync(dir)) {
-      if (!f.startsWith(prefix) || !f.endsWith('.md')) continue;
-      const m = f.match(/-checkpoint-(\d{2})\.md$/);
-      if (!m) continue;
-      allNns.push(Number(m[1]));
-      const content = readFileSync(join(dir, f), 'utf8');
-      if (/^trigger:\s*precompact/m.test(content) && !/^merged:\s*true/m.test(content)) {
-        stubs.push(f);
-      }
-    }
-  } catch {
-    // dir missing or unreadable — fall through to clean state write
-  }
-
-  if (stubs.length === 0) {
-    writeState(
-      token,
-      { count: 0, last_ts: state.last_ts, last_stop_nn: state.last_stop_nn },
-      tmpDir,
-    );
-    return;
-  }
-
-  stubs.sort();
-  const stubFilename = stubs[stubs.length - 1];
-  const stubNnMatch = stubFilename.match(/-checkpoint-(\d{2})\.md$/);
-  const stubNn = stubNnMatch?.[1] ?? '01';
-  const stubNnNum = Number(stubNn);
-  // Derive predecessor from disk — correct even when there are gaps in numbering
-  const predecessorNn = allNns.filter((n) => n < stubNnNum).reduce((max, n) => Math.max(max, n), 0);
-  const since =
-    predecessorNn === 0
-      ? ' since start'
-      : ` since checkpoint-${String(predecessorNn).padStart(2, '0')}`;
-  emitBlock(`fill-checkpoint: ${stubFilename}${since}`);
-  writeState(token, { count: 0, last_ts: now, last_stop_nn: stubNn }, tmpDir);
+  handlePostcompact(token, vaultRoot, now, tmpDir);
 }
 
 // ---------------------------------------------------------------------------
@@ -573,7 +383,7 @@ export async function checkpointCommand(
         handleStop(token, vaultRoot);
         break;
       case 'precompact':
-        await handlePrecompact(token, vaultRoot);
+        handlePrecompact(token, vaultRoot);
         break;
       case 'postcompact':
         postcompactFallback(token, vaultRoot);

--- a/packages/cli/src/internal/checkpoint.ts
+++ b/packages/cli/src/internal/checkpoint.ts
@@ -78,9 +78,10 @@ export function readState(token: string, tmpDir: string = osTmpdir()): Checkpoin
     // last_ts=0: avoids SKIP_WINDOW on first run (guard requires last_ts > 0)
     // and avoids false "recent checkpoint" in precompact (guard requires last_ts > 0)
     // Eagerly rewrite the state file so v1/malformed files don't accumulate.
-    const now = Math.floor(Date.now() / 1000);
+    // Use last_ts=0 to match the returned value — callers rely on last_ts=0 to
+    // disable SKIP_WINDOW and recency guards on the first run.
     try {
-      writeFileSync(stateFilePath(token, tmpDir), `0:${now}:00`, 'utf8');
+      writeFileSync(stateFilePath(token, tmpDir), '0:0:00', 'utf8');
     } catch (writeErr) {
       process.stderr.write(
         `checkpoint: failed to rewrite state file for token ${token}: ${writeErr}\n`,
@@ -307,7 +308,9 @@ export function handlePrecompact(
 ): void {
   const state = readState(token, tmpDir);
 
-  // Recency check: if last checkpoint < 5 minutes ago, let compact proceed
+  // Recency check: if last checkpoint < 5 minutes ago, let compact proceed.
+  // Invariant: handleStop resets count=0 when it writes last_ts, so count is
+  // already 0 when we reach this path — no write needed.
   if (state.last_ts > 0 && now - state.last_ts < PRECOMPACT_RECENCY) {
     return; // no-op
   }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onebrain/core",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "type": "module",
   "main": "src/index.ts",
   "exports": {


### PR DESCRIPTION
## Summary

- **PostCompact → auto-wrapup**: replaces unreliable `fill-checkpoint` mechanism. Postcompact emits `auto-wrapup: <token>` so Claude runs full wrapup synthesis while the compact summary is fresh. Precompact simplified to count-reset only. State format drops `pending_stub` — 3-field only; legacy 4-field silently ignored on read.
- **update vault.yml guard**: `onebrain update` exits 1 with a clear error if `vault.yml` is not found; uses `findVaultRoot` so running from any subdirectory works.
- **update skip-if-same-version**: binary install skipped when `latestVersion === currentVersion`; vault-sync and hook registration still run. TTY spinners added.
- **vault root auto-detect**: `session-init`, `checkpoint`, `update`, and `doctor` now walk up from cwd to find `vault.yml` — no `cd` to vault required. `--vault-dir` explicit override added to all three hidden commands.
- **fix(changelog)**: remove CLI-only v2.0.5 and v2.0.6 entries; restore `latest_version: 2.0.4` and `released: 2026-04-25`.
- **fix(ci)**: bump `packages/core/package.json` to 2.0.6 (CLI track sync).
- **fix(docs)**: update CONTRIBUTING.md checkpoint example to describe CLI binary, session_token, 3-field state format.

## Test plan

- [x] `bun test packages/cli/src/` — 162 pass, 0 fail
- [x] `biome check` on changed files — clean
- [x] `check-version-sync.js` — both tracks in sync
- [x] 3 code review rounds + 1 consistency review completed
- [ ] Verify postcompact `auto-wrapup:` block handling in live session (INSTRUCTIONS.md handler in PR3)
- [ ] Verify `onebrain session-init` works when cwd is not vault root

🤖 Generated with [Claude Code](https://claude.com/claude-code)