### PR TITLE
fix(doctor): remove unimplemented sandbox check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-latest_version: 2.0.10
+latest_version: 2.0.11
 released: 2026-04-26
 ---
 
@@ -12,6 +12,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 > For plugin changes (skills, agents, hooks, INSTRUCTIONS), see [PLUGIN-CHANGELOG.md](PLUGIN-CHANGELOG.md).
 
 ## [Unreleased]
+
+## v2.0.11 — fix: remove unimplemented sandbox doctor check
+
+- fix(doctor): remove `checkSandbox` — sandbox feature not yet implemented; the check produced a permanent warn for all vaults without benefit
+- fix(types): remove `VaultSandbox` interface and `sandbox?: VaultSandbox` from `VaultConfig`
+- test(doctor): replace sandbox-based warning fixtures with orphan-checkpoints warn in affected tests
 
 ## v2.0.10 — fix: doctor no longer warns on CLI-vs-plugin version difference
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onebrain-ai/cli",
-  "version": "2.0.10",
+  "version": "2.0.11",
   "description": "CLI for OneBrain — personal AI OS for Obsidian with persistent memory, 24+ skills, and Claude Code integration",
   "keywords": [
     "onebrain",

--- a/src/commands/doctor.test.ts
+++ b/src/commands/doctor.test.ts
@@ -49,7 +49,6 @@ function makeAllOkValidators(): Required<
     | 'checkQmdEmbeddingsFn'
     | 'checkVersionDriftFn'
     | 'checkOrphanCheckpointsFn'
-    | 'checkSandboxFn'
   >
 > {
   return {
@@ -72,7 +71,6 @@ function makeAllOkValidators(): Required<
       status: 'ok',
       message: '0 orphans',
     }),
-    checkSandboxFn: async () => ({ check: 'sandbox', status: 'ok', message: 'enabled' }),
   };
 }
 
@@ -116,10 +114,10 @@ describe('runDoctor', () => {
         status: 'warn',
         message: '7/8 present',
       });
