### PR TITLE
fix(doctor): remove spurious binary-vs-plugin version-drift warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-latest_version: 2.0.9
+latest_version: 2.0.10
 released: 2026-04-26
 ---
 
@@ -12,6 +12,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 > For plugin changes (skills, agents, hooks, INSTRUCTIONS), see [PLUGIN-CHANGELOG.md](PLUGIN-CHANGELOG.md).
 
 ## [Unreleased]
+
+## v2.0.10 — fix: doctor no longer warns on CLI-vs-plugin version difference
+
+- fix(doctor): `checkVersionDrift` now compares `vault.yml onebrain_version` vs `plugin.json version` only — CLI binary version is on an independent release track and must not be compared against plugin files
+- fix(doctor): remove `binaryVersion` param from `checkVersionDriftFn` signature — CLI version was never a valid input for plugin-track drift detection
+- test(doctor): remove `binaryVersion forwarding` test suite — parameter no longer exists
+- test(lib): remove `checkVersionDrift binary-vs-plugin warn` test case
 
 ## v2.0.9 — fix: register-hooks drops SessionStart and env, adds type/matcher to hook entries
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onebrain-ai/cli",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "description": "CLI for OneBrain — personal AI OS for Obsidian with persistent memory, 24+ skills, and Claude Code integration",
   "keywords": [
     "onebrain",

--- a/src/commands/doctor.test.ts
+++ b/src/commands/doctor.test.ts
@@ -476,4 +476,23 @@ describe('runDoctor', () => {
       expect(result.warningCount).toBe(0);
     });
   });
+
+  // ── checkVersionDriftFn call signature ────────────────────────────────────
+
+  describe('checkVersionDriftFn call signature', () => {
+    it('calls checkVersionDriftFn with (vaultDir, config) — no binaryVersion arg', async () => {
+      let capturedArgs: unknown[] = [];
+      const validators = makeAllOkValidators();
+      validators.checkVersionDriftFn = async (...args: unknown[]) => {
+        capturedArgs = args;
+        return { check: 'version-drift' as const, status: 'ok' as const, message: 'v1.0.0' };
+      };
+
+      await runDoctor({ vaultDir: tempDir, isTTY: false, ...validators });
+
+      expect(capturedArgs).toHaveLength(2);
+      expect(capturedArgs[0]).toBe(tempDir);
+      expect(typeof capturedArgs[1]).toBe('object');
+    });
+  });
 });

--- a/src/commands/doctor.test.ts
+++ b/src/commands/doctor.test.ts
@@ -140,36 +140,6 @@ describe('runDoctor', () => {
     });
   });
 
