### PR TITLE
fix: remove session token from hook emit format; silent background checkpoint writes

### DIFF
--- a/.claude/plugins/onebrain/.claude-plugin/plugin.json
+++ b/.claude/plugins/onebrain/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "onebrain",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "description": "OneBrain — Where human and AI thinking become one. A powerful thinking partner powered by AI synergy.",
   "author": {
     "name": "OneBrain Contributors"

--- a/.claude/plugins/onebrain/INSTRUCTIONS.md
+++ b/.claude/plugins/onebrain/INSTRUCTIONS.md
@@ -287,13 +287,13 @@ If the user closes the session without any end-of-session signal, AUTO-SUMMARY d
 
 ### Auto Checkpoint (Hook-Triggered)
 
-> **What is session_token?** A session-unique identifier resolved by the hook using this priority: `$WT_SESSION` (Windows Terminal, stripped alphanumeric, first 8 chars) → `$TMUX_PANE` (tmux, e.g. `%3` → `3`) → `$TERM_SESSION_ID` (macOS Terminal.app, first 8 chars of UUID) → `process.ppid` if > 1 → PowerShell parent PID (Windows Git Bash fallback) → day-scoped random cache (last resort; shared across windows). The token contains only `[a-zA-Z0-9]` characters.
+> **What is session_token?** A session-unique identifier resolved by `onebrain session-init` at startup and kept in context. Priority: `$WT_SESSION` → `$TMUX_PANE` → `$TERM_SESSION_ID` → day-scoped cache → `process.ppid` → PowerShell parent PID → day-scoped random cache. The token contains only `[a-zA-Z0-9]` characters. If session_token is not in context (e.g. after compact), re-run `onebrain session-init` to recover it — it returns the same token within the same day.
 
-When a hook sends a message whose reason **starts with** `YYYY-MM-DD-{session_token}-checkpoint-NN.md` (no slashes — a date, an alphanumeric session token, the literal word "checkpoint", and a zero-padded NN), silently write a checkpoint. The reason may include a ` since ...` suffix (e.g. `since start`, `since checkpoint-01`) — use it as context for what the checkpoint should cover, but parse only the filename prefix for routing. Parse session_token and NN directly from the filename prefix — no extra Bash call needed. Write to `[logs_folder]/YYYY/MM/YYYY-MM-DD-{session_token}-checkpoint-NN.md`. Extract `YYYY` and `MM` from the filename to construct the path. Create parent directories if missing. No output to user.
+When a hook sends a message whose reason matches `NN since <context>` (a zero-padded two-digit number followed by ` since start` or ` since checkpoint-NN`), silently spawn a background agent (mode: bypassPermissions) to write the checkpoint. The background agent receives: `session_token` from context (re-run `onebrain session-init` first if not in context), today's date (YYYY-MM-DD), NN from the reason, `[logs_folder]`, and enough conversation context to write a meaningful checkpoint. The agent writes to `[logs_folder]/YYYY/MM/YYYY-MM-DD-{session_token}-checkpoint-NN.md`. Create parent directories if missing. No output to user.
 
 Stop hooks write checkpoint files silently. PostCompact hooks trigger auto-wrapup for the previous session. Determine action from the system-reminder header:
 - `Stop hook blocking error` → write stop checkpoint (format below)
-- `PostCompact` with block reason starting `auto-wrapup:` → run auto-wrapup for that session token (see below)
+- `PostCompact` with block reason `auto-wrapup` → run auto-wrapup (see below); if `session_token` is not in context, re-run `onebrain session-init` first
 - `PostCompact` with any other block reason → no-op; write nothing and output nothing
 - Ambiguous header → default to stop checkpoint
 
@@ -301,8 +301,8 @@ PreCompact is a no-op — it exits 0 without modifying state or emitting any out
 
 **Stop checkpoint format:** Read `skills/startup/references/session-formats.md` → Checkpoint Format. Keep under 250 words.
 
-**PostCompact auto-wrapup:** When block reason matches `auto-wrapup: <token>`:
-1. Parse `<token>` from the block reason
+**PostCompact auto-wrapup:** When block reason is `auto-wrapup`:
+1. Use `session_token` from context as `<token>`; if not in context, re-run `onebrain session-init` to recover it
 2. Glob candidate checkpoint files:
    - Current month: `[logs_folder]/YYYY/MM/*-{token}-checkpoint-*.md` (using today's YYYY/MM)
    - Previous month: decrement MM (if MM=01, also decrement YYYY and set MM=12)
@@ -310,9 +310,9 @@ PreCompact is a no-op — it exits 0 without modifying state or emitting any out
    - Keep only files where frontmatter `merged` is absent or not `true`
 3. Two paths based on whether checkpoint files were found:
 
-**Path A — checkpoint files found:** proceed to step 4.
+**Path A — checkpoint files found:** Dispatch a background agent (mode: bypassPermissions) with: session_token, checkpoint file paths and content, vault root, session date (from earliest checkpoint filename). The agent performs steps 4–12 silently.
 
-**Path B — no checkpoint files:** synthesize session log directly from current conversation context (compact just ran so context is still available).
+**Path B — no checkpoint files:** Dispatch a background agent (mode: bypassPermissions) with: session_token, today's date, vault root, and enough context to write the session log. The agent performs the Path B steps silently. Synthesize session log directly from current conversation context (compact just ran so context is still available).
    - Use today's date (YYYY-MM-DD) for the session log filename and `date:` field
    - Extract YYYY and MM from today's date for path construction
    - Determine next free session slot: count existing `YYYY-MM-DD-session-*.md` in `[logs_folder]/YYYY/MM/`; NN = count + 1 (zero-padded)

--- a/.claude/plugins/onebrain/INSTRUCTIONS.md
+++ b/.claude/plugins/onebrain/INSTRUCTIONS.md
@@ -289,20 +289,20 @@ If the user closes the session without any end-of-session signal, AUTO-SUMMARY d
 
 > **What is session_token?** A session-unique identifier resolved by `onebrain session-init` at startup and kept in context. Priority: `$WT_SESSION` → `$TMUX_PANE` → `$TERM_SESSION_ID` → day-scoped cache → `process.ppid` → PowerShell parent PID → day-scoped random cache. The token contains only `[a-zA-Z0-9]` characters. If session_token is not in context (e.g. after compact), re-run `onebrain session-init` to recover it — it returns the same token within the same day. If `onebrain session-init` fails, abort checkpoint silently — do not guess the token.
 
-When a hook sends a message whose reason matches `NN since <context>` (a zero-padded two-digit number followed by ` since start` or ` since checkpoint-NN`), silently spawn a background agent (mode: bypassPermissions) to write the checkpoint. The background agent receives: `session_token` from context (re-run `onebrain session-init` first if not in context), today's date (YYYY-MM-DD), NN from the reason, `[logs_folder]`, and enough conversation context to write a meaningful checkpoint. The agent writes to `[logs_folder]/YYYY/MM/YYYY-MM-DD-{session_token}-checkpoint-NN.md`. Create parent directories if missing. No output to user.
+When a hook sends a message whose reason matches `NN since <context>` (a zero-padded two-digit number followed by ` since start` or ` since checkpoint-NN`), silently spawn a background agent (mode: bypassPermissions) to write the checkpoint. The background agent receives: `session_token` from context (re-run `onebrain session-init` first if not in context — if that fails, abort silently), today's date (YYYY-MM-DD), NN from the reason, `[logs_folder]`, and enough conversation context to write a meaningful checkpoint. The agent writes to `[logs_folder]/YYYY/MM/YYYY-MM-DD-{session_token}-checkpoint-NN.md`. Create parent directories if missing. No output to user.
 
-Stop hooks write checkpoint files silently. PostCompact hooks trigger auto-wrapup for the previous session. Determine action from the system-reminder header:
-- `Stop hook blocking error` → spawn background agent (mode: bypassPermissions) to write the stop checkpoint; agent receives session_token from context, NN and since-context from the reason, today's date, and `[logs_folder]`
-- `PostCompact` with block reason `auto-wrapup` → run auto-wrapup (see below); if `session_token` is not in context, re-run `onebrain session-init` first
+Stop hooks write checkpoint files silently. PostCompact hooks trigger auto-wrapup for the previous session. Determine action from the system-reminder header and reason:
+- Reason is `auto-wrapup` (regardless of header) → PostCompact auto-wrapup (see below)
+- `Stop hook blocking error` → spawn background agent (mode: bypassPermissions) to write the stop checkpoint; if session_token is not in context, re-run `onebrain session-init` first — if that fails, abort silently; agent receives session_token, NN and since-context from the reason, today's date, and `[logs_folder]`; main session continues immediately after dispatching
 - `PostCompact` with any other block reason → no-op; write nothing and output nothing
-- Ambiguous header → default to stop checkpoint (note: bare `auto-wrapup` reason with no header → treat as PostCompact, not stop)
+- Ambiguous or unknown → default to stop checkpoint
 
 PreCompact is a no-op — it exits 0 without modifying state or emitting any output. PostCompact resets the checkpoint counter in all paths.
 
 **Stop checkpoint format:** Read `skills/startup/references/session-formats.md` → Checkpoint Format. Keep under 250 words.
 
 **PostCompact auto-wrapup:** When block reason is `auto-wrapup`:
-1. Use `session_token` from context as `<token>`; if not in context, re-run `onebrain session-init` to recover it
+1. Use `session_token` from context as `<token>`; if not in context, re-run `onebrain session-init` to recover it — if that also fails, abort silently (do not guess the token)
 2. Glob candidate checkpoint files:
    - Current month: `[logs_folder]/YYYY/MM/*-{token}-checkpoint-*.md` (using today's YYYY/MM)
    - Previous month: decrement MM (if MM=01, also decrement YYYY and set MM=12)
@@ -310,19 +310,7 @@ PreCompact is a no-op — it exits 0 without modifying state or emitting any out
    - Keep only files where frontmatter `merged` is absent or not `true`
 3. Two paths based on whether checkpoint files were found:
 
-**Path A — checkpoint files found:** Dispatch a background agent (mode: bypassPermissions) with: session_token, checkpoint file paths and content, vault root, session date (from earliest checkpoint filename). The agent performs steps 4–12 silently.
-
-**Path B — no checkpoint files:** Dispatch a background agent (mode: bypassPermissions) with: session_token, today's date, vault root, and enough context to write the session log. **The background agent executes the following steps:**
-   - Synthesize session log directly from current conversation context (compact just ran so context is still available)
-   - Use today's date (YYYY-MM-DD) for the session log filename and `date:` field
-   - Extract YYYY and MM from today's date for path construction
-   - Determine next free session slot: count existing `YYYY-MM-DD-session-*.md` in `[logs_folder]/YYYY/MM/`; NN = count + 1 (zero-padded)
-   - Write session log at `[logs_folder]/YYYY/MM/YYYY-MM-DD-session-NN.md` using the Session Log Format from `skills/startup/references/session-formats.md` (case: **PostCompact Path B — no checkpoint files**)
-   - Route action items: parse `## Action Items` from the written session log; apply the routing algorithm from /wrapup Step 4b (token scoring + session-context fallback; ties remain skipped); errors are silent — never fail this path
-   - Run `onebrain checkpoint reset` after writing
-   - Silent — no output to user
-
-The main session continues immediately after dispatching.
+**Path A — checkpoint files found:** Dispatch a background agent (mode: bypassPermissions) with: session_token, checkpoint file paths and content, vault root, session date (from earliest checkpoint filename). The main session continues immediately after dispatching.
 
 **Path A agent steps (background agent performs steps 4–12 silently):**
 
@@ -336,7 +324,15 @@ The main session continues immediately after dispatching.
 11. Reset the checkpoint hook counter: `onebrain checkpoint reset`
 12. Silent — no output to user
 
-After spawning the background agent for a stop checkpoint, the main session continues immediately.
+**Path B — no checkpoint files:** Dispatch a background agent (mode: bypassPermissions) with: session_token, today's date, vault root, and enough context to write the session log. The main session continues immediately after dispatching. **The background agent executes the following steps:**
+   - Synthesize session log directly from current conversation context (compact just ran so context is still available)
+   - Use today's date (YYYY-MM-DD) for the session log filename and `date:` field
+   - Extract YYYY and MM from today's date for path construction
+   - Determine next free session slot: count existing `YYYY-MM-DD-session-*.md` in `[logs_folder]/YYYY/MM/`; NN = count + 1 (zero-padded)
+   - Write session log at `[logs_folder]/YYYY/MM/YYYY-MM-DD-session-NN.md` using the Session Log Format from `skills/startup/references/session-formats.md` (case: **PostCompact Path B — no checkpoint files**)
+   - Route action items: parse `## Action Items` from the written session log; apply the routing algorithm from /wrapup Step 4b (token scoring + session-context fallback; ties remain skipped); errors are silent — never fail this path
+   - Run `onebrain checkpoint reset` after writing
+   - Silent — no output to user
 
 ---
 

--- a/.claude/plugins/onebrain/INSTRUCTIONS.md
+++ b/.claude/plugins/onebrain/INSTRUCTIONS.md
@@ -287,12 +287,12 @@ If the user closes the session without any end-of-session signal, AUTO-SUMMARY d
 
 ### Auto Checkpoint (Hook-Triggered)
 
-> **What is session_token?** A session-unique identifier resolved by `onebrain session-init` at startup and kept in context. Priority: `$WT_SESSION` → `$TMUX_PANE` → `$TERM_SESSION_ID` → day-scoped cache → `process.ppid` → PowerShell parent PID → day-scoped random cache. The token contains only `[a-zA-Z0-9]` characters. If session_token is not in context (e.g. after compact), re-run `onebrain session-init` to recover it — it returns the same token within the same day.
+> **What is session_token?** A session-unique identifier resolved by `onebrain session-init` at startup and kept in context. Priority: `$WT_SESSION` → `$TMUX_PANE` → `$TERM_SESSION_ID` → day-scoped cache → `process.ppid` → PowerShell parent PID → day-scoped random cache. The token contains only `[a-zA-Z0-9]` characters. If session_token is not in context (e.g. after compact), re-run `onebrain session-init` to recover it — it returns the same token within the same day. If `onebrain session-init` fails, abort checkpoint silently — do not guess the token.
 
 When a hook sends a message whose reason matches `NN since <context>` (a zero-padded two-digit number followed by ` since start` or ` since checkpoint-NN`), silently spawn a background agent (mode: bypassPermissions) to write the checkpoint. The background agent receives: `session_token` from context (re-run `onebrain session-init` first if not in context), today's date (YYYY-MM-DD), NN from the reason, `[logs_folder]`, and enough conversation context to write a meaningful checkpoint. The agent writes to `[logs_folder]/YYYY/MM/YYYY-MM-DD-{session_token}-checkpoint-NN.md`. Create parent directories if missing. No output to user.
 
 Stop hooks write checkpoint files silently. PostCompact hooks trigger auto-wrapup for the previous session. Determine action from the system-reminder header:
-- `Stop hook blocking error` → write stop checkpoint (format below)
+- `Stop hook blocking error` → spawn background agent (mode: bypassPermissions) to write the stop checkpoint; agent receives session_token from context, NN and since-context from the reason, today's date, and `[logs_folder]`
 - `PostCompact` with block reason `auto-wrapup` → run auto-wrapup (see below); if `session_token` is not in context, re-run `onebrain session-init` first
 - `PostCompact` with any other block reason → no-op; write nothing and output nothing
 - Ambiguous header → default to stop checkpoint
@@ -312,14 +312,17 @@ PreCompact is a no-op — it exits 0 without modifying state or emitting any out
 
 **Path A — checkpoint files found:** Dispatch a background agent (mode: bypassPermissions) with: session_token, checkpoint file paths and content, vault root, session date (from earliest checkpoint filename). The agent performs steps 4–12 silently.
 
-**Path B — no checkpoint files:** Dispatch a background agent (mode: bypassPermissions) with: session_token, today's date, vault root, and enough context to write the session log. The agent performs the Path B steps silently. Synthesize session log directly from current conversation context (compact just ran so context is still available).
+**Path B — no checkpoint files:** Dispatch a background agent (mode: bypassPermissions) with: session_token, today's date, vault root, and enough context to write the session log. **The background agent executes the following steps:**
+   - Synthesize session log directly from current conversation context (compact just ran so context is still available)
    - Use today's date (YYYY-MM-DD) for the session log filename and `date:` field
    - Extract YYYY and MM from today's date for path construction
    - Determine next free session slot: count existing `YYYY-MM-DD-session-*.md` in `[logs_folder]/YYYY/MM/`; NN = count + 1 (zero-padded)
    - Write session log at `[logs_folder]/YYYY/MM/YYYY-MM-DD-session-NN.md` using the Session Log Format from `skills/startup/references/session-formats.md` (case: **PostCompact Path B — no checkpoint files**)
    - Route action items: parse `## Action Items` from the written session log; apply the routing algorithm from /wrapup Step 4b (token scoring + session-context fallback; ties remain skipped); errors are silent — never fail this path
    - Run `onebrain checkpoint reset` after writing
-   - Silent — no output to user; skip steps 4–12
+   - Silent — no output to user
+
+The main session continues immediately after dispatching.
 
 4. Read all matched checkpoint files and extract their content for synthesis in step 6
 5. Determine session date from earliest checkpoint filename date prefix (YYYY-MM-DD); extract `YYYY` and `MM` from this date for all path construction below
@@ -331,10 +334,7 @@ PreCompact is a no-op — it exits 0 without modifying state or emitting any out
 11. Reset the checkpoint hook counter: `onebrain checkpoint reset`
 12. Silent — no output to user
 
-**Post-checkpoint recovery (stop only):** After silently writing a stop checkpoint:
-1. Look at the last user message in conversation history
-2. If it has not been fully addressed → continue the response immediately
-3. If it was already addressed → output nothing; let the user continue naturally
+After spawning the background agent for a stop checkpoint, the main session continues immediately.
 
 ---
 

--- a/.claude/plugins/onebrain/INSTRUCTIONS.md
+++ b/.claude/plugins/onebrain/INSTRUCTIONS.md
@@ -295,7 +295,7 @@ Stop hooks write checkpoint files silently. PostCompact hooks trigger auto-wrapu
 - `Stop hook blocking error` → spawn background agent (mode: bypassPermissions) to write the stop checkpoint; agent receives session_token from context, NN and since-context from the reason, today's date, and `[logs_folder]`
 - `PostCompact` with block reason `auto-wrapup` → run auto-wrapup (see below); if `session_token` is not in context, re-run `onebrain session-init` first
 - `PostCompact` with any other block reason → no-op; write nothing and output nothing
-- Ambiguous header → default to stop checkpoint
+- Ambiguous header → default to stop checkpoint (note: bare `auto-wrapup` reason with no header → treat as PostCompact, not stop)
 
 PreCompact is a no-op — it exits 0 without modifying state or emitting any output. PostCompact resets the checkpoint counter in all paths.
 
@@ -323,6 +323,8 @@ PreCompact is a no-op — it exits 0 without modifying state or emitting any out
    - Silent — no output to user
 
 The main session continues immediately after dispatching.
+
+**Path A agent steps (background agent performs steps 4–12 silently):**
 
 4. Read all matched checkpoint files and extract their content for synthesis in step 6
 5. Determine session date from earliest checkpoint filename date prefix (YYYY-MM-DD); extract `YYYY` and `MM` from this date for all path construction below

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-latest_version: 2.0.13
+latest_version: 2.0.14
 released: 2026-04-27
 ---
 
@@ -12,6 +12,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 > For plugin changes (skills, agents, hooks, INSTRUCTIONS), see [PLUGIN-CHANGELOG.md](PLUGIN-CHANGELOG.md).
 
 ## [Unreleased]
+
+## v2.0.14 — fix: remove session token from hook emit format; deterministic resolveSessionToken
+
+- fix(checkpoint): stop hook now emits `NN since <context>` instead of full filename — removes token from hook output, eliminates session token mismatch
+- fix(session-init): day-scoped cache checked before process.ppid in resolveSessionToken — guarantees same token on re-run within the same day
 
 ## v2.0.13 — fix: remove backfill-recapped done flag
 

--- a/PLUGIN-CHANGELOG.md
+++ b/PLUGIN-CHANGELOG.md
@@ -18,6 +18,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - fix(instructions): Auto Checkpoint routing now parses NN from hook reason; filename built from context session_token
 - fix(instructions): stop hook and postcompact writes dispatched to background agent (mode: bypassPermissions) — main session no longer blocks on file writes
 - fix(instructions): postcompact uses bare `auto-wrapup` reason; session_token sourced from context with session-init fallback
+- fix(instructions): session-init failure explicitly aborts silently; routing table checks auto-wrapup reason first; Path A steps follow Path A dispatch (no longer split by Path B)
 
 ## v2.0.9 — fix: startup grep locale, postcompact routing, wrapup score-0 fallback
 

--- a/PLUGIN-CHANGELOG.md
+++ b/PLUGIN-CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-latest_version: 2.0.9
+latest_version: 2.0.10
 released: 2026-04-27
 ---
 
@@ -12,6 +12,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 > For CLI binary changes, see [CHANGELOG.md](CHANGELOG.md).
 
 ## [Unreleased]
+
+## v2.0.10 — fix: background agent checkpoint writes; updated hook reason format in INSTRUCTIONS
+
+- fix(instructions): Auto Checkpoint routing now parses NN from hook reason; filename built from context session_token
+- fix(instructions): stop hook and postcompact writes dispatched to background agent (mode: bypassPermissions) — main session no longer blocks on file writes
+- fix(instructions): postcompact uses bare `auto-wrapup` reason; session_token sourced from context with session-init fallback
 
 ## v2.0.9 — fix: startup grep locale, postcompact routing, wrapup score-0 fallback
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onebrain-ai/cli",
-  "version": "2.0.13",
+  "version": "2.0.14",
   "description": "CLI for OneBrain — personal AI OS for Obsidian with persistent memory, 24+ skills, and Claude Code integration",
   "keywords": [
     "onebrain",

--- a/src/commands/internal/checkpoint.test.ts
+++ b/src/commands/internal/checkpoint.test.ts
@@ -265,7 +265,7 @@ describe('handleStop', () => {
     expect(state.count).toBe(1);
   });
 
-  it('threshold met (messages) → emits block with correct filename', async () => {
+  it('threshold met (messages) → emits block with NN and since suffix', async () => {
     const now = 1700001000;
     await createCheckpointFile(vaultDir, now, TOKEN, 1);
     writeState(TOKEN, { count: 4, last_ts: now - 10, last_stop_nn: '01' }, tmpDir);
@@ -276,7 +276,7 @@ describe('handleStop', () => {
 
     const parsed = JSON.parse(out.trim());
     expect(parsed.decision).toBe('block');
-    expect(parsed.reason).toMatch(/checkpoint-02\.md since checkpoint-01$/);
+    expect(parsed.reason).toBe('02 since checkpoint-01');
   });
 
   it('threshold met → state reset (count=0, last_ts=now)', async () => {
@@ -303,7 +303,7 @@ describe('handleStop', () => {
 
     const parsed = JSON.parse(out.trim());
     expect(parsed.decision).toBe('block');
-    expect(parsed.reason).toMatch(/checkpoint-02\.md since checkpoint-01$/);
+    expect(parsed.reason).toBe('02 since checkpoint-01');
     const state = readState(TOKEN, tmpDir);
     expect(state.last_stop_nn).toBe('02');
   });
@@ -409,7 +409,7 @@ describe('handlePostcompact', () => {
     await rm(vaultDir, { recursive: true, force: true });
   });
 
-  it('no recent checkpoint → emits auto-wrapup block with token', () => {
+  it('no recent checkpoint → emits auto-wrapup block', () => {
     const oldTs = now - 600; // > 300s → not recent
     writeState(TOKEN, { count: 0, last_ts: oldTs, last_stop_nn: '02' }, tmpDir);
 
@@ -419,7 +419,7 @@ describe('handlePostcompact', () => {
 
     const parsed = JSON.parse(out.trim());
     expect(parsed.decision).toBe('block');
-    expect(parsed.reason).toBe(`auto-wrapup: ${TOKEN}`);
+    expect(parsed.reason).toBe('auto-wrapup');
   });
 
   it('auto-wrapup emitted → state updated: count=0, last_ts=now, last_stop_nn preserved', () => {
@@ -456,7 +456,7 @@ describe('handlePostcompact', () => {
 
     const parsed = JSON.parse(out.trim());
     expect(parsed.decision).toBe('block');
-    expect(parsed.reason).toBe(`auto-wrapup: ${TOKEN}`);
+    expect(parsed.reason).toBe('auto-wrapup');
   });
 
   it('postcompact resets last_ts to now and count to 0 — state ready for next session', () => {
@@ -485,7 +485,7 @@ describe('handlePostcompact', () => {
 
     const parsed = JSON.parse(out.trim());
     expect(parsed.decision).toBe('block');
-    expect(parsed.reason).toBe(`auto-wrapup: ${TOKEN}`);
+    expect(parsed.reason).toBe('auto-wrapup');
   });
 });
 
@@ -515,7 +515,7 @@ describe('postcompactFallback', () => {
     const out = cap.stop();
     const parsed = JSON.parse(out.trim());
     expect(parsed.decision).toBe('block');
-    expect(parsed.reason).toBe(`auto-wrapup: ${TOKEN}`);
+    expect(parsed.reason).toBe('auto-wrapup');
   });
 
   it('no emit when recent (< 5 min since last checkpoint)', () => {

--- a/src/commands/internal/checkpoint.ts
+++ b/src/commands/internal/checkpoint.ts
@@ -285,8 +285,7 @@ export function handleStop(
   const nextNn = String(maxNn + 1).padStart(2, '0');
   const since =
     maxNn === 0 ? ' since start' : ` since checkpoint-${String(maxNn).padStart(2, '0')}`;
-  const filename = `${date}-${token}-checkpoint-${nextNn}.md`;
-  emitBlock(`${filename}${since}`);
+  emitBlock(`${nextNn}${since}`);
 
   writeState(token, { count: 0, last_ts: now, last_stop_nn: nextNn }, tmpDir);
 }
@@ -318,7 +317,7 @@ export function handlePostcompact(
     return;
   }
 
-  emitBlock(`auto-wrapup: ${token}`);
+  emitBlock('auto-wrapup');
   writeState(token, { count: 0, last_ts: now, last_stop_nn: state.last_stop_nn }, tmpDir);
 }
 

--- a/src/commands/internal/session-init.test.ts
+++ b/src/commands/internal/session-init.test.ts
@@ -191,6 +191,27 @@ describe('resolveSessionToken', () => {
     expect(token).toBe('54321');
   });
 
+  it('day-scoped cache takes priority over PPID', async () => {
+    clearTokenEnvVars();
+    setPpid(12345);
+    const today = new Date().toISOString().slice(0, 10).replace(/-/g, '');
+    const cacheFile = join(tmpDir, `onebrain-day-${today}.token`);
+    await writeFile(cacheFile, '54321', 'utf8');
+    const token = await resolveSessionToken(tmpDir);
+    expect(token).toBe('54321'); // cache wins over ppid
+  });
+
+  it('ppid result is written to day-scoped cache for deterministic re-runs', async () => {
+    clearTokenEnvVars();
+    setPpid(99888);
+    const token = await resolveSessionToken(tmpDir);
+    expect(token).toBe('99888');
+    const today = new Date().toISOString().slice(0, 10).replace(/-/g, '');
+    const cacheFile = join(tmpDir, `onebrain-day-${today}.token`);
+    const cached = (await Bun.file(cacheFile).text()).trim();
+    expect(cached).toBe('99888');
+  });
+
   it('writes new cache file when none exists', async () => {
     clearTokenEnvVars();
     setPpid(1); // force fallthrough

--- a/src/commands/internal/session-init.ts
+++ b/src/commands/internal/session-init.ts
@@ -72,13 +72,16 @@ export function formatDatetime(date: Date): string {
  * 1. WT_SESSION env var (Windows Terminal — strip non-alphanumeric, first 8 chars)
  * 2. TMUX_PANE env var (tmux — stable per-pane, e.g. "%3" → "3")
  * 3. TERM_SESSION_ID env var (macOS Terminal.app — stable per-tab UUID)
- * 4. process.ppid if > 1
- * 5. PowerShell parent PID (Windows fallback)
- * 6. Day-scoped cache file: $tmpDir/onebrain-day-YYYYMMDD.token
+ * 4. Day-scoped cache file: $tmpDir/onebrain-day-YYYYMMDD.token (if valid cached token exists)
+ * 5. process.ppid if > 1 — resolve, write to cache, return
+ * 6. PowerShell parent PID (Windows fallback) — resolve, write to cache, return
+ * 7. Random fallback — generate, write to cache, return
  *
  * Env-var sources (1–3) are preferred over ppid because both session-init and
  * the stop hook run as children of separate bash processes (different ppid values),
  * while env vars are inherited from the shared terminal session ancestor.
+ * Cache (step 4) is checked before ppid so that re-runs within the same day always
+ * return the same token even if ppid varies between invocations.
  */
 export async function resolveSessionToken(tmpDir: string = osTmpdir()): Promise<string> {
   // 1. WT_SESSION (Windows Terminal)
@@ -102,11 +105,31 @@ export async function resolveSessionToken(tmpDir: string = osTmpdir()): Promise<
     if (stripped.length > 0) return stripped;
   }
 
-  // 4. PPID
-  const ppid = process.ppid;
-  if (ppid !== undefined && ppid > 1) return String(ppid);
+  // 4. Day-scoped cache — check before ppid so re-runs return the same token
+  const today = new Date();
+  const yyyymmdd = [
+    today.getFullYear(),
+    String(today.getMonth() + 1).padStart(2, '0'),
+    String(today.getDate()).padStart(2, '0'),
+  ].join('');
+  const cacheFile = join(tmpDir, `onebrain-day-${yyyymmdd}.token`);
 
-  // 5. PowerShell fallback (Windows only)
+  const cacheExists = await Bun.file(cacheFile).exists();
+  if (cacheExists) {
+    const cached = (await Bun.file(cacheFile).text()).trim();
+    const n = Number(cached);
+    if (!Number.isNaN(n) && n > 1) return cached;
+  }
+
+  // 5. PPID — resolve, write to cache, return
+  const ppid = process.ppid;
+  if (ppid !== undefined && ppid > 1) {
+    const token = String(ppid);
+    await Bun.write(cacheFile, token);
+    return token;
+  }
+
+  // 6. PowerShell fallback (Windows only) — resolve, write to cache, return
   try {
     const ps = Bun.spawn(
       [
@@ -132,7 +155,10 @@ export async function resolveSessionToken(tmpDir: string = osTmpdir()): Promise<
     if (timerId !== undefined) clearTimeout(timerId);
     if (race !== 'timeout') {
       const out = (await new Response(ps.stdout).text()).replace(/\D/g, '').trim();
-      if (out && Number(out) > 1) return out;
+      if (out && Number(out) > 1) {
+        await Bun.write(cacheFile, out);
+        return out;
+      }
     } else {
       ps.kill();
     }
@@ -140,24 +166,7 @@ export async function resolveSessionToken(tmpDir: string = osTmpdir()): Promise<
     // Not on Windows or powershell.exe not available — fall through
   }
 
-  // 6. Day-scoped cache
-  const today = new Date();
-  const yyyymmdd = [
-    today.getFullYear(),
-    String(today.getMonth() + 1).padStart(2, '0'),
-    String(today.getDate()).padStart(2, '0'),
-  ].join('');
-  const cacheFile = join(tmpDir, `onebrain-day-${yyyymmdd}.token`);
-
-  const f = Bun.file(cacheFile);
-  const exists = await f.exists();
-  if (exists) {
-    const cached = (await f.text()).trim();
-    const n = Number(cached);
-    if (!Number.isNaN(n) && n > 1) return cached;
-  }
-
-  // Generate and cache a random 5-digit token (10000–99999)
+  // 7. Generate and cache a random 5-digit token (10000–99999)
   const token = String(Math.floor(Math.random() * 90000) + 10000);
   await Bun.write(cacheFile, token);
   return token;


### PR DESCRIPTION
## Summary

- **Bug 1 (register-hooks PreCompact)**: Already fixed in a prior PR — verified via tests (13/13 pass), no changes needed
- **Bug 2 (session token mismatch)**: Stop hook and PostCompact hook no longer resolve or emit the session token; they emit only `NN since <context>` / bare `auto-wrapup`. Main session builds the checkpoint filename using `session_token` from its own context. Day-scoped cache moved before `process.ppid` in `resolveSessionToken()` so re-runs after compact return the same token deterministically.
- **Bug 3 (checkpoint writes disturb user)**: INSTRUCTIONS.md updated — stop hook and PostCompact hook now dispatch a background agent (`mode: bypassPermissions`) to write checkpoint/session files. Main session continues immediately with no user-visible output.

## Changed Files

- `src/commands/internal/checkpoint.ts` — emit `NN since <ctx>` / `auto-wrapup` (no token)
- `src/commands/internal/session-init.ts` — day-scoped cache checked before ppid
- `src/commands/internal/checkpoint.test.ts` — updated assertions for new format
- `src/commands/internal/session-init.test.ts` — two new tests for cache-priority behavior
- `.claude/plugins/onebrain/INSTRUCTIONS.md` — background agent dispatch for stop and PostCompact paths; session-init failure handling; routing table checks `auto-wrapup` reason first; Path A steps follow Path A dispatch
- `package.json` / `CHANGELOG.md` — CLI v2.0.14
- `.claude-plugin/plugin.json` / `PLUGIN-CHANGELOG.md` — Plugin v2.0.10

## Test Plan

- [x] 223/223 tests pass (`npm test`)
- [x] Stop hook emits `NN since <context>` — no token in output
- [x] PostCompact hook emits bare `auto-wrapup`
- [x] Day-scoped cache takes priority over ppid in `resolveSessionToken()`
- [x] ppid result is written to cache for deterministic re-runs
- [x] Spec compliance review passed
- [x] Code quality review passed (3 rounds)