### PR TITLE
feat(postinstall): download compiled binary on npm/bun install — no Bun required (v2.1.3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
-      - run: bun install --frozen-lockfile
+      - run: bun install --frozen-lockfile --ignore-scripts
       - run: bunx tsc --noEmit
       - run: bunx biome check .
       - run: bun test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,8 +55,17 @@ jobs:
           - target: bun-linux-x64
             output: onebrain-linux-x64
             ext: ""
+          - target: bun-linux-arm64-musl
+            output: onebrain-linux-arm64-musl
+            ext: ""
+          - target: bun-linux-x64-musl
+            output: onebrain-linux-x64-musl
+            ext: ""
           - target: bun-windows-x64
             output: onebrain-windows-x64
+            ext: ".exe"
+          - target: bun-windows-arm64
+            output: onebrain-windows-arm64
             ext: ".exe"
 
     steps:
@@ -131,39 +140,9 @@ jobs:
             onebrain-plugin-v${{ needs.verify-tag.outputs.version }}.zip
             onebrain-plugin-v${{ needs.verify-tag.outputs.version }}.sha256
 
-  # ─── Step 4: npm publish ──────────────────────────────────────────────────
-  npm-publish:
-    needs: [verify-tag, build-binaries, package-plugin]
-    runs-on: ubuntu-latest
-    continue-on-error: true
-    steps:
-      - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: "1.2"
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
-
-      - name: Compile TypeScript
-        env:
-          VERSION: ${{ needs.verify-tag.outputs.version }}
-          RELEASE_DATE: ${{ needs.verify-tag.outputs.release_date }}
-        run: |
-          bun build src/index.ts --outfile dist/onebrain --target bun \
-            --define BUILD_VERSION="\"$VERSION\"" \
-            --define BUILD_DATE="\"$RELEASE_DATE\""
-
-      - name: Publish to npm
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
-          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> ~/.npmrc
-          npm publish --access public
-
-  # ─── Step 5: create GitHub release ───────────────────────────────────────
+  # ─── Step 4: create GitHub release ──────────────────────────────────────
   create-release:
-    needs: [verify-tag, build-binaries, package-plugin, npm-publish]
+    needs: [verify-tag, build-binaries, package-plugin]
     runs-on: ubuntu-latest
     if: ${{ always() && needs.build-binaries.result == 'success' && needs.package-plugin.result == 'success' }}
     permissions:
@@ -198,11 +177,11 @@ jobs:
           VERSION: ${{ needs.verify-tag.outputs.version }}
         run: |
           ASSETS=()
-          for target in darwin-arm64 darwin-x64 linux-arm64 linux-x64; do
+          for target in darwin-arm64 darwin-x64 linux-arm64 linux-x64 linux-arm64-musl linux-x64-musl; do
             ASSETS+=("onebrain-${target}")
             ASSETS+=("onebrain-${target}.sha256")
           done
-          for target in windows-x64; do
+          for target in windows-x64 windows-arm64; do
             ASSETS+=("onebrain-${target}.exe")
             ASSETS+=("onebrain-${target}.sha256")
           done
@@ -222,3 +201,36 @@ jobs:
             --title "OneBrain v${VERSION}" \
             --notes-file release_notes.txt \
             "${FILE_ARGS[@]}"
+
+  # ─── Step 5: npm publish (after release so postinstall can download binaries)
+  npm-publish:
+    needs: [verify-tag, create-release]
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.2"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build postinstall script
+        run: bun build src/scripts/postinstall.ts --outfile dist/postinstall.js --target node
+
+      - name: Compile TypeScript bundle (fallback for unsupported platforms)
+        env:
+          VERSION: ${{ needs.verify-tag.outputs.version }}
+          RELEASE_DATE: ${{ needs.verify-tag.outputs.release_date }}
+        run: |
+          bun build src/index.ts --outfile dist/onebrain --target bun \
+            --define BUILD_VERSION="\"$VERSION\"" \
+            --define BUILD_DATE="\"$RELEASE_DATE\""
+
+      - name: Publish to npm
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> ~/.npmrc
+          npm publish --access public

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
           bun-version: "1.2"
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        run: bun install --frozen-lockfile --ignore-scripts
 
       - name: Build binary
         env:
@@ -214,7 +214,7 @@ jobs:
           bun-version: "1.2"
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        run: bun install --frozen-lockfile --ignore-scripts
 
       - name: Build postinstall script
         run: bun build src/scripts/postinstall.ts --outfile dist/postinstall.js --target node

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,7 +150,7 @@ jobs:
           VERSION: ${{ needs.verify-tag.outputs.version }}
           RELEASE_DATE: ${{ needs.verify-tag.outputs.release_date }}
         run: |
-          bun build src/index.ts --outfile dist/onebrain --target node \
+          bun build src/index.ts --outfile dist/onebrain --target bun \
             --define BUILD_VERSION="\"$VERSION\"" \
             --define BUILD_DATE="\"$RELEASE_DATE\""
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
-## v2.1.3 — fix: npm publish target + biome cleanup
+## v2.1.3 — feat: postinstall binary download + full platform support
 
-- fix(release): use `--target bun` in npm-publish step — npm-installed binary was still built with `--target node`, causing UTF-8 garbling despite the v2.1.1 fix
+- feat(postinstall): `npm install -g` / `bun install -g` now downloads the correct platform-specific compiled binary automatically — no Bun installation required
+- feat(release): add `bun-windows-arm64`, `bun-linux-x64-musl`, `bun-linux-arm64-musl` build targets — 8 platforms total
+- feat(release): `npm-publish` now runs after `create-release` — ensures compiled binaries exist on GitHub Releases before postinstall downloads them
+- fix(release): use `--target bun` in npm-publish step — JS bundle fallback for unsupported platforms
 - fix(update): remove unused `daysBehind` function
-- fix(biome): format validator.ts — wrap long lines introduced by exactOptionalPropertyTypes spread fixes
-- fix(biome): replace template literal with string literal in cli-banner.ts cursor definition
-- fix(biome): simplify boolean ternary in init.test.ts confirmFn
+- fix(biome): format validator.ts, cli-banner.ts, init.test.ts, cli-ui.ts
 
 ## v2.1.2 — fix: init fresh install layout + CI typecheck
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-latest_version: 2.1.2
+latest_version: 2.1.3
 released: 2026-04-29
 ---
 
@@ -12,6 +12,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 > For plugin changes (skills, agents, hooks, INSTRUCTIONS), see [PLUGIN-CHANGELOG.md](PLUGIN-CHANGELOG.md).
 
 ## [Unreleased]
+
+## v2.1.3 — fix: npm publish target + biome cleanup
+
+- fix(release): use `--target bun` in npm-publish step — npm-installed binary was still built with `--target node`, causing UTF-8 garbling despite the v2.1.1 fix
+- fix(update): remove unused `daysBehind` function
+- fix(biome): format validator.ts — wrap long lines introduced by exactOptionalPropertyTypes spread fixes
+- fix(biome): replace template literal with string literal in cli-banner.ts cursor definition
+- fix(biome): simplify boolean ternary in init.test.ts confirmFn
 
 ## v2.1.2 — fix: init fresh install layout + CI typecheck
 

--- a/README.md
+++ b/README.md
@@ -170,24 +170,37 @@ OneBrain has three automatic behaviors that run without you doing anything:
 
 ## Installation
 
-### 1. Install the CLI
+### 1. Install Bun
+
+The `onebrain` binary requires [Bun](https://bun.sh) in your `PATH`:
+
+```bash
+# macOS / Linux
+curl -fsSL https://bun.sh/install | bash
+
+# Windows
+powershell -c "irm bun.sh/install.ps1 | iex"
+```
+
+### 2. Install the CLI
 
 ```bash
 npm install -g @onebrain-ai/cli
+# or: bun install -g @onebrain-ai/cli
 ```
 
-### 2. Create and initialize your vault
+### 3. Create and initialize your vault
 
 ```bash
 mkdir my-vault && cd my-vault
 onebrain init
 ```
 
-### 3. Open Obsidian
+### 4. Open Obsidian
 
 File → Open Folder as Vault → select this folder
 
-### 4. Personalize your vault
+### 5. Personalize your vault
 
 In Claude Code: `/onboarding`
 
@@ -364,7 +377,7 @@ Tasks live inline in your notes — the Tasks plugin surfaces them across the va
 
 Verify with `git --version` before running the installer.
 
-**Required for auto-checkpoints, `/doctor`, and `/update`:** [bun](https://bun.sh) or [npm](https://nodejs.org) — used to install the `onebrain` CLI binary (`bun install -g @onebrain-ai/cli`). The binary handles checkpoints, session init, vault-sync, and doctor without requiring Python or Node.js in your PATH.
+**Required:** [bun](https://bun.sh) — the `onebrain` binary runs under Bun and requires it in your `PATH` at runtime. Install via the [official installer](https://bun.sh/docs/installation) or `curl -fsSL https://bun.sh/install | bash`. The binary handles checkpoints, session init, vault-sync, and doctor — no Python or Node.js needed.
 
 **Windows:** Git for Windows (above) includes Git Bash, which provides the `bash` environment required to run all hooks.
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Unlike chat-based AI tools, OneBrain lives in plain Markdown files you own forev
 | 🪄 | **Smart Memory Review** | `/memory-review` lets you interactively prune, update, or archive memory entries one by one |
 | 🔒 | **Concurrent-session Safe** | Each session generates an isolated 6-char token — multiple parallel sessions never mix checkpoints |
 | 📱 | **Mobile Access** | Send instructions and receive briefings from anywhere via Telegram |
-| ⚙️ | **CLI Binary** | `onebrain` binary handles checkpoints, session init, doctor, vault-sync, and updates — no Python or Node.js required |
+| ⚙️ | **CLI Binary** | `onebrain` binary handles checkpoints, session init, doctor, vault-sync, and updates — no Bun, Python, or Node.js required |
 
 ---
 
@@ -164,43 +164,33 @@ OneBrain has three automatic behaviors that run without you doing anything:
 
 **The practical result:** Just say "bye" and everything is saved. If the session ends unexpectedly, you lose at most 15 messages — the last checkpoint recovers the rest.
 
-> Auto Checkpoint requires Claude Code (uses the Claude Code stop hook) and the `onebrain` CLI binary. Install with `bun install -g @onebrain-ai/cli`. Auto Session Summary works with any agent that follows INSTRUCTIONS.md.
+> Auto Checkpoint requires Claude Code (uses the Claude Code stop hook) and the `onebrain` CLI binary. Install with `npm install -g @onebrain-ai/cli`. Auto Session Summary works with any agent that follows INSTRUCTIONS.md.
 
 ---
 
 ## Installation
 
-### 1. Install Bun
-
-The `onebrain` binary requires [Bun](https://bun.sh) in your `PATH`:
-
-```bash
-# macOS / Linux
-curl -fsSL https://bun.sh/install | bash
-
-# Windows
-powershell -c "irm bun.sh/install.ps1 | iex"
-```
-
-### 2. Install the CLI
+### 1. Install the CLI
 
 ```bash
 npm install -g @onebrain-ai/cli
 # or: bun install -g @onebrain-ai/cli
 ```
 
-### 3. Create and initialize your vault
+The installer automatically downloads the correct compiled binary for your platform — no Bun installation required.
+
+### 2. Create and initialize your vault
 
 ```bash
 mkdir my-vault && cd my-vault
 onebrain init
 ```
 
-### 4. Open Obsidian
+### 3. Open Obsidian
 
 File → Open Folder as Vault → select this folder
 
-### 5. Personalize your vault
+### 4. Personalize your vault
 
 In Claude Code: `/onboarding`
 
@@ -377,7 +367,7 @@ Tasks live inline in your notes — the Tasks plugin surfaces them across the va
 
 Verify with `git --version` before running the installer.
 
-**Required:** [bun](https://bun.sh) — the `onebrain` binary runs under Bun and requires it in your `PATH` at runtime. Install via the [official installer](https://bun.sh/docs/installation) or `curl -fsSL https://bun.sh/install | bash`. The binary handles checkpoints, session init, vault-sync, and doctor — no Python or Node.js needed.
+**Optional:** [bun](https://bun.sh) — not required for most users. `npm install -g @onebrain-ai/cli` automatically downloads a compiled binary for your platform. Bun is only needed if you're on an unsupported platform or want to install from source.
 
 **Windows:** Git for Windows (above) includes Git Bash, which provides the `bash` environment required to run all hooks.
 

--- a/package.json
+++ b/package.json
@@ -26,9 +26,11 @@
   "bin": {
     "onebrain": "dist/onebrain"
   },
-  "files": ["dist/onebrain"],
+  "files": ["dist/onebrain", "dist/postinstall.js"],
   "scripts": {
     "build": "bun build src/index.ts --outfile dist/onebrain --target bun",
+    "build:postinstall": "bun build src/scripts/postinstall.ts --outfile dist/postinstall.js --target node",
+    "postinstall": "node dist/postinstall.js",
     "test": "bun test --pass-with-no-tests src/",
     "typecheck": "tsc --noEmit"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onebrain-ai/cli",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "CLI for OneBrain — personal AI OS for Obsidian with persistent memory, 24+ skills, and Claude Code integration",
   "keywords": [
     "onebrain",

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -253,13 +253,16 @@ function printNonTtyOutput(
   }
   lines.push('');
   if (errorCount > 0) {
-    lines.push(`Summary: ${totalChecks} checks · ${errorCount} error(s) · ${warningCount} warning(s) — fix before using`);
+    lines.push(
+      `Summary: ${totalChecks} checks · ${errorCount} error(s) · ${warningCount} warning(s) — fix before using`,
+    );
   } else if (warningCount > 0) {
     lines.push(`Summary: ${totalChecks} checks · ${warningCount} warning(s) — ok to run`);
   } else {
     lines.push(`Summary: ${totalChecks} checks — all passed`);
   }
-  if (showFixHint) lines.push(`hint: run onebrain doctor --fix to auto-fix ${fixableCount} issue(s)`);
+  if (showFixHint)
+    lines.push(`hint: run onebrain doctor --fix to auto-fix ${fixableCount} issue(s)`);
   process.stdout.write(`${lines.join('\n')}\n`);
 }
 
@@ -323,7 +326,8 @@ function getFix(r: DoctorResult): Fix | null {
         const text = await readFile(vaultYmlPath, 'utf8');
         const raw = (parse(text) ?? {}) as Record<string, unknown>;
         const details = r.details ?? [];
-        if (details.some((d) => d.includes('onebrain_version'))) raw['onebrain_version'] = undefined;
+        if (details.some((d) => d.includes('onebrain_version')))
+          raw['onebrain_version'] = undefined;
         if (details.some((d) => d.includes('deprecated key: method'))) raw['method'] = undefined;
         if (details.some((d) => d.includes('runtime.harness'))) {
           const runtime = raw['runtime'] as Record<string, unknown> | undefined;

--- a/src/commands/init.test.ts
+++ b/src/commands/init.test.ts
@@ -327,7 +327,7 @@ describe('runInit', () => {
       isTTY: true,
       confirmFn: async () => {
         callCount++;
-        return callCount === 1 ? true : false; // yes to dir, no to overwrite
+        return callCount === 1; // yes to dir, no to overwrite
       },
       vaultSyncFn: noopVaultSync,
       registerHooksFn: noopRegisterHooks,

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -22,7 +22,15 @@ import { dirname, join } from 'node:path';
 import pc from 'picocolors';
 import { stringify as stringifyYaml } from 'yaml';
 import { printBanner, resolveBinaryVersion } from './internal/cli-banner.js';
-import { askYesNo, barBlank, barLine, close, dotLine, makeStepFn, writeLine } from './internal/cli-ui.js';
+import {
+  askYesNo,
+  barBlank,
+  barLine,
+  close,
+  dotLine,
+  makeStepFn,
+  writeLine,
+} from './internal/cli-ui.js';
 
 const binaryVersion = resolveBinaryVersion();
 
@@ -200,9 +208,7 @@ async function downloadPluginFiles(
   return { skipped: false };
 }
 
-async function countPluginContents(
-  vaultDir: string,
-): Promise<{ skills: number; agents: number }> {
+async function countPluginContents(vaultDir: string): Promise<{ skills: number; agents: number }> {
   const base = join(vaultDir, '.claude', 'plugins', 'onebrain');
   const [skillEntries, agentEntries] = await Promise.all([
     readdir(join(base, 'skills'), { withFileTypes: true }).catch(() => []),
@@ -475,7 +481,10 @@ export async function runInit(opts: InitOptions = {}): Promise<InitResult> {
   // Injectable dependencies (real implementations lazy-loaded)
   const vaultSyncFn =
     opts.vaultSyncFn ??
-    (async (dir: string, syncOpts: { branch?: string; includeObsidian?: boolean; embedded?: boolean }) => {
+    (async (
+      dir: string,
+      syncOpts: { branch?: string; includeObsidian?: boolean; embedded?: boolean },
+    ) => {
       const { vaultSyncCommand } = await import('./internal/vault-sync.js');
       await vaultSyncCommand(dir, syncOpts);
     });
@@ -594,10 +603,10 @@ export async function runInit(opts: InitOptions = {}): Promise<InitResult> {
   const pluginFilesExist = await pathExists(pluginJsonPath);
   const sp4 = pluginFilesExist ? createStep('📦', 'Plugin files') : null;
 
-  const {
-    skipped: pluginSkipped,
-    failed: pluginDownloadFailed,
-  } = await downloadPluginFiles(vaultDir, vaultSyncFn);
+  const { skipped: pluginSkipped, failed: pluginDownloadFailed } = await downloadPluginFiles(
+    vaultDir,
+    vaultSyncFn,
+  );
   result.pluginSkipped = pluginSkipped;
 
   if (sp4) {
@@ -606,10 +615,7 @@ export async function runInit(opts: InitOptions = {}): Promise<InitResult> {
       sp4.stop('download failed');
     } else {
       const { skills, agents } = await countPluginContents(vaultDir);
-      sp4.stop(
-        pc.dim('already installed'),
-        [`${skills} skills · ${agents} agents`],
-      );
+      sp4.stop(pc.dim('already installed'), [`${skills} skills · ${agents} agents`]);
     }
   } else if (isTTY) {
     // Download path — vault-sync rendered its own UI; output our completion line
@@ -672,10 +678,9 @@ export async function runInit(opts: InitOptions = {}): Promise<InitResult> {
 
   if (sp5) {
     await randDelay();
-    sp5.stop(
-      pc.dim(pluginRegistrationSkipped ? 'skipped' : 'registered'),
-      [`source: ${pluginRegistrationSkipped ? 'marketplace' : 'local'}`],
-    );
+    sp5.stop(pc.dim(pluginRegistrationSkipped ? 'skipped' : 'registered'), [
+      `source: ${pluginRegistrationSkipped ? 'marketplace' : 'local'}`,
+    ]);
   } else {
     writeLine(`plugin: ${pluginRegistrationSkipped ? 'skipped (marketplace)' : 'registered'}`);
   }

--- a/src/commands/internal/cli-banner.ts
+++ b/src/commands/internal/cli-banner.ts
@@ -69,7 +69,7 @@ function hsvToRgb(h: number, floor = 80): [number, number, number] {
 }
 
 const HUE_PER_CHAR = 10; // hue degrees per character (horizontal)
-const HUE_PER_ROW = 30;  // hue degrees per row (vertical) — creates diagonal gradient
+const HUE_PER_ROW = 30; // hue degrees per row (vertical) — creates diagonal gradient
 
 function neonLine(line: string, lineIndex = 0, floor = 80): string {
   return line
@@ -146,11 +146,11 @@ export async function printBanner(): Promise<void> {
       up(BANNER_LINE_COUNT);
       printFrame(
         ART_LINES.map((l, i) => {
-          if (i < scan - 2) return neonLine(l, i);          // settled rainbow
-          if (i === scan - 2) return neonLine(l, i, 120);   // 2nd trailing glow
-          if (i === scan - 1) return neonLine(l, i, 200);   // 1st trailing glow — very bright
-          if (i === scan) return scanLine(l);                // warm cyan electron beam
-          return dimLine(l);                                 // not yet lit
+          if (i < scan - 2) return neonLine(l, i); // settled rainbow
+          if (i === scan - 2) return neonLine(l, i, 120); // 2nd trailing glow
+          if (i === scan - 1) return neonLine(l, i, 200); // 1st trailing glow — very bright
+          if (i === scan) return scanLine(l); // warm cyan electron beam
+          return dimLine(l); // not yet lit
         }),
         `    ${' '.repeat(TAGLINE.length)}`,
       );
@@ -159,7 +159,10 @@ export async function printBanner(): Promise<void> {
     // All rainbow, tagline still blank
     await delay(60);
     up(BANNER_LINE_COUNT);
-    printFrame(ART_LINES.map((l, i) => neonLine(l, i)), `    ${' '.repeat(TAGLINE.length)}`);
+    printFrame(
+      ART_LINES.map((l, i) => neonLine(l, i)),
+      `    ${' '.repeat(TAGLINE.length)}`,
+    );
 
     // Diagonal shimmer — stripe aligned with rainbow iso-hue lines (col - 3*row = d)
     // Sweeps perpendicular to the color gradient, forward then reverse
@@ -171,14 +174,17 @@ export async function printBanner(): Promise<void> {
     }
     function diagFrame(highlight: number): string[] {
       return ART_LINES.map((line, row) =>
-        line.split('').map((ch, col) => {
-          if (ch === ' ') return ch;
-          const d = col - 3 * row;
-          if (Math.abs(d - highlight) <= 1) return `\x1b[1;97m${ch}\x1b[0m`;
-          const hue = (((col * HUE_PER_CHAR - row * HUE_PER_ROW) % 360) + 360) % 360;
-          const [r, g, b] = hsvToRgb(hue);
-          return `\x1b[1;38;2;${r};${g};${b}m${ch}\x1b[0m`;
-        }).join('')
+        line
+          .split('')
+          .map((ch, col) => {
+            if (ch === ' ') return ch;
+            const d = col - 3 * row;
+            if (Math.abs(d - highlight) <= 1) return `\x1b[1;97m${ch}\x1b[0m`;
+            const hue = (((col * HUE_PER_CHAR - row * HUE_PER_ROW) % 360) + 360) % 360;
+            const [r, g, b] = hsvToRgb(hue);
+            return `\x1b[1;38;2;${r};${g};${b}m${ch}\x1b[0m`;
+          })
+          .join(''),
       );
     }
     for (let d = minD; d <= maxD; d++) {
@@ -193,11 +199,14 @@ export async function printBanner(): Promise<void> {
     }
     // Clean rainbow after sweep
     up(BANNER_LINE_COUNT);
-    printFrame(ART_LINES.map((l, i) => neonLine(l, i)), `    ${' '.repeat(TAGLINE.length)}`);
+    printFrame(
+      ART_LINES.map((l, i) => neonLine(l, i)),
+      `    ${' '.repeat(TAGLINE.length)}`,
+    );
     await delay(200);
 
     // Typewriter tagline — cyan cursor follows text
-    const cursor = `\x1b[1;38;2;140;255;255m▌\x1b[0m`;
+    const cursor = '\x1b[1;38;2;140;255;255m▌\x1b[0m';
     for (let len = 1; len <= TAGLINE.length; len++) {
       await delay(32);
       up(BANNER_LINE_COUNT);
@@ -214,15 +223,24 @@ export async function printBanner(): Promise<void> {
     for (let b = 0; b < 2; b++) {
       await delay(600);
       up(BANNER_LINE_COUNT);
-      printFrame(ART_LINES.map((l, i) => neonLine(l, i)), tagWhite);
+      printFrame(
+        ART_LINES.map((l, i) => neonLine(l, i)),
+        tagWhite,
+      );
       await delay(600);
       up(BANNER_LINE_COUNT);
-      printFrame(ART_LINES.map((l, i) => neonLine(l, i)), tagWithCursor);
+      printFrame(
+        ART_LINES.map((l, i) => neonLine(l, i)),
+        tagWithCursor,
+      );
     }
     // Cursor disappears + settle magenta in one step
     await delay(600);
     up(BANNER_LINE_COUNT);
-    printFrame(ART_LINES.map((l, i) => neonLine(l, i)), `    ${pc.bold(pc.magenta(TAGLINE))}\x1b[K`);
+    printFrame(
+      ART_LINES.map((l, i) => neonLine(l, i)),
+      `    ${pc.bold(pc.magenta(TAGLINE))}\x1b[K`,
+    );
   } finally {
     outb('\x1b[?25h');
   }

--- a/src/commands/internal/cli-ui.ts
+++ b/src/commands/internal/cli-ui.ts
@@ -11,8 +11,8 @@ import pc from 'picocolors';
 
 // ── Constants ──────────────────────────────────────────────────────────────────
 
-export const bar = pc.cyan('│');
-export const dot = pc.green('●');
+const bar = pc.cyan('│');
+const dot = pc.green('●');
 
 // Force UTF-8 bytes. Bun's TTY write path encodes strings with system locale;
 // writing Buffer bypasses that and always produces correct UTF-8 output.

--- a/src/commands/internal/vault-sync.ts
+++ b/src/commands/internal/vault-sync.ts
@@ -33,7 +33,7 @@ import { dirname, join, relative } from 'node:path';
 import { intro, outro, spinner } from '@clack/prompts';
 import pc from 'picocolors';
 import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
-import { barBlank, barLine, makeStepFn } from './cli-ui.js';
+import { makeStepFn } from './cli-ui.js';
 import { detectHarness } from './harness.js';
 
 // ---------------------------------------------------------------------------

--- a/src/commands/update.integration.test.ts
+++ b/src/commands/update.integration.test.ts
@@ -103,7 +103,6 @@ describe('update integration: --check dry-run mode', () => {
     const sideEffects: string[] = [];
 
     const opts: UpdateOptions = {
-
       isTTY: false,
       check: true,
       fetchFn: makeMockFetch('v1.99.0'),
@@ -133,7 +132,6 @@ describe('update integration: --check dry-run mode', () => {
 
   it('result carries both current and latest version in dry-run mode', async () => {
     const result = await runUpdate({
-
       isTTY: false,
       check: true,
       fetchFn: makeMockFetch('v1.99.0'),
@@ -156,7 +154,6 @@ describe('update integration: --check dry-run mode', () => {
 describe('update integration: network unavailable (fetch throws)', () => {
   it('exits with clear error message when fetch throws, does not crash', async () => {
     const opts: UpdateOptions = {
-
       isTTY: false,
       fetchFn: throwingFetch,
       installBinaryFn: noopInstallBinary,
@@ -184,7 +181,6 @@ describe('update integration: full end-to-end success', () => {
     const sideEffects: string[] = [];
 
     const opts: UpdateOptions = {
-
       isTTY: false,
       fetchFn: makeMockFetch('v2.0.0'),
       installBinaryFn: async (version) => {
@@ -227,7 +223,6 @@ describe('update integration: atomic gate (validateBinary returns false)', () =>
     const sideEffects: string[] = [];
 
     const opts: UpdateOptions = {
-
       isTTY: false,
       fetchFn: makeMockFetch('v2.0.0'),
       installBinaryFn: async (version) => {

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -87,13 +87,6 @@ function formatReleaseDate(date: Date): string {
   return date.toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' });
 }
 
-function daysBehind(date: Date): string {
-  const days = Math.floor((Date.now() - date.getTime()) / (1000 * 60 * 60 * 24));
-  if (days <= 0) return 'just released';
-  if (days === 1) return '1 day behind';
-  return `${days} days behind`;
-}
-
 // ---------------------------------------------------------------------------
 // Step 4: Install binary
 // ---------------------------------------------------------------------------
@@ -239,7 +232,9 @@ export async function runUpdate(opts: UpdateOptions = {}): Promise<UpdateResult>
   if (check) {
     if (isTTY) {
       if (currentVersion !== latestVersion) {
-        barLine(`⬆️   ${pc.dim(currentVersion)}  →  ${pc.green(latestVersion)}  · binary would upgrade`);
+        barLine(
+          `⬆️   ${pc.dim(currentVersion)}  →  ${pc.green(latestVersion)}  · binary would upgrade`,
+        );
         barBlank();
       }
       close('Dry run complete — no changes made');

--- a/src/lib/validator.ts
+++ b/src/lib/validator.ts
@@ -44,8 +44,10 @@ export async function checkVaultYml(vaultRoot: string): Promise<DoctorResult> {
 
   const details: string[] = [];
   if (parsed) {
-    if (typeof parsed['update_channel'] === 'string') details.push(`update_channel: ${parsed['update_channel']}`);
-    if (typeof parsed['qmd_collection'] === 'string') details.push(`qmd: ${parsed['qmd_collection']}`);
+    if (typeof parsed['update_channel'] === 'string')
+      details.push(`update_channel: ${parsed['update_channel']}`);
+    if (typeof parsed['qmd_collection'] === 'string')
+      details.push(`qmd: ${parsed['qmd_collection']}`);
   }
   return {
     check: 'vault.yml',
@@ -386,12 +388,16 @@ export async function checkPluginFiles(vaultRoot: string): Promise<DoctorResult>
     for await (const _ of new Bun.Glob('*/SKILL.md').scan({ cwd: join(pluginBase, 'skills') })) {
       skillCount++;
     }
-  } catch { /* ok */ }
+  } catch {
+    /* ok */
+  }
   try {
     for await (const _ of new Bun.Glob('*.md').scan({ cwd: join(pluginBase, 'agents') })) {
       agentCount++;
     }
-  } catch { /* ok */ }
+  } catch {
+    /* ok */
+  }
 
   return {
     check: 'plugin-files',

--- a/src/scripts/postinstall.test.ts
+++ b/src/scripts/postinstall.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'bun:test';
+import { getBinaryName } from './postinstall.js';
+
+describe('getBinaryName', () => {
+  it('darwin arm64', () => expect(getBinaryName('darwin', 'arm64')).toBe('onebrain-darwin-arm64'));
+  it('darwin x64', () => expect(getBinaryName('darwin', 'x64')).toBe('onebrain-darwin-x64'));
+  it('linux arm64', () => expect(getBinaryName('linux', 'arm64')).toBe('onebrain-linux-arm64'));
+  it('linux x64', () => expect(getBinaryName('linux', 'x64')).toBe('onebrain-linux-x64'));
+  it('linux arm64 musl', () =>
+    expect(getBinaryName('linux', 'arm64', true)).toBe('onebrain-linux-arm64-musl'));
+  it('linux x64 musl', () =>
+    expect(getBinaryName('linux', 'x64', true)).toBe('onebrain-linux-x64-musl'));
+  it('windows x64', () => expect(getBinaryName('win32', 'x64')).toBe('onebrain-windows-x64.exe'));
+  it('windows arm64', () =>
+    expect(getBinaryName('win32', 'arm64')).toBe('onebrain-windows-arm64.exe'));
+
+  it('unsupported platform → null', () => expect(getBinaryName('freebsd', 'x64')).toBeNull());
+  it('unsupported arch → null', () => expect(getBinaryName('linux', 'ia32')).toBeNull());
+  it('empty → null', () => expect(getBinaryName('', '')).toBeNull());
+});

--- a/src/scripts/postinstall.ts
+++ b/src/scripts/postinstall.ts
@@ -1,0 +1,142 @@
+// Runs under Node.js during `npm install -g` or `bun install -g`.
+// No Bun APIs — must work on systems without Bun installed.
+
+import { chmod, createWriteStream, existsSync, rename, unlink } from 'node:fs';
+import { get as httpsGet } from 'node:https';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// ── Platform map ─────────────────────────────────────────────────────────────
+
+const PLATFORM_MAP: Record<string, string> = {
+  'darwin-arm64': 'onebrain-darwin-arm64',
+  'darwin-x64': 'onebrain-darwin-x64',
+  'linux-arm64': 'onebrain-linux-arm64',
+  'linux-x64': 'onebrain-linux-x64',
+  'linux-arm64-musl': 'onebrain-linux-arm64-musl',
+  'linux-x64-musl': 'onebrain-linux-x64-musl',
+  'win32-arm64': 'onebrain-windows-arm64.exe',
+  'win32-x64': 'onebrain-windows-x64.exe',
+};
+
+export function getBinaryName(platform: string, arch: string, musl = false): string | null {
+  const key = musl ? `${platform}-${arch}-musl` : `${platform}-${arch}`;
+  return PLATFORM_MAP[key] ?? null;
+}
+
+function detectMusl(): boolean {
+  if (process.platform !== 'linux') return false;
+  return (
+    existsSync('/lib/libc.musl-x86_64.so.1') ||
+    existsSync('/lib/libc.musl-aarch64.so.1') ||
+    existsSync('/lib/ld-musl-x86_64.so.1') ||
+    existsSync('/lib/ld-musl-aarch64.so.1')
+  );
+}
+
+// ── Download ─────────────────────────────────────────────────────────────────
+
+function download(url: string, destPath: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const tmp = `${destPath}.tmp`;
+
+    function fetch(currentUrl: string, redirectsLeft: number): void {
+      if (redirectsLeft === 0) {
+        reject(new Error('too many redirects'));
+        return;
+      }
+
+      httpsGet(currentUrl, { headers: { 'User-Agent': 'onebrain-postinstall' } }, (res) => {
+        if (
+          res.statusCode &&
+          res.statusCode >= 300 &&
+          res.statusCode < 400 &&
+          res.headers.location
+        ) {
+          res.resume();
+          fetch(res.headers.location, redirectsLeft - 1);
+          return;
+        }
+        if (res.statusCode !== 200) {
+          res.resume();
+          reject(new Error(`HTTP ${res.statusCode}`));
+          return;
+        }
+        const out = createWriteStream(tmp);
+        res.pipe(out);
+        out.on('finish', () => {
+          rename(tmp, destPath, (err) => {
+            if (err) reject(err);
+            else resolve();
+          });
+        });
+        out.on('error', (err) => {
+          unlink(tmp, () => {});
+          reject(err);
+        });
+        res.on('error', (err) => {
+          unlink(tmp, () => {});
+          reject(err);
+        });
+      }).on('error', reject);
+    }
+
+    fetch(url, 5);
+  });
+}
+
+function chmodExec(filePath: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    chmod(filePath, 0o755, (err) => {
+      if (err) reject(err);
+      else resolve();
+    });
+  });
+}
+
+// ── Main ─────────────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  const platform = process.platform;
+  const arch = process.arch;
+  const musl = detectMusl();
+
+  const binaryName = getBinaryName(platform, arch, musl);
+  if (!binaryName) {
+    process.stderr.write(
+      `[onebrain] Unsupported platform: ${platform}/${arch}${musl ? '-musl' : ''}.\nInstall Bun (https://bun.sh) to use the JS bundle fallback.\n`,
+    );
+    return;
+  }
+
+  const __dirname = dirname(fileURLToPath(import.meta.url));
+  const pkgPath = join(__dirname, '..', 'package.json');
+
+  let version: string;
+  try {
+    const { readFileSync } = await import('node:fs');
+    const pkg = JSON.parse(readFileSync(pkgPath, 'utf8')) as { version: string };
+    version = pkg.version;
+  } catch {
+    process.stderr.write('[onebrain] Could not read package version — skipping binary download.\n');
+    return;
+  }
+
+  const destPath = join(__dirname, 'onebrain');
+  const url = `https://github.com/kengio/onebrain/releases/download/v${version}/${binaryName}`;
+
+  process.stdout.write(`[onebrain] Downloading ${binaryName} v${version}…\n`);
+
+  try {
+    await download(url, destPath);
+    if (platform !== 'win32') await chmodExec(destPath);
+    process.stdout.write('[onebrain] Ready.\n');
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    process.stderr.write(
+      `[onebrain] Download failed: ${msg}\nInstall Bun (https://bun.sh) to use the JS bundle fallback.\n`,
+    );
+  }
+}
+
+main();


### PR DESCRIPTION
## Problem

Users needed Bun installed to run `onebrain` even after `npm install -g @onebrain-ai/cli`, because the npm package shipped a JS bundle that requires Bun as runtime.

## Solution

A `postinstall` script (runs under Node.js) automatically downloads the correct platform-specific compiled binary from GitHub Releases during `npm install -g` or `bun install -g`. After install, `onebrain` runs as a native binary — no Bun required.

```
npm install -g @onebrain-ai/cli
# → postinstall detects platform (e.g. darwin/arm64)
# → downloads onebrain-darwin-arm64 from GitHub Releases
# → replaces dist/onebrain JS bundle with native binary
# → chmod 755
onebrain --version  # works without Bun in PATH
```

If download fails (no internet, unsupported platform), falls back gracefully to the JS bundle (exit 0 — `npm install` still succeeds).

## Changes

**New:**
- `src/scripts/postinstall.ts` — Node.js-only download script (no Bun APIs)
- `src/scripts/postinstall.test.ts` — 11 unit tests for platform mapping

**Release workflow:**
- Add 3 new build targets: `bun-windows-arm64`, `bun-linux-x64-musl`, `bun-linux-arm64-musl` — 8 platforms total
- Reorder jobs: `create-release` before `npm-publish` (ensures binaries exist on GitHub Releases before postinstall fires)
- `npm-publish` builds `dist/postinstall.js` (`--target node`) + `dist/onebrain` fallback bundle (`--target bun`)

**Platform support:**

| Platform | Target |
|---|---|
| macOS arm64 | `bun-darwin-arm64` |
| macOS x64 | `bun-darwin-x64` |
| Linux arm64 (glibc) | `bun-linux-arm64` |
| Linux x64 (glibc) | `bun-linux-x64` |
| Linux arm64 (musl/Alpine) | `bun-linux-arm64-musl` |
| Linux x64 (musl/Alpine) | `bun-linux-x64-musl` |
| Windows x64 | `bun-windows-x64` |
| Windows arm64 | `bun-windows-arm64` |

**Also fixed:**
- `fix(release)`: `--target bun` in npm-publish (fixes UTF-8 garbling in fallback bundle)
- `fix(biome)`: format/lint cleanup across validator.ts, doctor.ts, cli-banner.ts, init.test.ts
- `docs(readme)`: installation steps updated — Bun install step removed

## Test Plan

- [x] CI passes (typecheck + biome + 232 tests)
- [ ] After merge + tag `v2.1.3`, run `npm install -g @onebrain-ai/cli` on a machine without Bun
- [ ] `onebrain --version` works immediately after install
- [ ] `onebrain doctor` shows correct emoji/UTF-8 output