-      validators.checkSandboxFn = async () => ({
-        check: 'sandbox',
+      validators.checkOrphanCheckpointsFn = async () => ({
+        check: 'orphan-checkpoints',
         status: 'warn',
-        message: 'disabled',
+        message: '2 unmerged checkpoint(s)',
       });
 
       const result = await runDoctor({ vaultDir: tempDir, isTTY: false, ...validators });
@@ -197,10 +195,10 @@ describe('runDoctor', () => {
       });
       try {
         const validators = makeAllOkValidators();
-        validators.checkSandboxFn = async () => ({
-          check: 'sandbox',
+        validators.checkOrphanCheckpointsFn = async () => ({
+          check: 'orphan-checkpoints',
           status: 'warn',
-          message: 'disabled',
+          message: '1 unmerged checkpoint(s)',
         });
         await runDoctor({ vaultDir: tempDir, isTTY: false, ...validators });
       } finally {
@@ -452,10 +450,10 @@ describe('runDoctor', () => {
         status: 'error',
         message: '0/8 present',
       });
-      validators.checkSandboxFn = async () => ({
-        check: 'sandbox',
+      validators.checkOrphanCheckpointsFn = async () => ({
+        check: 'orphan-checkpoints',
         status: 'warn',
-        message: 'disabled',
+        message: '1 unmerged checkpoint(s)',
       });
       validators.checkHarnessBinaryFn = async () => ({
         check: 'runtime.harness',

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -6,7 +6,6 @@ import {
   checkHarnessBinary,
   checkOrphanCheckpoints,
   checkQmdEmbeddings,
-  checkSandbox,
   checkVaultYml,
   checkVersionDrift,
   loadVaultConfig,
@@ -29,7 +28,6 @@ export interface DoctorOptions {
   checkQmdEmbeddingsFn?: (config: VaultConfig) => Promise<DoctorResult>;
   checkVersionDriftFn?: (vaultDir: string, config: VaultConfig) => Promise<DoctorResult>;
   checkOrphanCheckpointsFn?: (vaultDir: string, config: VaultConfig) => Promise<DoctorResult>;
-  checkSandboxFn?: (config: VaultConfig) => DoctorResult | Promise<DoctorResult>;
 }
 
 export interface DoctorCommandResult {
@@ -54,7 +52,6 @@ export async function runDoctor(opts: DoctorOptions = {}): Promise<DoctorCommand
   const checkQmdEmbeddingsFn = opts.checkQmdEmbeddingsFn ?? checkQmdEmbeddings;
   const checkVersionDriftFn = opts.checkVersionDriftFn ?? checkVersionDrift;
   const checkOrphanCheckpointsFn = opts.checkOrphanCheckpointsFn ?? checkOrphanCheckpoints;
-  const checkSandboxFn = opts.checkSandboxFn ?? checkSandbox;
 
   const vaultYmlResult = await checkVaultYmlFn(vaultDir);
 
@@ -87,7 +84,6 @@ export async function runDoctor(opts: DoctorOptions = {}): Promise<DoctorCommand
   let qmdResult: DoctorResult;
   let versionDriftResult: DoctorResult;
   let orphanCheckpointsResult: DoctorResult;
-  let sandboxResult: DoctorResult;
   try {
     [
       foldersResult,
@@ -95,14 +91,12 @@ export async function runDoctor(opts: DoctorOptions = {}): Promise<DoctorCommand
       qmdResult,
       versionDriftResult,
       orphanCheckpointsResult,
-      sandboxResult,
     ] = await Promise.all([
       checkFoldersFn(vaultDir, config),
       checkHarnessBinaryFn(config),
       checkQmdEmbeddingsFn(config),
       checkVersionDriftFn(vaultDir, config),
       checkOrphanCheckpointsFn(vaultDir, config),
-      checkSandboxFn(config),
     ]);
     sp?.stop();
   } catch (err) {
@@ -117,7 +111,6 @@ export async function runDoctor(opts: DoctorOptions = {}): Promise<DoctorCommand
     qmdResult,
     versionDriftResult,
     orphanCheckpointsResult,
-    sandboxResult,
   ];
 
   const errorCount = results.filter((r) => r.status === 'error').length;

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -85,19 +85,14 @@ export async function runDoctor(opts: DoctorOptions = {}): Promise<DoctorCommand
   let versionDriftResult: DoctorResult;
   let orphanCheckpointsResult: DoctorResult;
   try {
-    [
-      foldersResult,
-      harnessResult,
-      qmdResult,
-      versionDriftResult,
-      orphanCheckpointsResult,
-    ] = await Promise.all([
-      checkFoldersFn(vaultDir, config),
-      checkHarnessBinaryFn(config),
-      checkQmdEmbeddingsFn(config),
-      checkVersionDriftFn(vaultDir, config),
-      checkOrphanCheckpointsFn(vaultDir, config),
-    ]);
+    [foldersResult, harnessResult, qmdResult, versionDriftResult, orphanCheckpointsResult] =
+      await Promise.all([
+        checkFoldersFn(vaultDir, config),
+        checkHarnessBinaryFn(config),
+        checkQmdEmbeddingsFn(config),
+        checkVersionDriftFn(vaultDir, config),
+        checkOrphanCheckpointsFn(vaultDir, config),
+      ]);
     sp?.stop();
   } catch (err) {
     sp?.stop('Health check failed');

--- a/src/lib/index.test.ts
+++ b/src/lib/index.test.ts
@@ -567,4 +567,3 @@ describe('checkOrphanCheckpoints', () => {
     expect(result.message).toContain('1');
   });
 });
-

--- a/src/lib/index.test.ts
+++ b/src/lib/index.test.ts
@@ -8,7 +8,6 @@ import {
   checkHarnessBinary,
   checkOrphanCheckpoints,
   checkQmdEmbeddings,
-  checkSandbox,
   checkVaultYml,
   checkVersionDrift,
   loadVaultConfig,
@@ -145,8 +144,6 @@ describe('loadVaultConfig', () => {
   it('preserves optional fields when present', async () => {
     const yaml = `
 onebrain_version: "1.9.0"
-sandbox:
-  enabled: true
 runtime:
   harness: claude-code
 recap:
@@ -157,7 +154,6 @@ recap:
     const config = await loadVaultConfig(dir);
 
     expect(config.onebrain_version).toBe('1.9.0');
-    expect(config.sandbox?.enabled).toBe(true);
     expect(config.runtime?.harness).toBe('claude-code');
     expect(config.recap?.min_sessions).toBe(3);
     expect(config.recap?.min_frequency).toBe(7);
@@ -572,47 +568,3 @@ describe('checkOrphanCheckpoints', () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// checkSandbox
-// ---------------------------------------------------------------------------
-
-describe('checkSandbox', () => {
-  const baseConfig: VaultConfig = {
-    folders: {
-      inbox: '00-inbox',
-      projects: '01-projects',
-      areas: '02-areas',
-      knowledge: '03-knowledge',
-      resources: '04-resources',
-      agent: '05-agent',
-      archive: '06-archive',
-      logs: '07-logs',
-    },
-    checkpoint: { messages: 15, minutes: 30 },
-    update_channel: 'stable',
-  };
-
-  it('returns ok when sandbox.enabled is true', () => {
-    const config = { ...baseConfig, sandbox: { enabled: true } };
-    const result = checkSandbox(config);
-
-    expect(result.status).toBe('ok');
-    expect(result.check).toBe('sandbox');
-  });
-
-  it('returns warn when sandbox is absent', () => {
-    const result = checkSandbox(baseConfig);
-
-    expect(result.status).toBe('warn');
-    expect(result.message).toBe('disabled');
-    expect(result.hint).toContain('vault.yml');
-  });
-
-  it('returns warn when sandbox.enabled is false', () => {
-    const config = { ...baseConfig, sandbox: { enabled: false } };
-    const result = checkSandbox(config);
-
-    expect(result.status).toBe('warn');
-    expect(result.message).toBe('disabled');
-  });
-});

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -5,7 +5,6 @@ export type {
   VaultFolders,
   VaultCheckpoint,
   VaultRuntime,
-  VaultSandbox,
   VaultStats,
   VaultRecap,
   DoctorResult,
@@ -20,5 +19,4 @@ export {
   checkQmdEmbeddings,
   checkVersionDrift,
   checkOrphanCheckpoints,
-  checkSandbox,
 } from './validator.js';

--- a/src/lib/parser.ts
+++ b/src/lib/parser.ts
@@ -6,7 +6,6 @@ import type {
   VaultFolders,
   VaultRecap,
   VaultRuntime,
-  VaultSandbox,
   VaultStats,
 } from './types.js';
 
@@ -92,10 +91,6 @@ export async function loadVaultConfig(vaultRoot: string): Promise<VaultConfig> {
 
   if (raw['runtime'] !== undefined) {
     config.runtime = raw['runtime'] as VaultRuntime;
-  }
-
-  if (raw['sandbox'] !== undefined) {
-    config.sandbox = raw['sandbox'] as VaultSandbox;
   }
 
   if (raw['stats'] !== undefined) {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -23,10 +23,6 @@ export interface VaultRuntime {
   harness: 'claude-code' | 'gemini' | 'direct';
 }
 
-export interface VaultSandbox {
-  enabled: boolean;
-}
-
 export interface VaultStats {
   last_doctor_run?: string;
   last_update_run?: string;
@@ -44,7 +40,6 @@ export interface VaultConfig {
   qmd_collection?: string;
   checkpoint?: VaultCheckpoint;
   runtime?: VaultRuntime;
-  sandbox?: VaultSandbox;
   onebrain_version?: string;
   update_channel?: 'stable' | 'next';
   stats?: VaultStats;

--- a/src/lib/validator.ts
+++ b/src/lib/validator.ts
@@ -406,26 +406,3 @@ async function readMergedField(filePath: string): Promise<boolean | undefined> {
   }
 }
 
-// ---------------------------------------------------------------------------
-// checkSandbox
-// ---------------------------------------------------------------------------
-
-/**
- * Check that sandbox is explicitly enabled in vault.yml.
- */
-export function checkSandbox(config: VaultConfig): DoctorResult {
-  if (config.sandbox?.enabled === true) {
-    return {
-      check: 'sandbox',
-      status: 'ok',
-      message: 'enabled',
-    };
-  }
-
-  return {
-    check: 'sandbox',
-    status: 'warn',
-    message: 'disabled',
-    hint: 'Set sandbox.enabled: true in vault.yml',
-  };
-}

--- a/src/lib/validator.ts
+++ b/src/lib/validator.ts
@@ -405,4 +405,3 @@ async function readMergedField(filePath: string): Promise<boolean | undefined> {
     return undefined;
   }
 }
-


### PR DESCRIPTION
## Summary

- Removes `checkSandbox` validator — sandbox feature is not yet implemented; the check permanently warned on all vaults with no benefit
- Removes `VaultSandbox` interface and `sandbox?` field from `VaultConfig`
- Removes `sandbox` field parsing from `parser.ts` (missed in initial commit — caught by code review)
- Updates doctor tests to use `checkOrphanCheckpointsFn` as warning fixture instead of the removed sandbox stub

## Test plan

- [x] 220 tests pass, 0 fail
- [x] `onebrain doctor` output no longer shows sandbox check or warning
- [x] `VaultConfig` no longer has `sandbox` field (TypeScript compile clean)
- [x] CI passing