### PR TITLE
fix(release): drop bun-windows-arm64 — unsupported in bun v1.2 (v2.1.4)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,9 +64,6 @@ jobs:
           - target: bun-windows-x64
             output: onebrain-windows-x64
             ext: ".exe"
-          - target: bun-windows-arm64
-            output: onebrain-windows-arm64
-            ext: ".exe"
 
     steps:
       - uses: actions/checkout@v4
@@ -181,7 +178,7 @@ jobs:
             ASSETS+=("onebrain-${target}")
             ASSETS+=("onebrain-${target}.sha256")
           done
-          for target in windows-x64 windows-arm64; do
+          for target in windows-x64; do
             ASSETS+=("onebrain-${target}.exe")
             ASSETS+=("onebrain-${target}.sha256")
           done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-latest_version: 2.1.3
+latest_version: 2.1.4
 released: 2026-04-29
 ---
 
@@ -12,6 +12,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 > For plugin changes (skills, agents, hooks, INSTRUCTIONS), see [PLUGIN-CHANGELOG.md](PLUGIN-CHANGELOG.md).
 
 ## [Unreleased]
+
+## v2.1.4 — fix: drop bun-windows-arm64 (unsupported in bun v1.2)
+
+- fix(release): remove `bun-windows-arm64` build target — unsupported in bun v1.2.x (regression from v2.1.3)
+- fix(postinstall): remove `win32-arm64` from PLATFORM_MAP — falls back to JS bundle on Windows ARM64
 
 ## v2.1.3 — feat: postinstall binary download + full platform support
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onebrain-ai/cli",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "CLI for OneBrain — personal AI OS for Obsidian with persistent memory, 24+ skills, and Claude Code integration",
   "keywords": [
     "onebrain",

--- a/src/scripts/postinstall.test.ts
+++ b/src/scripts/postinstall.test.ts
@@ -11,8 +11,8 @@ describe('getBinaryName', () => {
   it('linux x64 musl', () =>
     expect(getBinaryName('linux', 'x64', true)).toBe('onebrain-linux-x64-musl'));
   it('windows x64', () => expect(getBinaryName('win32', 'x64')).toBe('onebrain-windows-x64.exe'));
-  it('windows arm64', () =>
-    expect(getBinaryName('win32', 'arm64')).toBe('onebrain-windows-arm64.exe'));
+  it('windows arm64 → null (unsupported by bun v1.2)', () =>
+    expect(getBinaryName('win32', 'arm64')).toBeNull());
 
   it('unsupported platform → null', () => expect(getBinaryName('freebsd', 'x64')).toBeNull());
   it('unsupported arch → null', () => expect(getBinaryName('linux', 'ia32')).toBeNull());

--- a/src/scripts/postinstall.ts
+++ b/src/scripts/postinstall.ts
@@ -15,7 +15,6 @@ const PLATFORM_MAP: Record<string, string> = {
   'linux-x64': 'onebrain-linux-x64',
   'linux-arm64-musl': 'onebrain-linux-arm64-musl',
   'linux-x64-musl': 'onebrain-linux-x64-musl',
-  'win32-arm64': 'onebrain-windows-arm64.exe',
   'win32-x64': 'onebrain-windows-x64.exe',
 };
 


### PR DESCRIPTION
## Summary

- `bun-windows-arm64` was re-added in v2.1.3 but bun v1.2.x does not support this compile target (`error: Unsupported compile target: bun-windows-aarch64-v1.2.23`) — regression from v2.0.1 which originally dropped it for the same reason
- Removes target from build matrix and `win32-arm64` from postinstall PLATFORM_MAP (falls back to JS bundle on Windows ARM64)
- Bumps version to 2.1.4

## Test plan

- [x] `bun test src/scripts/postinstall.test.ts` — 11/11 pass
- [x] CI passes
- [ ] Release CI builds 7 binaries successfully (no windows-arm64)