-  // ── binaryVersion forwarding ───────────────────────────────────────────────
-
-  describe('binaryVersion forwarding', () => {
-    it('forwards binaryVersion to checkVersionDriftFn when provided', async () => {
-      let capturedBinaryVersion: string | undefined = 'not-set';
-      const validators = makeAllOkValidators();
-      validators.checkVersionDriftFn = async (_vaultDir, _config, bv) => {
-        capturedBinaryVersion = bv;
-        return { check: 'version-drift', status: 'ok', message: 'ok' };
-      };
-
-      await runDoctor({ vaultDir: tempDir, isTTY: false, binaryVersion: 'v2.0.0', ...validators });
-
-      expect(capturedBinaryVersion).toBe('v2.0.0');
-    });
-
-    it('passes undefined binaryVersion to checkVersionDriftFn when omitted', async () => {
-      let capturedBinaryVersion: string | undefined = 'not-set';
-      const validators = makeAllOkValidators();
-      validators.checkVersionDriftFn = async (_vaultDir, _config, bv) => {
-        capturedBinaryVersion = bv;
-        return { check: 'version-drift', status: 'ok', message: 'ok' };
-      };
-
-      await runDoctor({ vaultDir: tempDir, isTTY: false, ...validators });
-
-      expect(capturedBinaryVersion).toBeUndefined();
-    });
-  });
-
   // ── Summary line selection ─────────────────────────────────────────────────
 
   describe('summary line selection', () => {

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -21,19 +21,13 @@ export interface DoctorOptions {
   vaultDir?: string;
   /** Whether stdout is a TTY (default: process.stdout.isTTY). */
   isTTY?: boolean;
-  /** Compiled binary version (BUILD_VERSION). When provided, compared against plugin.json instead of vault.yml onebrain_version. */
-  binaryVersion?: string;
   /** Injectable validators — real implementations are used when absent. */
   checkVaultYmlFn?: (vaultDir: string) => Promise<DoctorResult>;
   loadVaultConfigFn?: (vaultDir: string) => Promise<VaultConfig>;
   checkFoldersFn?: (vaultDir: string, config: VaultConfig) => Promise<DoctorResult>;
   checkHarnessBinaryFn?: (config: VaultConfig) => Promise<DoctorResult>;
   checkQmdEmbeddingsFn?: (config: VaultConfig) => Promise<DoctorResult>;
-  checkVersionDriftFn?: (
-    vaultDir: string,
-    config: VaultConfig,
-    binaryVersion?: string,
-  ) => Promise<DoctorResult>;
+  checkVersionDriftFn?: (vaultDir: string, config: VaultConfig) => Promise<DoctorResult>;
   checkOrphanCheckpointsFn?: (vaultDir: string, config: VaultConfig) => Promise<DoctorResult>;
   checkSandboxFn?: (config: VaultConfig) => DoctorResult | Promise<DoctorResult>;
 }
@@ -52,7 +46,6 @@ export interface DoctorCommandResult {
 export async function runDoctor(opts: DoctorOptions = {}): Promise<DoctorCommandResult> {
   const vaultDir = opts.vaultDir ?? process.cwd();
   const isTTY = opts.isTTY ?? process.stdout.isTTY ?? false;
-  const binaryVersion = opts.binaryVersion;
 
   const checkVaultYmlFn = opts.checkVaultYmlFn ?? checkVaultYml;
   const loadVaultConfigFn = opts.loadVaultConfigFn ?? loadVaultConfig;
@@ -107,7 +100,7 @@ export async function runDoctor(opts: DoctorOptions = {}): Promise<DoctorCommand
       checkFoldersFn(vaultDir, config),
       checkHarnessBinaryFn(config),
       checkQmdEmbeddingsFn(config),
-      checkVersionDriftFn(vaultDir, config, binaryVersion),
+      checkVersionDriftFn(vaultDir, config),
       checkOrphanCheckpointsFn(vaultDir, config),
       checkSandboxFn(config),
     ]);

--- a/src/index.ts
+++ b/src/index.ts
@@ -106,7 +106,7 @@ program
   .description('Run vault health checks and report issues')
   .action(async () => {
     const vaultRoot = findVaultRoot(process.cwd());
-    await doctorCommand({ vaultDir: vaultRoot, binaryVersion: VERSION });
+    await doctorCommand({ vaultDir: vaultRoot });
   });
 
 program

--- a/src/lib/index.test.ts
+++ b/src/lib/index.test.ts
@@ -467,9 +467,20 @@ describe('checkVersionDrift', () => {
     const result = await checkVersionDrift(dir, config);
 
     expect(result.status).toBe('warn');
-    expect(result.message).toContain('1.9.0');
-    expect(result.message).toContain('1.8.0');
+    expect(result.message).toBe('vault v1.9.0, plugin files v1.8.0');
     expect(result.hint).toContain('onebrain update');
+  });
+
+  it('plugin.json exists but contains invalid JSON → status: ok, message contains unreadable', async () => {
+    const pluginDir = join(dir, '.claude', 'plugins', 'onebrain', '.claude-plugin');
+    await mkdir(pluginDir, { recursive: true });
+    await writeFile(join(pluginDir, 'plugin.json'), '{bad json', 'utf8');
+    const config = { ...baseConfig, onebrain_version: '1.9.0' };
+
+    const result = await checkVersionDrift(dir, config);
+
+    expect(result.status).toBe('ok');
+    expect(result.message).toContain('unreadable');
   });
 
   it('plugin.json with no version field → status: ok, message contains skip', async () => {

--- a/src/lib/index.test.ts
+++ b/src/lib/index.test.ts
@@ -472,17 +472,6 @@ describe('checkVersionDrift', () => {
     expect(result.hint).toContain('onebrain update');
   });
 
-  it('binaryVersion param: checkVersionDrift(dir, config, "2.0.0") with plugin at 1.9.0 → status: warn, message contains binary v2.0.0', async () => {
-    const pluginDir = join(dir, '.claude', 'plugins', 'onebrain', '.claude-plugin');
-    await mkdir(pluginDir, { recursive: true });
-    await writeFile(join(pluginDir, 'plugin.json'), JSON.stringify({ version: '1.9.0' }), 'utf8');
-
-    const result = await checkVersionDrift(dir, baseConfig, '2.0.0');
-
-    expect(result.status).toBe('warn');
-    expect(result.message).toContain('binary v2.0.0');
-  });
-
   it('plugin.json with no version field → status: ok, message contains skip', async () => {
     const pluginDir = join(dir, '.claude', 'plugins', 'onebrain', '.claude-plugin');
     await mkdir(pluginDir, { recursive: true });

--- a/src/lib/validator.ts
+++ b/src/lib/validator.ts
@@ -243,19 +243,18 @@ export async function checkQmdEmbeddings(config: VaultConfig): Promise<DoctorRes
 // ---------------------------------------------------------------------------
 
 /**
- * Compare a version against plugin.json version to detect drift.
+ * Compare vault.yml onebrain_version against plugin.json version to detect drift.
  *
- * When `binaryVersion` is provided, it is compared against plugin.json version
- * (detects "binary is newer than installed plugin files").
- * When `binaryVersion` is absent, falls back to comparing vault.yml
- * `onebrain_version` against plugin.json version.
+ * Both values are on the plugin version track — drift means /update ran partially
+ * (e.g. set onebrain_version in vault.yml but didn't bump plugin.json, or vice versa).
+ * The CLI binary version is intentionally NOT compared here: CLI and plugin files
+ * are released on independent tracks and will routinely differ.
  *
- * Returns ok if the required data for the selected comparison path is unavailable.
+ * Returns ok when the required data is unavailable.
  */
 export async function checkVersionDrift(
   vaultRoot: string,
   config: VaultConfig,
-  binaryVersion?: string,
 ): Promise<DoctorResult> {
   const pluginJsonPath = join(
     vaultRoot,
@@ -268,8 +267,7 @@ export async function checkVersionDrift(
   const pluginFile = Bun.file(pluginJsonPath);
   const exists = await pluginFile.exists();
 
-  // Determine which version to compare against plugin.json
-  const compareVersion = binaryVersion ?? config.onebrain_version;
+  const compareVersion = config.onebrain_version;
 
   if (!compareVersion || !exists) {
     return {
@@ -308,14 +306,10 @@ export async function checkVersionDrift(
     };
   }
 
-  const driftMessage = binaryVersion
-    ? `binary v${binaryVersion}, plugin files v${pluginVersion}`
-    : `vault v${compareVersion}, plugin files v${pluginVersion}`;
-
   return {
     check: 'version-drift',
     status: 'warn',
-    message: driftMessage,
+    message: `vault v${compareVersion}, plugin files v${pluginVersion}`,
     hint: 'Run onebrain update to sync',
   };
 }


### PR DESCRIPTION
## Summary

- CLI binary (e.g. v2.0.9) and plugin files (e.g. v2.0.6) are on **independent release tracks** — they are expected to differ and comparing them always produced a false warning after every `/update` run
- The meaningful drift check is `vault.yml onebrain_version` vs `plugin.json` version — both are on the plugin track; a mismatch here means `/update` ran partially
- Removed `binaryVersion` parameter from `checkVersionDrift`, its propagation through `DoctorOptions`, and the corresponding tests

## Test plan

- [ ] `bun test` passes (221 tests, 0 fail)
- [ ] `onebrain doctor` no longer shows `version-drift` warning when CLI and plugin versions differ by design
- [ ] `version-drift` warning still fires when `vault.yml onebrain_version` differs from `plugin.json` version

🤖 Generated with [Claude Code](https://claude.com/claude-code)