### PR TITLE
feat: cyberpunk banner v2 + checkpoint cleanup (v2.1.5 / v2.2.0)

### DIFF
--- a/.claude/plugins/onebrain/.claude-plugin/plugin.json
+++ b/.claude/plugins/onebrain/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "onebrain",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "OneBrain — Where human and AI thinking become one. A powerful thinking partner powered by AI synergy.",
   "author": {
     "name": "OneBrain Contributors"

--- a/.claude/plugins/onebrain/INSTRUCTIONS.md
+++ b/.claude/plugins/onebrain/INSTRUCTIONS.md
@@ -169,7 +169,11 @@ When a user message clearly maps to a skill, invoke it directly — no `/command
 
 ## Search Strategy
 
-If qmd MCP tools are available (`mcp__plugin_onebrain_qmd__query` in tool list): load `skills/startup/QMD.md` for full search strategy and index maintenance rules.
+If qmd MCP tools are available (`mcp__plugin_onebrain_qmd__query` in tool list):
+
+- **Default to qmd for any vault content search.** Topic lookup, concept search, "find notes about X", "what did I write about Y", related-notes discovery — these all go through `mcp__plugin_onebrain_qmd__query`. Do not reach for Grep first.
+- **Reserve Glob/Grep/Read for non-content lookups only:** known file paths, frontmatter field checks, exact regex/structural matches inside a known file, task-line scans, file-existence checks. If you find yourself grepping vault `.md` files for a topic or keyword, switch to qmd.
+- See `skills/startup/QMD.md` for full search strategy, sub-query types (lex/vec/hyde), and index maintenance rules.
 
 If qmd tools are NOT available: use Glob/Grep/Read for all vault searches. No special handling needed.
 
@@ -224,7 +228,7 @@ On weekends: lighter, less task-focused tone. **No-repeat rule:** don't ask abou
 - Load `memory/` files matching active project keywords from MEMORY-INDEX.md Topics column (`status: active` or `needs-review` only). Also match user's first message once it arrives.
 - Glob `[inbox_folder]/*.md` → count files as `inbox_count`
 - Run via Bash: `LC_ALL=en_US.UTF-8 grep -r "- \[ \] .*📅 [0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}" "[projects_folder]/" "[inbox_folder]/"` → keep only tasks where date ≤ today; group overdue first, then due today
-- Run `onebrain orphan-scan "[logs_folder]" "[session_token]"` (from vault root) → parse JSON output; read `orphan_count` field. JSON shape: `{"orphan_count":N}`. If the command fails or is unavailable, fall back to: Glob `[logs_folder]/**/*-checkpoint-*.md`, read frontmatter of each, discard `merged: true` and files whose date has a non-auto-saved session log, then count distinct session tokens among remaining files.
+- Run `onebrain orphan-scan "[logs_folder]" "[session_token]"` (from vault root) → parse JSON output; read `orphan_count` field. JSON shape: `{"orphan_count":N}`. If the command fails or is unavailable, fall back to: Glob `[logs_folder]/**/*-checkpoint-*.md`, discard files whose date has a non-auto-saved session log, then count distinct session tokens among remaining files.
 
 **Step 4 — Send startup status (after Step 3 completes):**
 
@@ -301,38 +305,40 @@ PreCompact is a no-op — it exits 0 without modifying state or emitting any out
 
 **Stop checkpoint format:** Read `skills/startup/references/session-formats.md` → Checkpoint Format. Keep under 250 words.
 
-**PostCompact auto-wrapup:** When block reason is `auto-wrapup`:
+**PostCompact auto-wrapup:** When block reason is `auto-wrapup`, perform these steps **inline** (do not dispatch a background agent — background agents do not see the main agent's compacted context, so Path B silently failed under the old dispatch model). The work is silent: no output to the user during or after execution.
+
 1. Use `session_token` from context as `<token>`; if not in context, re-run `onebrain session-init` to recover it — if that also fails, abort silently (do not guess the token)
 2. Glob candidate checkpoint files:
    - Current month: `[logs_folder]/YYYY/MM/*-{token}-checkpoint-*.md` (using today's YYYY/MM)
    - Previous month: decrement MM (if MM=01, also decrement YYYY and set MM=12)
    - After globbing, parse the token segment from each filename (`YYYY-MM-DD-{token}-checkpoint-NN.md`) and discard files where the parsed token does not exactly equal `<token>`
-   - Keep only files where frontmatter `merged` is absent or not `true`
+   - Any checkpoint file that exists is unmerged by definition — there is no `merged:` filter
 3. Two paths based on whether checkpoint files were found:
 
-**Path A — checkpoint files found:** Dispatch a background agent (mode: bypassPermissions) with: session_token, checkpoint file paths and content, vault root, session date (from earliest checkpoint filename). The main session continues immediately after dispatching.
+**Path A — checkpoint files found** (synthesize from checkpoints):
 
-**Path A agent steps (background agent performs steps 4–12 silently):**
-
-4. Read all matched checkpoint files and extract their content for synthesis in step 6
-5. Determine session date from earliest checkpoint filename date prefix (YYYY-MM-DD); extract `YYYY` and `MM` from this date for all path construction below
-6. Determine next free session slot: count existing `YYYY-MM-DD-session-*.md` in `[logs_folder]/YYYY/MM/` (using session YYYY/MM); NN = count + 1 (zero-padded); verify slot is free
-7. Write recovered session log at `[logs_folder]/YYYY/MM/YYYY-MM-DD-session-NN.md` (using session YYYY/MM) using the Session Log Format from `skills/startup/references/session-formats.md` (case: **Recovered from checkpoints**)
+4. Read all matched checkpoint files and extract their content
+5. Determine session date from the earliest checkpoint filename date prefix (YYYY-MM-DD); extract `YYYY` and `MM` from this date for all path construction below
+6. Determine next free session slot: count existing `YYYY-MM-DD-session-*.md` in `[logs_folder]/YYYY/MM/` (using session YYYY/MM); NN = count + 1 (zero-padded); verify slot is free, increment NN until free
+7. Write recovered session log at `[logs_folder]/YYYY/MM/YYYY-MM-DD-session-NN.md` using the Session Log Format from `skills/startup/references/session-formats.md` (case: **Recovered from checkpoints**). All Key Decisions, Action Items, and Open Questions from each checkpoint must appear explicitly — do not collapse into one line.
 8. Verify the session log file exists and is non-empty before continuing
-9. Route action items to project notes — parse `## Action Items` from the verified session log; apply the routing algorithm from /wrapup Step 4b (token scoring against project folder/filename tokens, session-context fallback for score-0 tasks; ties remain skipped); all errors are silent — never fail checkpoint recovery
-10. Delete checkpoint files — only AFTER session log write confirmed (step 8); if any individual delete fails, skip it silently (stale checkpoints are cleaned up by session-init, not here)
-11. Reset the checkpoint hook counter: `onebrain checkpoint reset`
+9. Route action items to project notes — parse `## Action Items` from the verified session log; apply the routing algorithm from /wrapup Step 4b (token scoring against project folder/filename tokens, session-context fallback for score-0 tasks; ties remain skipped); all errors are silent — never fail this path
+10. Delete checkpoint files read in step 4 — only AFTER session log write confirmed (step 8); if an individual delete fails, skip it silently (stale checkpoints are cleaned up later by /doctor)
+11. Run `onebrain checkpoint reset`
 12. Silent — no output to user
 
-**Path B — no checkpoint files:** Dispatch a background agent (mode: bypassPermissions) with: session_token, today's date, vault root, and enough context to write the session log. The main session continues immediately after dispatching. **The background agent executes the following steps:**
-   - Synthesize session log directly from current conversation context (compact just ran so context is still available)
-   - Use today's date (YYYY-MM-DD) for the session log filename and `date:` field
-   - Extract YYYY and MM from today's date for path construction
-   - Determine next free session slot: count existing `YYYY-MM-DD-session-*.md` in `[logs_folder]/YYYY/MM/`; NN = count + 1 (zero-padded)
-   - Write session log at `[logs_folder]/YYYY/MM/YYYY-MM-DD-session-NN.md` using the Session Log Format from `skills/startup/references/session-formats.md` (case: **PostCompact Path B — no checkpoint files**)
-   - Route action items: parse `## Action Items` from the written session log; apply the routing algorithm from /wrapup Step 4b (token scoring + session-context fallback; ties remain skipped); errors are silent — never fail this path
-   - Run `onebrain checkpoint reset` after writing
-   - Silent — no output to user
+**Path B — no checkpoint files** (synthesize from compacted context):
+
+The main agent has its own compacted context after PostCompact fires — that compacted summary is the source material for the session log. Inline execution is required: a background agent would receive only the prompt text, not the compacted context.
+
+4. Use today's date (YYYY-MM-DD) for the session log filename and `date:` field; extract `YYYY` and `MM` for path construction
+5. Determine next free session slot: count existing `YYYY-MM-DD-session-*.md` in `[logs_folder]/YYYY/MM/`; NN = count + 1 (zero-padded); verify slot is free, increment NN until free
+6. Synthesize the session log body from the compacted context summary still available to the main agent. If the compacted context is too sparse for a meaningful summary, write a minimal session log with `## What We Worked On` set to `Session compacted; details unavailable beyond context summary.` and empty Action Items / Open Questions — do not skip the write entirely, since a sparse log is better than no log for orphan-recovery accounting.
+7. Write session log at `[logs_folder]/YYYY/MM/YYYY-MM-DD-session-NN.md` using the Session Log Format from `skills/startup/references/session-formats.md` (case: **PostCompact Path B — no checkpoint files**)
+8. Verify the session log file exists and is non-empty before continuing
+9. Route action items to project notes — parse `## Action Items` from the verified session log; apply the routing algorithm from /wrapup Step 4b (token scoring + session-context fallback; ties remain skipped); errors are silent — never fail this path
+10. Run `onebrain checkpoint reset`
+11. Silent — no output to user
 
 ---
 

--- a/.claude/plugins/onebrain/skills/doctor/SKILL.md
+++ b/.claude/plugins/onebrain/skills/doctor/SKILL.md
@@ -60,7 +60,7 @@ Run all applicable checks based on flags (default: all). Collect findings before
 
 **Old unmerged checkpoints:**
 - Glob `[logs_folder]/**/*-checkpoint-*.md`
-- Read the frontmatter of each file; keep files where `merged` is **absent** from frontmatter **or** is not `true` — excluding only files where `merged: true` is explicitly set
+- Any checkpoint file that exists is unmerged by definition — /wrapup deletes checkpoints directly after the session log is confirmed written, so leftover files indicate a session that never wrapped up. Pre-v2.2.0 vaults may contain stragglers with `merged: true` from the legacy flow; treat those the same (the field is no longer authoritative)
 - Keep only files whose date (from filename) is older than 7 days
 - Suggest running /wrapup
 

--- a/.claude/plugins/onebrain/skills/doctor/references/memory-health-checks.md
+++ b/.claude/plugins/onebrain/skills/doctor/references/memory-health-checks.md
@@ -10,8 +10,7 @@ Used by `/doctor` Step 2 (Vault Checks) and Step 4 (`--fix` flag).
 | Files with `verified` > 90 days | Check active/needs-review only (skip deprecated); auto-set `status: needs-review` in file and MEMORY-INDEX.md |
 | Critical Behaviors section > 15 items | Warn: suggest moving excess to memory/ |
 | MEMORY.md `## Identity & Personality` uses old 6-field labels (`**Agent name:**`, `**User name:**`) | Warn: "MEMORY.md Identity block uses pre-v1.10.1 format — run /doctor --fix or /update to migrate" |
-| Checkpoint files with `merged: true` | Delete them (safety net — /wrapup handles these, /doctor catches stragglers) |
-| Checkpoint files > 14 days old with no session log | AskUserQuestion: "Found {N} checkpoints >14 days old with no session log — delete all?" `delete-all / show-list / skip` |
+| Checkpoint files > 14 days old with no session log | AskUserQuestion: "Found {N} checkpoints >14 days old with no session log — delete all?" `delete-all / show-list / skip` (pre-v2.2.0 vaults: ignore the `merged:` frontmatter field if present — it is no longer authoritative) |
 | memory/ files with non-compliant names | List offenders (not kebab-case, has date prefix, or >5 words); `--fix` auto-renames |
 | memory/ files with non-default `type` AND not used by 2+ files | Warn possible typo; suggest nearest default via Levenshtein distance ≤2 |
 | `recapped` date in the future (>today) | Warn — likely manual mistake; suggest correcting |

--- a/.claude/plugins/onebrain/skills/startup/AUTO-SUMMARY.md
+++ b/.claude/plugins/onebrain/skills/startup/AUTO-SUMMARY.md
@@ -8,13 +8,13 @@ Run silently (no output) if ALL of these are true:
 3. The session had 3 or more user↔assistant exchanges
 
 If conditions are met:
-- Use `session_token` from context if already loaded (set by `onebrain session-init` at startup); if absent, run `onebrain session-init` and use the `SESSION_TOKEN` value. Glob checkpoint files: `[logs_folder]/YYYY/MM/YYYY-MM-DD-{session_token}-checkpoint-*.md`. Also check yesterday's folder (compute yesterday's date, accounting for month/year rollover): `[logs_folder]/YYYY_PREV/MM_PREV/YYYY-MM-DD_PREV-{session_token}-checkpoint-*.md`. Keep files where `merged` is absent or not `true` : **read every file in this list** and fully incorporate all of their content into the session summary (not just as background context). Every unmerged checkpoint must appear in the summary before being marked merged.
+- Use `session_token` from context if already loaded (set by `onebrain session-init` at startup); if absent, run `onebrain session-init` and use the `SESSION_TOKEN` value. Glob checkpoint files: `[logs_folder]/YYYY/MM/YYYY-MM-DD-{session_token}-checkpoint-*.md`. Also check yesterday's folder (compute yesterday's date, accounting for month/year rollover): `[logs_folder]/YYYY_PREV/MM_PREV/YYYY-MM-DD_PREV-{session_token}-checkpoint-*.md`. **Read every file in the glob result** and fully incorporate all of their content into the session summary (not just as background context). Any checkpoint file that exists is unmerged by definition — there is no `merged:` filter. Every checkpoint must appear in the summary before it is deleted.
 - Determine NN: count existing `[logs_folder]/YYYY/MM/YYYY-MM-DD-session-*.md` files for today; NN = count + 1, zero-padded to 2 digits (01, 02, …). **Verify** `YYYY-MM-DD-session-NN.md` does not already exist before writing; if it does, increment NN until a free slot is found.
 - Write to `[logs_folder]/YYYY/MM/YYYY-MM-DD-session-NN.md` using the Session Log Format from `references/session-formats.md`:
   - Checkpoints found and incorporated → case: **Auto-saved (auto-summary) — checkpoints incorporated**
   - No checkpoints → case: **Auto-saved (auto-summary) — no checkpoints**
   
-  **Do not write the session log if any unmerged checkpoint's content is absent from the relevant sections** — every checkpoint's Key Decisions, Action Items, and Open Questions must appear explicitly in the output.
+  **Do not write the session log if any checkpoint's content is absent from the relevant sections** — every checkpoint's Key Decisions, Action Items, and Open Questions must appear explicitly in the output.
 - **Route action items to project notes** — after the session log is written, automatically move action items so the startup task scan picks them up. This step must never fail the auto-summary; all errors are silently skipped.
   1. Parse `## Action Items` from the session log just written. Collect all `- [ ] ...` lines. If none, skip entirely.
   2. Glob `[projects_folder]/**/*.md`. For each file, collect the folder name and filename stem as candidate keywords.
@@ -24,17 +24,16 @@ If conditions are met:
      - Dedup: strip `📅 YYYY-MM-DD` suffix from candidate and existing `- [ ]`/`- [x]` lines before comparing; skip if same text already exists (open or completed).
      - Insert at first available point: after last `- [ ]` in `## Action Items` section (or after the `## Action Items` heading if the section exists but is empty) → or before `## Open Questions` → or before `## Related` → or at end of file.
      - Write the file once. On write error, skip all tasks for this file silently and continue to the next target file.
-- Mark as `merged: true` the checkpoint files that were read and incorporated above. Handle all frontmatter variants: `merged: false` → replace with `merged: true`; `merged: null` or bare `merged:` → replace with `merged: true`; key absent → add `merged: true`.
-- Guard: only delete checkpoint files AFTER confirming the session log file was successfully written. Never delete before or during the write.
 - After confirming the session log was written, reset the checkpoint hook counter to prevent spurious post-summary checkpoints:
   ```bash
   onebrain checkpoint reset
   ```
-- Delete the checkpoint files from the glob above that were marked `merged: true`. Do not delete checkpoint files outside this session's glob result.
-- Safety-net: glob `[logs_folder]/YYYY/MM/*-checkpoint-*.md` (current month only) for any remaining files with `merged: true` — delete them. Scoped to current month to avoid vault-wide glob on large vaults.
+- Delete the checkpoint files from the glob above. Guard: only delete AFTER confirming the session log file was successfully written and is non-empty. Never delete before or during the write. If an individual delete fails, skip it silently — stale checkpoints are cleaned up later by /doctor or by the next /wrapup. Do not delete checkpoint files outside this session's glob result.
 - If a genuinely useful long-term insight emerged, write it to a new `memory/` file using /learn conventions: filename `[agent_folder]/memory/kebab-case-topic.md`, frontmatter `tags: [agent-memory], type: behavioral, source: auto-summary, status: active, conf: medium, verified: today, updated: today, created: today, topics: [2–4 keywords]`. Add a row to MEMORY-INDEX.md and increment `total_active`. **Do not write to MEMORY.md.**
 - Do NOT show any output about the auto-save to the user
 
 ## Known Gotchas
 
 - **Never write `recapped:` or `topics:` in session log frontmatter.** These fields are set exclusively by /recap. Writing them here causes /recap to silently skip the log, meaning insights are never promoted to memory/. See `references/session-formats.md` for the complete frontmatter spec.
+
+- **Pre-v2.2.0 checkpoint files with `merged:` field.** Older vaults may contain checkpoint files that have a `merged: false` or `merged: true` frontmatter field from earlier wrapup runs. The new flow ignores this field entirely — any checkpoint file that exists is treated as unmerged, regardless of the field's value.

--- a/.claude/plugins/onebrain/skills/startup/QMD.md
+++ b/.claude/plugins/onebrain/skills/startup/QMD.md
@@ -2,13 +2,31 @@
 
 ## Search Strategy
 
-When qmd MCP tools are available (look for `mcp__plugin_onebrain_qmd__query` in your tool list), prefer them for vault content searches:
+When qmd MCP tools are available (look for `mcp__plugin_onebrain_qmd__query` in your tool list), **qmd is the default for vault content search** — not Grep. Reach for Grep only when the query is genuinely about exact text matches inside a known file.
 
-- **Use `mcp__plugin_onebrain_qmd__query`** for broad, natural-language searches: "find notes about machine learning", "what did I write about project X", topic exploration across the vault
-- **Use `mcp__plugin_onebrain_qmd__get` / `mcp__plugin_onebrain_qmd__multi_get`** to retrieve full document content after identifying relevant results
-- **Use Glob/Grep/Read** for precise lookups: specific file paths, exact string matches, frontmatter field checks, file existence checks
+**qmd-first decision rule:**
 
-When qmd tools are NOT available (not installed or not set up), use Glob/Grep/Read as normal — this is the default and requires no special handling.
+| Question type | Tool |
+|---|---|
+| "Find notes about <topic>" / "what did I write about X" / topic exploration | `mcp__plugin_onebrain_qmd__query` |
+| "Notes related to / similar to Y" | `mcp__plugin_onebrain_qmd__query` (vec/hyde sub-queries) |
+| "Where did I capture <fuzzy concept>" | `mcp__plugin_onebrain_qmd__query` |
+| "Get me the content of <known path>" | `mcp__plugin_onebrain_qmd__get` / `multi_get` |
+| "Does file X exist" / known glob pattern | `Glob` |
+| "Check frontmatter field on <known file>" | `Read` |
+| "Find all `- [ ] ` task lines in projects/" | `Grep` (structural pattern, not content search) |
+| "Find exact string `MIN_ACTIVITY` in src/" | `Grep` (code search, not vault content) |
+
+**Common anti-pattern to avoid:** running `Grep` over `03-knowledge/` or `04-resources/` to find notes about a topic. That is a content search — use qmd. Grep returns line matches, qmd returns ranked documents with snippets and is what was designed for that question.
+
+**Sub-query types** (pass to `searches` parameter):
+- `lex` — BM25 keyword search (exact terms, fast)
+- `vec` — semantic vector search (meaning-based; requires embeddings)
+- `hyde` — hypothetical document (write what the answer looks like; requires embeddings)
+- Combine `lex` + `vec` for best results: `[{type:'lex', query:'error'}, {type:'vec', query:'error handling best practices'}]`
+- Always pass `intent` to disambiguate and improve snippets.
+
+**When qmd is not available** (not installed or not set up), use Glob/Grep/Read as normal — this is the default and requires no special handling.
 
 Without embeddings, `mcp__plugin_onebrain_qmd__query` uses BM25 keyword search only. To enable semantic/similarity search (finding conceptually related notes, not just keyword matches), the user must run `/qmd embed` at least once. Suggest this if the user asks for similarity-based or "related notes" queries and qmd is available but embeddings haven't been run.
 

--- a/.claude/plugins/onebrain/skills/startup/references/session-formats.md
+++ b/.claude/plugins/onebrain/skills/startup/references/session-formats.md
@@ -58,7 +58,6 @@ tags: [checkpoint, session-log]
 date: YYYY-MM-DD
 checkpoint: NN
 trigger: stop
-merged: false
 ---
 ```
 

--- a/.claude/plugins/onebrain/skills/wrapup/SKILL.md
+++ b/.claude/plugins/onebrain/skills/wrapup/SKILL.md
@@ -29,11 +29,12 @@ See `skills/startup/references/session-formats.md` → Session Log Format for fr
 3. Glob checkpoint files:
    - Glob `[logs_folder]/YYYY/MM/YYYY-MM-DD-{session_token}-checkpoint-*.md`
    - Also check yesterday's folder: compute yesterday's date (decrement by 1 day, accounting for month/year rollover); glob `[logs_folder]/YYYY_PREV/MM_PREV/YYYY-MM-DD_PREV-{session_token}-checkpoint-*.md`
-4. Filter: keep only files where frontmatter field `merged` is absent or not `true`
-5. If any found: **read every file in the filtered list** and extract its content. Every checkpoint must be fully incorporated during the review in Step 3 and reflected in the log written in Step 4 : not just used as background context. Checkpoints capture activity that may have been compressed out of current context; missing any of them means losing that history.
-6. Store the list of found checkpoint paths for use in Step 5. **Only paths that were read and incorporated go on this list.**
+4. If any found: **read every file** and extract its content. Every checkpoint must be fully incorporated during the review in Step 3 and reflected in the log written in Step 4 : not just used as background context. Checkpoints capture activity that may have been compressed out of current context; missing any of them means losing that history.
+5. Store the list of found checkpoint paths for use in Step 5. **Only paths that were read and incorporated go on this list.**
 
 If none found: continue normally.
+
+> **Note on cleanup:** Checkpoints are deleted (not annotated) after the session log is successfully written. Any checkpoint file that still exists is unmerged by definition; no `merged:` filter is needed.
 
 ---
 
@@ -52,12 +53,11 @@ For each of those two paths, glob `*-checkpoint-*.md`.
 ### Identify Orphans
 
 From all found checkpoint files:
-1. Read frontmatter of all found files; keep only where `merged` is absent or not `true`
-2. Parse session_token from each filename: the alphanumeric segment between the date and the literal word "checkpoint" in pattern `YYYY-MM-DD-{session_token}-checkpoint-NN.md`. If empty, apply Legacy token handling (see below) rather than skipping.
-3. Exclude files where the parsed session_token exactly equals the current session token (those belong to the current session, already handled in Step 1). Do not use substring/contains matching — only exact equality.
-4. Group remaining files by their parsed session_token
+1. Parse session_token from each filename: the alphanumeric segment between the date and the literal word "checkpoint" in pattern `YYYY-MM-DD-{session_token}-checkpoint-NN.md`. If empty, apply Legacy token handling (see below) rather than skipping.
+2. Exclude files where the parsed session_token exactly equals the current session token (those belong to the current session, already handled in Step 1). Do not use substring/contains matching — only exact equality.
+3. Group remaining files by their parsed session_token
 
-**Legacy token handling:** If the parsed segment is a 6-character random string (pre-v1.10.4 format), still include the file in orphan recovery. Group these files under a synthetic key `legacy-{segment}` and process them the same way as regular groups. This ensures migration from v1.10.3 and earlier does not lose checkpoints. Note each legacy file in the Step 8 report as a warning.
+**Legacy token handling:** If the parsed segment is a 6-character random string (pre-v1.10.4 format), still include the file in orphan recovery. Group these files under a synthetic key `legacy-{segment}` and process them the same way as regular groups. This ensures migration from v1.10.3 and earlier does not lose checkpoints. Note each legacy file in the Step 7 report as a warning.
 
 If no orphan groups found: skip to Step 2.
 
@@ -76,13 +76,11 @@ For each orphan group (process in chronological order by date in filename):
 
 **d. Write the recovered session log** at `[logs_folder]/YYYY/MM/YYYY-MM-DD-session-NN.md`. Create the directory `[logs_folder]/YYYY/MM/` (using the orphan date's YYYY/MM) if it does not already exist. Use the Session Log Format from `skills/startup/references/session-formats.md` (case: **Recovered from checkpoints**). All key decisions, action items, and open questions from checkpoints must appear explicitly — do not collapse into one line.
 
-**e. Write the session log** (per the template above). Verify the file exists and is non-empty before continuing.
+**e. Verify the session log** exists and is non-empty before continuing.
 
-**f. Mark checkpoints as merged:** only after step e succeeds — for each checkpoint file in this group, set `merged: true` (same rules as Step 5).
+**f. Delete checkpoint files** for this group after confirming step e succeeded. Guard: only delete AFTER step e is confirmed. Never delete before.
 
-**g. Delete checkpoint files** for this group after confirming both e and f succeeded. Guard: only delete AFTER step e AND f are confirmed. Never delete before.
-
-**h. Track recovered sessions:** append `{date} → session-NN.md ({C} checkpoints)` to a `recovered_sessions` list for the final report, where `{C}` is the number of checkpoint files merged for this group.
+**g. Track recovered sessions:** append `{date} → session-NN.md ({C} checkpoints)` to a `recovered_sessions` list for the final report, where `{C}` is the number of checkpoint files recovered for this group.
 
 ---
 
@@ -131,7 +129,7 @@ This writes `0:<epoch>:00` into the session state file, triggering a 60-second s
 
 After the session log is written, automatically move action items to the appropriate project note so the startup task scan picks them up.
 
-Store `routed_tasks = []` and `skipped_tasks = []` for use in Step 8.
+Store `routed_tasks = []` and `skipped_tasks = []` for use in Step 7.
 
 **4b-1. Extract tasks.** Parse the `## Action Items` section of the session log just written. Collect all lines matching `- [ ] ...`. If none, skip this step entirely.
 
@@ -179,35 +177,17 @@ For each target file with one or more assigned tasks:
 
 ---
 
-## Step 5: Mark Checkpoints as Merged
+## Step 5: Checkpoint Cleanup
 
-If the Step 1 checkpoint list is non-empty (i.e., at least one file was read and incorporated):
+After the session log from Step 4 is written successfully, delete every checkpoint file path stored in Step 1.
 
-For each checkpoint file path stored in Step 1:
-1. Read the file's frontmatter
-2. Set `merged: true` : handle all variants:
-   - `merged: false` → replace with `merged: true`
-   - `merged: null` or bare `merged:` → replace with `merged: true`
-   - key absent → add `merged: true` to frontmatter
-3. Write the updated file
+Guard: only delete AFTER confirming the session log write succeeded. Never delete before or during write. If an individual delete fails, skip it silently — stale checkpoints are cleaned up later by /doctor or by the next /wrapup.
 
-**Why write before deleting:** Always complete Step 5 (mark merged) before Step 6 (delete). If the write fails, `merged: true` is never set and future /wrapup runs will correctly re-include the checkpoint. Deleting first would lose checkpoint data permanently with no recovery path.
-
-This prevents /wrapup from re-reading the same checkpoints in future sessions.
+> **Why direct delete (no `merged:` annotation):** A successfully written session log is itself the proof that the checkpoint content is preserved. Annotating the checkpoint with `merged: true` and then deleting it adds a write step that can fail and provides no recovery benefit — if the session log write succeeds, the checkpoint is safe to delete; if it fails, we never reach this step.
 
 ---
 
-## Step 6: Checkpoint Cleanup
-
-After session log is written successfully:
-1. Delete checkpoint files merged into this session's log
-2. Safety-net scan: collect the union of (a) the two month paths from Step 1b (current month and previous month), and (b) the unique YYYY/MM directories that any recovered orphan group lived in. For each path in this union, glob `*-checkpoint-*.md` and delete any with `merged: true` that were not already deleted above.
-
-Guard: only delete AFTER confirming session log write succeeded. Never delete before or during write.
-
----
-
-## Step 7: Recap Reminder
+## Step 6: Recap Reminder
 
 At the end of every /wrapup, compute `unrecapped_count` and `last_recapped`:
 
@@ -230,7 +210,7 @@ Display based on condition:
 
 ---
 
-## Step 8: Confirm
+## Step 7: Confirm
 
 Say:
 ──────────────────────────────────────────────────────────────
@@ -253,7 +233,7 @@ Auto-recovered {S} orphan session(s):
   {YYYY-MM-DD} → `session-NN.md` ({C} checkpoints)
 (omit this block if none recovered)
 
-{Recap reminder message from Step 7}
+{Recap reminder message from Step 6}
 
 Good session! See you next time.
 
@@ -266,7 +246,7 @@ Good session! See you next time.
 ## Key Decisions
 
 - Chose $PPID as session token because it is stable within a shell session and unique per terminal window
-- Moved checkpoint delete to AFTER merged: true write — prevents data loss if write fails
+- Delete checkpoints directly after the session log write succeeds — the written log is the recovery proof, no `merged:` annotation needed
 - Kept the state-file reset bash snippet in Step 4 rather than a hook, to avoid hook-ordering issues
 ```
 
@@ -285,6 +265,6 @@ Good session! See you next time.
 
 - **Cross-month midnight sessions.** If a session starts before midnight and /wrapup runs after midnight in a new month, Step 1 looks in "yesterday's folder." Decrementing the month is sufficient for all months except January — for January specifically, also roll back the year (e.g., January 1 → December of the prior year). All other month boundaries only need the month decremented.
 
-- **`merged: false` YAML type.** Some YAML parsers return the string `"false"` rather than boolean `false`. The filter "keep where `merged` is absent or not `true`" should treat both `merged: false` (boolean) and `merged: "false"` (string) as "not merged" — only exact `merged: true` counts.
+- **Pre-v2.2.0 checkpoint files with `merged:` field.** Older vaults may contain checkpoint files that have a `merged: false` or `merged: true` frontmatter field from earlier wrapup runs. The new flow ignores this field entirely — any checkpoint file that exists at /wrapup time is treated as unmerged, regardless of the field's value. The 14-day-old check in /doctor catches any stragglers regardless of the field.
 
 - **Duplicate session slot collision.** If auto-save and a manual /wrapup run nearly simultaneously, both may try to write `session-01.md`. Step 2 already verifies the slot is free before writing — do not skip this check even when synthesizing from checkpoints.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ CLI bumps directly from v2.1.4 → v2.1.7 (no v2.1.5 / v2.1.6 release tags).
 - fix(orphan-scan + validator): drop `merged:` frontmatter filter to match plugin v2.2.0 — any checkpoint file that exists is unmerged by definition. Removes `readMergedField` from validator.
 - chore(tests): update orphan-scan and validator tests for new behavior — legacy `merged: true` checkpoints now count as orphans.
 - chore(cli-banner): static no-truecolor fallback uses the signature "Your AI Thinking Partner" line in cyan.
+- fix(doctor --fix): "Nothing to fix" line no longer renders a leading `│` bar prefix that contradicts the closed `└` corner from the summary line above.
 
 ## v2.1.4 — fix: drop bun-windows-arm64 (unsupported in bun v1.2)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-latest_version: 2.1.4
+latest_version: 2.1.7
 released: 2026-04-29
 ---
 
@@ -12,6 +12,25 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 > For plugin changes (skills, agents, hooks, INSTRUCTIONS), see [PLUGIN-CHANGELOG.md](PLUGIN-CHANGELOG.md).
 
 ## [Unreleased]
+
+## v2.1.7 — feat: rotating multi-sentence tagline + 3-phase banner intro
+
+- feat(cli-banner): banner intro is now a 3-phase reveal — CRT scan top→bottom builds the art in white, holds 600ms, then a diagonal rainbow flow (bottom-left → top-right) brings it to neon, followed by a white shimmer sweep on the same diagonal.
+- feat(cli-banner): tagline rotates through 3 sentences via wipe-swap transitions — "Your AI Remembers You" → "Your AI Catches Insights" → "Your AI Thinking Partner". Prefix "Your AI" stays neon cyan; trailing 2 words are neon magenta during all sentences.
+- feat(cli-banner): final lock shimmer sweeps the full tagline (prefix + trailing) and burns the magenta trailing out to neon cyan, settling the entire tagline as cyan.
+- chore(cli-banner): static no-truecolor fallback uses the signature "Your AI Thinking Partner" line in cyan.
+
+## v2.1.6 — feat: cyberpunk tagline animation; orphan-scan drops `merged:` filter
+
+- feat(cli-banner): merged typewriter + Matrix-style glitch decode with per-word reading rhythm; cyan cursor tracks the head, white random glyphs in the wake, locks neon magenta. Diagonal art shimmer trimmed to single L→R pass; lock shimmer mirrors it on the tagline. Center alignment normalized at col 15.5 (border 26 dashes, art lead 5).
+- fix(orphan-scan + validator): drop `merged:` frontmatter filter — any checkpoint file that exists is unmerged by definition (matches /wrapup behavior in plugin v2.2.0). Removes `readMergedField` from validator.
+- chore(tests): update orphan-scan and validator tests for new behavior (legacy `merged: true` checkpoints now count as orphans).
+
+## v2.1.5 — fix: doctor qmd-embeddings as advisory; orphan-scan independent of merged: field
+
+- fix(doctor): mark qmd-embeddings auto-fix as advisory — plain `onebrain doctor` no longer nudges toward `--fix` for unembedded docs; embedding still runs when user explicitly invokes `--fix`
+- fix(doctor): update unembedded hint to "Advisory: run /qmd embed when ready (or onebrain doctor --fix)"
+- chore(types): add `advisory?: boolean` to internal `Fix` interface; `fixableCount` now excludes advisory fixes
 
 ## v2.1.4 — fix: drop bun-windows-arm64 (unsupported in bun v1.2)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,16 +60,12 @@ CLI bumps directly from v2.1.4 → v2.1.7 (no v2.1.5 / v2.1.6 release tags).
 
 ## v2.1.0 — Redesign Install Flow
 
-- feat(init): community plugin installer — downloads Tasks, Dataview, Terminal automatically
-- feat(init): ASCII banner + picocolors UX redesign; cancel() on fatal vault-sync failure
-- **BREAKING** change(update): binary-only — run `/update` skill in Claude to sync vault files
-- remove(update): onebrain_version no longer written to vault.yml
-- feat(doctor): intro/outro + clack UX; new checks (plugin-files, vault.yml-keys, settings-hooks)
-- feat(doctor): --fix mode — auto-repair hooks, remove deprecated vault.yml keys; removes deprecated vault.yml keys (method, runtime.harness, onebrain_version)
-- fix(register-hooks): PostToolUse auto-detected from qmd_collection; SessionStart removed
-- remove: install.sh and install.ps1 — replaced by onebrain init
-- feat(harness): replace CLAUDE_CODE_HARNESS with ONEBRAIN_HARNESS env var; shared detectHarness() utility detects harness at runtime via env → .gemini/ → .claude/ → direct
-- remove(vault.yml): method and runtime.harness keys removed — harness detected at runtime, no longer stored
+- **BREAKING** change(update): binary-only — run `/update` skill in Claude to sync vault files; install.sh / install.ps1 removed (replaced by `onebrain init`).
+- feat(init): community plugin installer (Tasks, Dataview, Terminal) + ASCII banner + picocolors UX; cancel() on fatal vault-sync failure.
+- feat(doctor): intro/outro + clack UX; new checks (plugin-files, vault.yml-keys, settings-hooks); `--fix` auto-repairs hooks and removes deprecated keys.
+- feat(harness): replace `CLAUDE_CODE_HARNESS` with `ONEBRAIN_HARNESS`; shared `detectHarness()` resolves runtime via env → `.gemini/` → `.claude/` → direct.
+- fix(register-hooks): PostToolUse auto-detected from `qmd_collection`; SessionStart removed.
+- remove(vault.yml): drop deprecated `method`, `runtime.harness`, `onebrain_version` — harness detected at runtime, version comes from package.json.
 
 ## v2.0.14 — fix: remove session token from hook emit format; deterministic resolveSessionToken
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-latest_version: 2.1.7
+latest_version: 2.1.5
 released: 2026-04-29
 ---
 
@@ -13,9 +13,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
-## v2.1.7 — feat: cyberpunk banner v2 + checkpoint cleanup consistency
-
-CLI bumps directly from v2.1.4 → v2.1.7 (no v2.1.5 / v2.1.6 release tags).
+## v2.1.5 — feat: cyberpunk banner v2 + checkpoint cleanup consistency
 
 - feat(cli-banner): 3-phase banner intro — white CRT scan ↓ (hold 600ms), diagonal rainbow flow ↗, white shimmer ↗.
 - feat(cli-banner): rotating tagline via wipe-swap — `Remembers You` → `Catches Insights` → `Thinking Partner`. Prefix cyan, trailing magenta; final shimmer burns trailing to all-cyan settle.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,13 +17,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 CLI bumps directly from v2.1.4 → v2.1.7 (no v2.1.5 / v2.1.6 release tags).
 
-- feat(cli-banner): 3-phase banner intro — CRT scan top→bottom builds the art in white, holds 600ms, diagonal rainbow flow (bottom-left → top-right) brings it to neon, followed by a white shimmer sweep on the same diagonal.
-- feat(cli-banner): rotating multi-sentence tagline via wipe-swap transitions — "Your AI Remembers You" → "Your AI Catches Insights" → "Your AI Thinking Partner". Prefix "Your AI" stays neon cyan; trailing 2 words are neon magenta. Final lock shimmer sweeps the full tagline and burns the trailing magenta out to neon cyan; entire tagline settles cyan. Center alignment normalized at col 15.5 (border 26 dashes, art lead 5).
-- fix(doctor): mark qmd-embeddings auto-fix as advisory — plain `onebrain doctor` no longer nudges toward `--fix`; `--fix` still embeds when explicitly invoked. New `advisory?: boolean` on internal Fix interface; `fixableCount` excludes advisory fixes. Hint updated to "Advisory: run /qmd embed when ready (or onebrain doctor --fix)".
-- fix(orphan-scan + validator): drop `merged:` frontmatter filter to match plugin v2.2.0 — any checkpoint file that exists is unmerged by definition. Removes `readMergedField` from validator.
-- chore(tests): update orphan-scan and validator tests for new behavior — legacy `merged: true` checkpoints now count as orphans.
-- chore(cli-banner): static no-truecolor fallback uses the signature "Your AI Thinking Partner" line in cyan.
-- fix(doctor --fix): "Nothing to fix" line no longer renders a leading `│` bar prefix that contradicts the closed `└` corner from the summary line above.
+- feat(cli-banner): 3-phase banner intro — white CRT scan ↓ (hold 600ms), diagonal rainbow flow ↗, white shimmer ↗.
+- feat(cli-banner): rotating tagline via wipe-swap — `Remembers You` → `Catches Insights` → `Thinking Partner`. Prefix cyan, trailing magenta; final shimmer burns trailing to all-cyan settle.
+- feat(cli-banner): center alignment normalized at col 15.5 (border 26 dashes, art lead 5); static no-truecolor fallback uses signature line in cyan.
+- fix(doctor): qmd-embeddings auto-fix marked advisory — plain `doctor` no longer nudges toward `--fix`; `--fix` still embeds. New `advisory?: boolean` on internal Fix interface.
+- fix(orphan-scan + validator): drop `merged:` filter to match plugin v2.2.0 — any leftover checkpoint is unmerged by definition. `readMergedField` removed.
+- fix(doctor --fix): bar-pattern visual cleanup — "Nothing to fix" flush-left; multi-fix opens own `┌` group (new `barOpen` helper).
+- chore(tests): orphan-scan + validator tests reframed — legacy `merged: true` now counts as orphan.
 
 ## v2.1.4 — fix: drop bun-windows-arm64 (unsupported in bun v1.2)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,24 +13,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
-## v2.1.7 — feat: rotating multi-sentence tagline + 3-phase banner intro
+## v2.1.7 — feat: cyberpunk banner v2 + checkpoint cleanup consistency
 
-- feat(cli-banner): banner intro is now a 3-phase reveal — CRT scan top→bottom builds the art in white, holds 600ms, then a diagonal rainbow flow (bottom-left → top-right) brings it to neon, followed by a white shimmer sweep on the same diagonal.
-- feat(cli-banner): tagline rotates through 3 sentences via wipe-swap transitions — "Your AI Remembers You" → "Your AI Catches Insights" → "Your AI Thinking Partner". Prefix "Your AI" stays neon cyan; trailing 2 words are neon magenta during all sentences.
-- feat(cli-banner): final lock shimmer sweeps the full tagline (prefix + trailing) and burns the magenta trailing out to neon cyan, settling the entire tagline as cyan.
+CLI bumps directly from v2.1.4 → v2.1.7 (no v2.1.5 / v2.1.6 release tags).
+
+- feat(cli-banner): 3-phase banner intro — CRT scan top→bottom builds the art in white, holds 600ms, diagonal rainbow flow (bottom-left → top-right) brings it to neon, followed by a white shimmer sweep on the same diagonal.
+- feat(cli-banner): rotating multi-sentence tagline via wipe-swap transitions — "Your AI Remembers You" → "Your AI Catches Insights" → "Your AI Thinking Partner". Prefix "Your AI" stays neon cyan; trailing 2 words are neon magenta. Final lock shimmer sweeps the full tagline and burns the trailing magenta out to neon cyan; entire tagline settles cyan. Center alignment normalized at col 15.5 (border 26 dashes, art lead 5).
+- fix(doctor): mark qmd-embeddings auto-fix as advisory — plain `onebrain doctor` no longer nudges toward `--fix`; `--fix` still embeds when explicitly invoked. New `advisory?: boolean` on internal Fix interface; `fixableCount` excludes advisory fixes. Hint updated to "Advisory: run /qmd embed when ready (or onebrain doctor --fix)".
+- fix(orphan-scan + validator): drop `merged:` frontmatter filter to match plugin v2.2.0 — any checkpoint file that exists is unmerged by definition. Removes `readMergedField` from validator.
+- chore(tests): update orphan-scan and validator tests for new behavior — legacy `merged: true` checkpoints now count as orphans.
 - chore(cli-banner): static no-truecolor fallback uses the signature "Your AI Thinking Partner" line in cyan.
-
-## v2.1.6 — feat: cyberpunk tagline animation; orphan-scan drops `merged:` filter
-
-- feat(cli-banner): merged typewriter + Matrix-style glitch decode with per-word reading rhythm; cyan cursor tracks the head, white random glyphs in the wake, locks neon magenta. Diagonal art shimmer trimmed to single L→R pass; lock shimmer mirrors it on the tagline. Center alignment normalized at col 15.5 (border 26 dashes, art lead 5).
-- fix(orphan-scan + validator): drop `merged:` frontmatter filter — any checkpoint file that exists is unmerged by definition (matches /wrapup behavior in plugin v2.2.0). Removes `readMergedField` from validator.
-- chore(tests): update orphan-scan and validator tests for new behavior (legacy `merged: true` checkpoints now count as orphans).
-
-## v2.1.5 — fix: doctor qmd-embeddings as advisory; orphan-scan independent of merged: field
-
-- fix(doctor): mark qmd-embeddings auto-fix as advisory — plain `onebrain doctor` no longer nudges toward `--fix` for unembedded docs; embedding still runs when user explicitly invokes `--fix`
-- fix(doctor): update unembedded hint to "Advisory: run /qmd embed when ready (or onebrain doctor --fix)"
-- chore(types): add `advisory?: boolean` to internal `Fix` interface; `fixableCount` now excludes advisory fixes
 
 ## v2.1.4 — fix: drop bun-windows-arm64 (unsupported in bun v1.2)
 

--- a/PLUGIN-CHANGELOG.md
+++ b/PLUGIN-CHANGELOG.md
@@ -15,12 +15,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## v2.2.0 — fix: PostCompact session log; simplify checkpoint cleanup; stronger qmd-first search
 
-- fix(INSTRUCTIONS PostCompact): rewrite auto-wrapup to inline writes (no background agent dispatch). Path B silently failed because background agents do not see the main agent's compacted context. Path A still consolidates leftover checkpoints into the session log and deletes them, identical to /wrapup.
-- fix(wrapup): remove Step 5 (mark `merged: true`) and Step 6 safety-net scan. Checkpoints are deleted directly after the session log write is verified — the written log is the recovery proof.
-- fix(AUTO-SUMMARY): same simplification — drop `merged: true` annotation; delete checkpoints after session log confirmed.
+- fix(INSTRUCTIONS PostCompact): inline writes replace background-agent dispatch — Path B silently failed because background agents don't see the main agent's compacted context. Path A still consolidates leftover checkpoints + deletes them, identical to /wrapup.
+- fix(wrapup + AUTO-SUMMARY): drop Step 5 (mark `merged: true`) and Step 6 safety-net scan. Checkpoints deleted directly after session log write verified — the log is the recovery proof.
 - fix(session-formats): remove `merged: false` from checkpoint frontmatter template.
 - fix(doctor): orphan-checkpoint check no longer reads `merged:` frontmatter — any leftover checkpoint is unmerged by definition.
-- feat(INSTRUCTIONS Search Strategy + QMD.md): stronger qmd-first guidance — qmd is the explicit default for vault content searches; Grep reserved for non-content lookups (paths, frontmatter, structural patterns, code).
+- feat(INSTRUCTIONS + QMD.md): stronger qmd-first guidance — qmd is the explicit default for vault content searches; Grep reserved for non-content lookups.
 - chore(memory-health-checks): drop the `merged: true` straggler row; ignore the field on legacy files.
 
 ## v2.1.0

--- a/PLUGIN-CHANGELOG.md
+++ b/PLUGIN-CHANGELOG.md
@@ -1,6 +1,6 @@
 ---
-latest_version: 2.1.0
-released: 2026-04-28
+latest_version: 2.2.0
+released: 2026-04-29
 ---
 
 # Plugin Changelog
@@ -12,6 +12,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 > For CLI binary changes, see [CHANGELOG.md](CHANGELOG.md).
 
 ## [Unreleased]
+
+## v2.2.0 — fix: PostCompact session log; simplify checkpoint cleanup; stronger qmd-first search
+
+- fix(INSTRUCTIONS PostCompact): rewrite auto-wrapup to inline writes (no background agent dispatch). Path B silently failed because background agents do not see the main agent's compacted context. Path A still consolidates leftover checkpoints into the session log and deletes them, identical to /wrapup.
+- fix(wrapup): remove Step 5 (mark `merged: true`) and Step 6 safety-net scan. Checkpoints are deleted directly after the session log write is verified — the written log is the recovery proof.
+- fix(AUTO-SUMMARY): same simplification — drop `merged: true` annotation; delete checkpoints after session log confirmed.
+- fix(session-formats): remove `merged: false` from checkpoint frontmatter template.
+- fix(doctor): orphan-checkpoint check no longer reads `merged:` frontmatter — any leftover checkpoint is unmerged by definition.
+- feat(INSTRUCTIONS Search Strategy + QMD.md): stronger qmd-first guidance — qmd is the explicit default for vault content searches; Grep reserved for non-content lookups (paths, frontmatter, structural patterns, code).
+- chore(memory-health-checks): drop the `merged: true` straggler row; ignore the field on legacy files.
 
 ## v2.1.0
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onebrain-ai/cli",
-  "version": "2.1.7",
+  "version": "2.1.5",
   "description": "CLI for OneBrain — personal AI OS for Obsidian with persistent memory, 24+ skills, and Claude Code integration",
   "keywords": [
     "onebrain",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onebrain-ai/cli",
-  "version": "2.1.4",
+  "version": "2.1.7",
   "description": "CLI for OneBrain — personal AI OS for Obsidian with persistent memory, 24+ skills, and Claude Code integration",
   "keywords": [
     "onebrain",

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -183,7 +183,14 @@ export async function runDoctor(opts: DoctorOptions = {}): Promise<DoctorCommand
   const totalChecks = results.length;
   const errorCount = results.filter((r) => r.status === 'error').length;
   const warningCount = results.filter((r) => r.status === 'warn').length;
-  const fixableCount = results.filter((r) => r.status !== 'ok' && getFix(r) !== null).length;
+  // fixableCount drives the "→ Run doctor --fix" hint. Exclude advisory fixes
+  // so checks like qmd-embeddings (potentially long-running, opt-in) do not
+  // nudge the user toward `--fix`. They still run when --fix is invoked.
+  const fixableCount = results.filter((r) => {
+    if (r.status === 'ok') return false;
+    const fix = getFix(r);
+    return fix !== null && !fix.advisory;
+  }).length;
   const showFixHint = !opts.fix && fixableCount > 0;
 
   const summaryParts = [`${totalChecks} checks`];
@@ -278,6 +285,13 @@ type FixFn = (
 interface Fix {
   fn: FixFn;
   description: string;
+  /**
+   * Advisory fixes still run when the user explicitly invokes `--fix`, but they
+   * do not contribute to `fixableCount`, so plain `onebrain doctor` does not
+   * suggest `--fix` solely because of them. Use this for fixes whose work is
+   * potentially long-running or otherwise opt-in (e.g. qmd embedding).
+   */
+  advisory?: boolean;
 }
 
 function getFix(r: DoctorResult): Fix | null {
@@ -347,11 +361,15 @@ function getFix(r: DoctorResult): Fix | null {
     };
   }
 
-  // qmd-embeddings: unembedded docs → qmd update + qmd embed
+  // qmd-embeddings: unembedded docs → qmd update + qmd embed.
+  // Marked advisory so plain `onebrain doctor` does not nudge the user toward
+  // `--fix` solely for embeddings (embedding can be slow). When the user does
+  // run `--fix`, the embedding still happens.
   if (r.check === 'qmd-embeddings' && r.status === 'warn' && r.message.includes('unembedded')) {
     const pendingMatch = r.message.match(/(\d+) unembedded/);
     const count = pendingMatch?.[1] ?? 'some';
     return {
+      advisory: true,
       fn: async (vaultDir) => {
         const { join } = await import('node:path');
         const { parse: parseYaml } = await import('yaml');

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -433,7 +433,9 @@ async function applyFixes(
   const fixable = results.filter((r) => r.status !== 'ok' && getFix(r) !== null);
 
   if (fixable.length === 0) {
-    if (isTTY) barLine(`${pc.green('◆')}  Nothing to fix`);
+    // The previous close() already closed the bar pattern with `└`; render
+    // "Nothing to fix" as a plain line (no `│` prefix) to match that closure.
+    if (isTTY) writeLine(`${pc.green('◆')}  Nothing to fix`);
     else writeLine('nothing to fix');
     return;
   }

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -12,7 +12,15 @@ import {
   loadVaultConfig,
 } from '../lib/index.js';
 import { printBanner } from './internal/cli-banner.js';
-import { askYesNo, barBlank, barLine, close, makeStepFn, writeLine } from './internal/cli-ui.js';
+import {
+  askYesNo,
+  barBlank,
+  barLine,
+  barOpen,
+  close,
+  makeStepFn,
+  writeLine,
+} from './internal/cli-ui.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -441,8 +449,10 @@ async function applyFixes(
   }
 
   if (isTTY) {
-    barBlank();
-    barLine(pc.bold(`${fixable.length} fix(es) to apply:`));
+    // The previous close() emitted └. Start a fresh bar group with ┌ so
+    // the fix-application section reads as its own clack-style box.
+    writeLine('');
+    barOpen(pc.bold(`${fixable.length} fix(es) to apply:`));
     barBlank();
     for (const r of fixable) {
       barLine(`  ${pc.cyan('◆')}  ${getFix(r)!.description}`);

--- a/src/commands/internal/cli-banner.ts
+++ b/src/commands/internal/cli-banner.ts
@@ -17,6 +17,13 @@ export function resolveBinaryVersion(): string {
 //   border:  lead 2 + ◆ + 26 ─ + ◆        (visible col 2..29 → center 15.5)
 //   inner:   lead 5 + 22 chars             (visible col 5..26 → center 15.5)
 //   tagline: lead 4 + 24 chars             (visible col 4..27 → center 15.5)
+//
+// Tagline lead is fixed at 4 spaces — anchors the prefix "Your AI" at col
+// 4..11 across all rotating sentences. Sentence 1 ("Remembers You", 21 chars
+// total) ends at col 24, while sentences 2 and 3 (24 chars) end at col 27.
+// The prefix stays stable; only the right edge varies, which keeps the
+// wipe-swap transitions feeling like the new sentence simply extends further
+// to the right rather than the whole tagline shifting horizontally.
 // ---------------------------------------------------------------------------
 
 const ART_LINES = [
@@ -488,8 +495,9 @@ export async function printBanner(): Promise<void> {
   const rainbowArt = ART_LINES.map((l, i) => neonLine(l, i));
   const whiteArt = ART_LINES.map((l) => whiteLine(l));
 
-  outb('\x1b[?25l');
   try {
+    // Hide system cursor inside the try block so the finally always restores it.
+    outb('\x1b[?25l');
     await playBannerIntro(rainbowArt, whiteArt);
 
     // Tagline rotation

--- a/src/commands/internal/cli-banner.ts
+++ b/src/commands/internal/cli-banner.ts
@@ -13,21 +13,48 @@ export function resolveBinaryVersion(): string {
 }
 
 // ---------------------------------------------------------------------------
-// Art
+// Banner data — center axis at col 15.5
+//   border:  lead 2 + ◆ + 26 ─ + ◆        (visible col 2..29 → center 15.5)
+//   inner:   lead 5 + 22 chars             (visible col 5..26 → center 15.5)
+//   tagline: lead 4 + 24 chars             (visible col 4..27 → center 15.5)
 // ---------------------------------------------------------------------------
 
 const ART_LINES = [
-  `  ◆${'─'.repeat(25)}◆`,
-  '    ┌─┐┌┐╷┌─╴┌┐ ┌─┐┌─┐╷┌┐╷',
-  '    │ ││└┤├╴ ├┴┐├┬┘├─┤││└┤',
-  '    └─┘╵ ╵└─╴└─┘╵└╴╵ ╵╵╵ ╵',
-  `  ◆${'─'.repeat(25)}◆`,
+  `  ◆${'─'.repeat(26)}◆`,
+  '     ┌─┐┌┐╷┌─╴┌┐ ┌─┐┌─┐╷┌┐╷',
+  '     │ ││└┤├╴ ├┴┐├┬┘├─┤││└┤',
+  '     └─┘╵ ╵└─╴└─┘╵└╴╵ ╵╵╵ ╵',
+  `  ◆${'─'.repeat(26)}◆`,
 ];
 
-const TAGLINE = 'Your AI Thinking Partner';
-
-// blank + 5 art + blank + tagline + blank
+const PREFIX = 'Your AI ';
+const TAGLINE_LEAD = '    '; // 4 spaces — fits longest sentence at center
+const TAGLINE_FALLBACK = `${PREFIX}Thinking Partner`;
 const BANNER_LINE_COUNT = 1 + ART_LINES.length + 3;
+
+type Rgb = [number, number, number];
+
+interface Sentence {
+  trailing: string;
+  trailingWords: string[];
+  /** Per-word ms/char tick rate (length matches trailingWords) */
+  wordTicks: number[];
+}
+
+// Color scheme:
+//   "Your AI" prefix   → neon cyan throughout
+//   trailing 2 words   → neon magenta during all sentences
+//   final lock shimmer → sweeps full tagline; behind the head, every char
+//                        settles to neon cyan (magenta "burns out" to cyan)
+const PREFIX_COLOR: Rgb = [120, 230, 255];
+const TRAILING_COLOR: Rgb = [255, 80, 255];
+const FINAL_COLOR: Rgb = [120, 230, 255];
+
+const SENTENCES: Sentence[] = [
+  { trailing: 'Remembers You', trailingWords: ['Remembers', 'You'], wordTicks: [24, 32] },
+  { trailing: 'Catches Insights', trailingWords: ['Catches', 'Insights'], wordTicks: [27, 26] },
+  { trailing: 'Thinking Partner', trailingWords: ['Thinking', 'Partner'], wordTicks: [26, 31] },
+];
 
 // ---------------------------------------------------------------------------
 // Color helpers
@@ -38,38 +65,30 @@ function supportsRgb(): boolean {
   return c === 'truecolor' || c === '24bit';
 }
 
-function hsvToRgb(h: number, floor = 80): [number, number, number] {
-  // s=1, v=1 (full neon); h in [0, 360)
+function rgb(r: number, g: number, b: number, ch: string): string {
+  return `\x1b[1;38;2;${r};${g};${b}m${ch}\x1b[0m`;
+}
+function rgbStr(c: Rgb, ch: string): string {
+  return rgb(c[0], c[1], c[2], ch);
+}
+
+function hsvToRgb(h: number, floor = 80): Rgb {
   const c = 255;
   const x = Math.round(c * (1 - Math.abs(((h / 60) % 2) - 1)));
   let r = 0;
   let g = 0;
   let b = 0;
-  if (h < 60) {
-    r = c;
-    g = x;
-  } else if (h < 120) {
-    r = x;
-    g = c;
-  } else if (h < 180) {
-    g = c;
-    b = x;
-  } else if (h < 240) {
-    g = x;
-    b = c;
-  } else if (h < 300) {
-    r = x;
-    b = c;
-  } else {
-    r = c;
-    b = x;
-  }
-  // Luminance floor: lifts dark channels so all hues appear equally vivid
+  if (h < 60) [r, g, b] = [c, x, 0];
+  else if (h < 120) [r, g, b] = [x, c, 0];
+  else if (h < 180) [r, g, b] = [0, c, x];
+  else if (h < 240) [r, g, b] = [0, x, c];
+  else if (h < 300) [r, g, b] = [x, 0, c];
+  else [r, g, b] = [c, 0, x];
   return [Math.min(255, r + floor), Math.min(255, g + floor), Math.min(255, b + floor)];
 }
 
-const HUE_PER_CHAR = 10; // hue degrees per character (horizontal)
-const HUE_PER_ROW = 30; // hue degrees per row (vertical) — creates diagonal gradient
+const HUE_PER_CHAR = 10;
+const HUE_PER_ROW = 30;
 
 function neonLine(line: string, lineIndex = 0, floor = 80): string {
   return line
@@ -78,16 +97,22 @@ function neonLine(line: string, lineIndex = 0, floor = 80): string {
       if (ch === ' ') return ch;
       const hue = (((i * HUE_PER_CHAR - lineIndex * HUE_PER_ROW) % 360) + 360) % 360;
       const [r, g, b] = hsvToRgb(hue, floor);
-      return `\x1b[1;38;2;${r};${g};${b}m${ch}\x1b[0m`;
+      return rgb(r, g, b, ch);
     })
     .join('');
 }
 
-// Warm cyan electron beam — the active scanline
-function scanLine(line: string): string {
+function whiteLine(line: string): string {
   return line
     .split('')
-    .map((ch) => (ch === ' ' ? ch : `\x1b[1;38;2;140;255;255m${ch}\x1b[0m`))
+    .map((ch) => (ch === ' ' ? ch : `\x1b[1;97m${ch}\x1b[0m`))
+    .join('');
+}
+
+function whiteGlowLine(line: string, alpha: number): string {
+  return line
+    .split('')
+    .map((ch) => (ch === ' ' ? ch : `\x1b[1;38;2;${alpha};${alpha};${alpha}m${ch}\x1b[0m`))
     .join('');
 }
 
@@ -97,6 +122,18 @@ function dimLine(line: string): string {
     .map((ch) => (ch === ' ' ? ch : `\x1b[2;38;2;50;50;70m${ch}\x1b[0m`))
     .join('');
 }
+
+function scanLineCh(line: string): string {
+  return line
+    .split('')
+    .map((ch) => (ch === ' ' ? ch : rgb(140, 255, 255, ch)))
+    .join('');
+}
+
+const CURSOR = rgb(140, 255, 255, '▌');
+const GLYPHS = '▓░▒█│┤┐└┴┬├─┼╪╫╬╧╨╤╥╙╘╒╓┘┌║▌▀▄▐∆ƒΩ§¶±÷×ø¥€';
+const randGlyph = () => GLYPHS[Math.floor(Math.random() * GLYPHS.length)] ?? '?';
+const glitchWhite = (g: string) => `\x1b[1;97m${g}\x1b[0m`;
 
 // ---------------------------------------------------------------------------
 // Frame printer
@@ -114,133 +151,358 @@ function printFrame(artLines: string[], tagline: string): void {
   outb('\n');
 }
 
+function blankTagline(): string {
+  return `${TAGLINE_LEAD}${' '.repeat(TAGLINE_FALLBACK.length)}`;
+}
+
+function buildTaglineLine(prefixLockedChars: number, trailingPart: string): string {
+  let s = TAGLINE_LEAD;
+  for (let i = 0; i < PREFIX.length; i++) {
+    if (i < prefixLockedChars) {
+      s += PREFIX[i] === ' ' ? ' ' : rgbStr(PREFIX_COLOR, PREFIX[i]!);
+    } else {
+      s += ' ';
+    }
+  }
+  s += trailingPart;
+  return `${s}\x1b[K`;
+}
+
+// Tagline tempo
+const LOCK_LATENCY = 4;
+const PREFIX_TICK_MS = [27, 27]; // "Your" / "AI"
+const INTER_WORD_PAUSE_MS = 65;
+const SENTENCE_HOLD_MS = 500;
+const WIPE_TICK_MS = 22;
+const WIPE_TRAIL = 3;
+const WIPE_PAUSE_MS = 80;
+
 // ---------------------------------------------------------------------------
-// CRT power-on scan animation
+// Banner intro — 3-phase reveal (sequential)
+// ---------------------------------------------------------------------------
+
+async function playBannerIntro(rainbowArt: string[], whiteArt: string[]): Promise<void> {
+  const delay = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+  const up = (n: number) => outb(`\x1b[${n}F`);
+
+  // Phase 1A — CRT scan top→bottom, banner builds in white
+  printFrame(ART_LINES.map(dimLine), blankTagline());
+
+  for (let scan = 0; scan < ART_LINES.length; scan++) {
+    await delay(55);
+    up(BANNER_LINE_COUNT);
+    printFrame(
+      ART_LINES.map((l, i) => {
+        if (i < scan - 2) return whiteLine(l);
+        if (i === scan - 2) return whiteGlowLine(l, 200);
+        if (i === scan - 1) return whiteGlowLine(l, 230);
+        if (i === scan) return scanLineCh(l);
+        return dimLine(l);
+      }),
+      blankTagline(),
+    );
+  }
+
+  await delay(40);
+  up(BANNER_LINE_COUNT);
+  printFrame(whiteArt, blankTagline());
+
+  // Hold pure white (CRT settle) — 600ms
+  await delay(600);
+
+  // Phase 1B — rainbow flows diagonally bottom-left → top-right
+  let minD = 0;
+  let maxD = 0;
+  for (let row = 0; row < ART_LINES.length; row++) {
+    minD = Math.min(minD, -row * 3);
+    maxD = Math.max(maxD, ART_LINES[row]!.length - 1 - row * 3);
+  }
+
+  function flowFrame(frontD: number): string[] {
+    return ART_LINES.map((line, row) =>
+      line
+        .split('')
+        .map((ch, col) => {
+          if (ch === ' ') return ch;
+          const d = col - 3 * row;
+          if (d <= frontD) {
+            const hue = (((col * HUE_PER_CHAR - row * HUE_PER_ROW) % 360) + 360) % 360;
+            const [r, g, b] = hsvToRgb(hue);
+            return rgb(r, g, b, ch);
+          }
+          return `\x1b[1;97m${ch}\x1b[0m`;
+        })
+        .join(''),
+    );
+  }
+
+  for (let d = minD; d <= maxD; d++) {
+    await delay(9);
+    up(BANNER_LINE_COUNT);
+    printFrame(flowFrame(d), blankTagline());
+  }
+  up(BANNER_LINE_COUNT);
+  printFrame(rainbowArt, blankTagline());
+  await delay(180);
+
+  // Phase 1C — white shimmer sweeps the same diagonal direction over rainbow
+  function shimmerArtFrame(highlight: number): string[] {
+    return ART_LINES.map((line, row) =>
+      line
+        .split('')
+        .map((ch, col) => {
+          if (ch === ' ') return ch;
+          const d = col - 3 * row;
+          if (Math.abs(d - highlight) <= 1) return `\x1b[1;97m${ch}\x1b[0m`;
+          const hue = (((col * HUE_PER_CHAR - row * HUE_PER_ROW) % 360) + 360) % 360;
+          const [r, g, b] = hsvToRgb(hue);
+          return rgb(r, g, b, ch);
+        })
+        .join(''),
+    );
+  }
+  for (let d = minD; d <= maxD; d++) {
+    await delay(9);
+    up(BANNER_LINE_COUNT);
+    printFrame(shimmerArtFrame(d), blankTagline());
+  }
+  up(BANNER_LINE_COUNT);
+  printFrame(rainbowArt, blankTagline());
+  await delay(80);
+}
+
+// ---------------------------------------------------------------------------
+// Tagline phase — 3 rotating sentences via wipe swap, then lock shimmer
+// ---------------------------------------------------------------------------
+
+async function decodeFirstSentence(rainbowArt: string[], s: Sentence): Promise<void> {
+  const delay = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+  const up = (n: number) => outb(`\x1b[${n}F`);
+
+  const prefixWords = ['Your', 'AI'];
+  for (let wi = 0; wi < prefixWords.length; wi++) {
+    const w = prefixWords[wi]!;
+    const tickMs = PREFIX_TICK_MS[wi]!;
+    const totalTicks = w.length + LOCK_LATENCY;
+    const baseIdx = prefixWords.slice(0, wi).reduce((a, x) => a + x.length + 1, 0);
+
+    for (let t = 1; t <= totalTicks; t++) {
+      await delay(tickMs);
+      up(BANNER_LINE_COUNT);
+      let prefixPart = TAGLINE_LEAD;
+      for (let i = 0; i < PREFIX.length; i++) {
+        if (i < baseIdx) {
+          prefixPart += PREFIX[i] === ' ' ? ' ' : rgbStr(PREFIX_COLOR, PREFIX[i]!);
+        } else if (i >= baseIdx + w.length) {
+          prefixPart += ' ';
+        } else {
+          const localIdx = i - baseIdx;
+          const age = t - localIdx;
+          if (age > LOCK_LATENCY) prefixPart += rgbStr(PREFIX_COLOR, PREFIX[i]!);
+          else if (age > 0) prefixPart += glitchWhite(randGlyph());
+          else if (age === 0 && t < w.length) prefixPart += CURSOR;
+          else prefixPart += ' ';
+        }
+      }
+      const trailingBlank = ' '.repeat(s.trailing.length);
+      printFrame(rainbowArt, `${prefixPart}${trailingBlank}\x1b[K`);
+    }
+    if (wi < prefixWords.length - 1) {
+      await delay(INTER_WORD_PAUSE_MS);
+    }
+  }
+
+  await delay(INTER_WORD_PAUSE_MS);
+  await decodeTrailing(rainbowArt, s, PREFIX.length);
+}
+
+async function decodeTrailing(
+  rainbowArt: string[],
+  s: Sentence,
+  lockedPrefixChars: number,
+): Promise<void> {
+  const delay = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+  const up = (n: number) => outb(`\x1b[${n}F`);
+
+  const words = s.trailingWords;
+  const ticks = s.wordTicks;
+  const offsets: number[] = [];
+  let off = 0;
+  for (const w of words) {
+    offsets.push(off);
+    off += w.length + 1;
+  }
+
+  for (let wi = 0; wi < words.length; wi++) {
+    const w = words[wi]!;
+    const tickMs = ticks[wi]!;
+    const totalTicks = w.length + LOCK_LATENCY;
+
+    for (let t = 1; t <= totalTicks; t++) {
+      await delay(tickMs);
+      up(BANNER_LINE_COUNT);
+      let trailing = '';
+      for (let j = 0; j < s.trailing.length; j++) {
+        const ch = s.trailing[j]!;
+        if (ch === ' ') {
+          trailing += ' ';
+          continue;
+        }
+        let owningWi = -1;
+        let localIdx = -1;
+        for (let k = 0; k < words.length; k++) {
+          const start = offsets[k]!;
+          const end = start + words[k]!.length;
+          if (j >= start && j < end) {
+            owningWi = k;
+            localIdx = j - start;
+            break;
+          }
+        }
+        if (owningWi < wi) {
+          trailing += rgbStr(TRAILING_COLOR, ch);
+        } else if (owningWi > wi) {
+          trailing += ' ';
+        } else {
+          const age = t - localIdx;
+          if (age > LOCK_LATENCY) trailing += rgbStr(TRAILING_COLOR, ch);
+          else if (age > 0) trailing += glitchWhite(randGlyph());
+          else if (age === 0 && t < w.length) trailing += CURSOR;
+          else trailing += ' ';
+        }
+      }
+      printFrame(rainbowArt, buildTaglineLine(lockedPrefixChars, trailing));
+    }
+    if (wi < words.length - 1) {
+      await delay(INTER_WORD_PAUSE_MS);
+    }
+  }
+}
+
+async function wipeSwapTransition(
+  rainbowArt: string[],
+  from: Sentence,
+  to: Sentence,
+): Promise<void> {
+  const delay = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+  const up = (n: number) => outb(`\x1b[${n}F`);
+
+  // Phase A: bright cyan scanner R→L erases the trailing
+  for (let pos = from.trailing.length - 1; pos >= -WIPE_TRAIL; pos--) {
+    await delay(WIPE_TICK_MS);
+    up(BANNER_LINE_COUNT);
+    let trailing = '';
+    for (let j = 0; j < from.trailing.length; j++) {
+      const ch = from.trailing[j]!;
+      if (ch === ' ') {
+        trailing += ' ';
+        continue;
+      }
+      const offset = j - pos;
+      if (offset >= 0 && offset <= WIPE_TRAIL) {
+        trailing += rgb(140, 255, 255, randGlyph());
+      } else if (j > pos) {
+        trailing += ' ';
+      } else {
+        trailing += rgbStr(TRAILING_COLOR, ch);
+      }
+    }
+    printFrame(rainbowArt, buildTaglineLine(PREFIX.length, trailing));
+  }
+  await delay(WIPE_PAUSE_MS);
+
+  // Phase B: type+glitch decode of the new trailing
+  await decodeTrailing(rainbowArt, to, PREFIX.length);
+}
+
+async function lockShimmer(rainbowArt: string[], s: Sentence): Promise<void> {
+  const delay = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+  const up = (n: number) => outb(`\x1b[${n}F`);
+
+  const SHIMMER_TICK_MS = 22;
+  const TRAIL = 3;
+  const STOPS: Rgb[] = [
+    [255, 255, 255], // head — pure white
+    [200, 245, 255], // mid — ice
+    [150, 235, 255], // tail — bright cyan
+  ];
+  const fullText = PREFIX + s.trailing;
+  const N = fullText.length;
+
+  for (let pos = 0; pos <= N + TRAIL; pos++) {
+    await delay(SHIMMER_TICK_MS);
+    up(BANNER_LINE_COUNT);
+    let line = TAGLINE_LEAD;
+    for (let j = 0; j < N; j++) {
+      const ch = fullText[j]!;
+      if (ch === ' ') {
+        line += ' ';
+        continue;
+      }
+      const offset = pos - j;
+      if (offset >= 0 && offset < TRAIL) {
+        line += rgbStr(STOPS[offset]!, ch);
+      } else if (offset >= TRAIL) {
+        // Behind head — every char settles to neon cyan
+        line += rgbStr(FINAL_COLOR, ch);
+      } else {
+        // Ahead of head — original locked color
+        const baseColor = j < PREFIX.length ? PREFIX_COLOR : TRAILING_COLOR;
+        line += rgbStr(baseColor, ch);
+      }
+    }
+    line += '\x1b[K';
+    printFrame(rainbowArt, line);
+  }
+
+  // Final settle — entire tagline neon cyan
+  up(BANNER_LINE_COUNT);
+  let finalLine = TAGLINE_LEAD;
+  for (let j = 0; j < N; j++) {
+    const ch = fullText[j]!;
+    finalLine += ch === ' ' ? ' ' : rgbStr(FINAL_COLOR, ch);
+  }
+  finalLine += '\x1b[K';
+  printFrame(rainbowArt, finalLine);
+  await delay(150);
+}
+
+// ---------------------------------------------------------------------------
+// Public entry point
 // ---------------------------------------------------------------------------
 
 export async function printBanner(): Promise<void> {
   if (!process.stdout.isTTY) return;
 
-  const delay = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
-  const up = (n: number) => outb(`\x1b[${n}F`);
-
   if (!supportsRgb()) {
-    // No true color — static banner
+    // No true color — static fallback. Use the final sentence (signature
+    // tagline) so non-truecolor terminals still see the brand line.
     outb('\n');
     for (const l of ART_LINES) outb(`${pc.bold(pc.cyan(l))}\n`);
     outb('\n');
-    outb(`    ${pc.bold(pc.magenta(TAGLINE))}\n`);
+    outb(`${TAGLINE_LEAD}${pc.bold(pc.cyan(TAGLINE_FALLBACK))}\n`);
     outb('\n');
     return;
   }
 
+  const rainbowArt = ART_LINES.map((l, i) => neonLine(l, i));
+  const whiteArt = ART_LINES.map((l) => whiteLine(l));
+
   outb('\x1b[?25l');
   try {
-    // Initial: all dim, tagline blank
-    printFrame(ART_LINES.map(dimLine), `    ${' '.repeat(TAGLINE.length)}`);
+    await playBannerIntro(rainbowArt, whiteArt);
 
-    // Scanline sweeps top → bottom
-    // Row layout: settled | 2nd trail (floor 120) | 1st trail (floor 200) | scan beam | dim
-    for (let scan = 0; scan < ART_LINES.length; scan++) {
-      await delay(65);
-      up(BANNER_LINE_COUNT);
-      printFrame(
-        ART_LINES.map((l, i) => {
-          if (i < scan - 2) return neonLine(l, i); // settled rainbow
-          if (i === scan - 2) return neonLine(l, i, 120); // 2nd trailing glow
-          if (i === scan - 1) return neonLine(l, i, 200); // 1st trailing glow — very bright
-          if (i === scan) return scanLine(l); // warm cyan electron beam
-          return dimLine(l); // not yet lit
-        }),
-        `    ${' '.repeat(TAGLINE.length)}`,
-      );
-    }
+    // Tagline rotation
+    await decodeFirstSentence(rainbowArt, SENTENCES[0]!);
+    await new Promise<void>((r) => setTimeout(r, SENTENCE_HOLD_MS));
 
-    // All rainbow, tagline still blank
-    await delay(60);
-    up(BANNER_LINE_COUNT);
-    printFrame(
-      ART_LINES.map((l, i) => neonLine(l, i)),
-      `    ${' '.repeat(TAGLINE.length)}`,
-    );
+    await wipeSwapTransition(rainbowArt, SENTENCES[0]!, SENTENCES[1]!);
+    await new Promise<void>((r) => setTimeout(r, SENTENCE_HOLD_MS));
 
-    // Diagonal shimmer — stripe aligned with rainbow iso-hue lines (col - 3*row = d)
-    // Sweeps perpendicular to the color gradient, forward then reverse
-    let minD = 0;
-    let maxD = 0;
-    for (let row = 0; row < ART_LINES.length; row++) {
-      minD = Math.min(minD, -row * 3);
-      maxD = Math.max(maxD, ART_LINES[row]!.length - 1 - row * 3);
-    }
-    function diagFrame(highlight: number): string[] {
-      return ART_LINES.map((line, row) =>
-        line
-          .split('')
-          .map((ch, col) => {
-            if (ch === ' ') return ch;
-            const d = col - 3 * row;
-            if (Math.abs(d - highlight) <= 1) return `\x1b[1;97m${ch}\x1b[0m`;
-            const hue = (((col * HUE_PER_CHAR - row * HUE_PER_ROW) % 360) + 360) % 360;
-            const [r, g, b] = hsvToRgb(hue);
-            return `\x1b[1;38;2;${r};${g};${b}m${ch}\x1b[0m`;
-          })
-          .join(''),
-      );
-    }
-    for (let d = minD; d <= maxD; d++) {
-      await delay(16);
-      up(BANNER_LINE_COUNT);
-      printFrame(diagFrame(d), `    ${' '.repeat(TAGLINE.length)}`);
-    }
-    for (let d = maxD; d >= minD; d--) {
-      await delay(16);
-      up(BANNER_LINE_COUNT);
-      printFrame(diagFrame(d), `    ${' '.repeat(TAGLINE.length)}`);
-    }
-    // Clean rainbow after sweep
-    up(BANNER_LINE_COUNT);
-    printFrame(
-      ART_LINES.map((l, i) => neonLine(l, i)),
-      `    ${' '.repeat(TAGLINE.length)}`,
-    );
-    await delay(200);
+    await wipeSwapTransition(rainbowArt, SENTENCES[1]!, SENTENCES[2]!);
+    await new Promise<void>((r) => setTimeout(r, SENTENCE_HOLD_MS));
 
-    // Typewriter tagline — cyan cursor follows text
-    const cursor = '\x1b[1;38;2;140;255;255m▌\x1b[0m';
-    for (let len = 1; len <= TAGLINE.length; len++) {
-      await delay(32);
-      up(BANNER_LINE_COUNT);
-      const hasCursor = len < TAGLINE.length;
-      printFrame(
-        ART_LINES.map((l, i) => neonLine(l, i)),
-        `    \x1b[1;97m${TAGLINE.slice(0, len)}\x1b[0m${hasCursor ? cursor : ''}${' '.repeat(Math.max(0, TAGLINE.length - len - 1))}`,
-      );
-    }
-
-    // Cursor blinks 2 times then disappears into magenta
-    const tagWithCursor = `    \x1b[1;97m${TAGLINE}\x1b[0m${cursor}`;
-    const tagWhite = `    \x1b[1;97m${TAGLINE}\x1b[0m\x1b[K`;
-    for (let b = 0; b < 2; b++) {
-      await delay(600);
-      up(BANNER_LINE_COUNT);
-      printFrame(
-        ART_LINES.map((l, i) => neonLine(l, i)),
-        tagWhite,
-      );
-      await delay(600);
-      up(BANNER_LINE_COUNT);
-      printFrame(
-        ART_LINES.map((l, i) => neonLine(l, i)),
-        tagWithCursor,
-      );
-    }
-    // Cursor disappears + settle magenta in one step
-    await delay(600);
-    up(BANNER_LINE_COUNT);
-    printFrame(
-      ART_LINES.map((l, i) => neonLine(l, i)),
-      `    ${pc.bold(pc.magenta(TAGLINE))}\x1b[K`,
-    );
+    await lockShimmer(rainbowArt, SENTENCES[2]!);
   } finally {
     outb('\x1b[?25h');
   }

--- a/src/commands/internal/cli-ui.ts
+++ b/src/commands/internal/cli-ui.ts
@@ -2,9 +2,10 @@
  * Shared CLI UI primitives used by init, update, and doctor commands.
  *
  * Layout language (clack-inspired):
+ *   ┌  message          ← barOpen (start a new bar group)
  *   │  message          ← barLine / barBlank
  *   ●  emoji  label     ← createStep (done state)
- *   └  message          ← close
+ *   └  message          ← close (finish bar group)
  */
 
 import pc from 'picocolors';
@@ -32,6 +33,12 @@ export function barLine(msg: string): void {
 
 export function barBlank(): void {
   out(`${bar}\n`);
+}
+
+/** Open a new bar group with a top corner. Use after a previous close()
+ * to start a visually-distinct second section without leaving an orphan │. */
+export function barOpen(msg: string): void {
+  out(`${pc.cyan('┌')}  ${msg}\n`);
 }
 
 export function close(msg: string, isError = false, isWarning = false): void {

--- a/src/commands/internal/orphan-scan.test.ts
+++ b/src/commands/internal/orphan-scan.test.ts
@@ -101,27 +101,31 @@ describe('runOrphanScan', () => {
     expect(result).toEqual({ orphan_count: 0 });
   });
 
-  it('skips checkpoint files with merged: true', async () => {
+  // Since v2.2.0, /wrapup deletes checkpoints directly after the session log
+  // is verified — any checkpoint file that still exists is unmerged by
+  // definition. Legacy `merged: true` files (and the `merged: "true"` quoted
+  // variant) are now treated identically to unmerged files, so the only thing
+  // that suppresses an orphan is a manual session log for that date or the
+  // current session token match.
+  it('counts legacy checkpoint with merged: true as an orphan', async () => {
     const { thisYear, thisMonth } = getMonthParts();
     const monthDir = await makeMonthDir(logsDir, thisYear, thisMonth);
-    // Use a past date so today-skip doesn't apply
     const pastDate = `${thisYear}-${thisMonth}-01`;
     const fname = checkpointName(pastDate, 'token11', 1);
     await writeFile(join(monthDir, fname), checkpointFrontmatter(true), 'utf8');
     const result = await runOrphanScan(logsDir, 'current99');
-    expect(result).toEqual({ orphan_count: 0 });
+    expect(result).toEqual({ orphan_count: 1 });
   });
 
-  it('skips checkpoint files with merged: "true" (quoted string in YAML)', async () => {
+  it('counts legacy checkpoint with merged: "true" (quoted string) as an orphan', async () => {
     const { thisYear, thisMonth } = getMonthParts();
     const monthDir = await makeMonthDir(logsDir, thisYear, thisMonth);
     const pastDate = `${thisYear}-${thisMonth}-01`;
     const fname = checkpointName(pastDate, 'tokenStrTrue', 1);
-    // Write frontmatter with merged as a quoted string (YAML string "true", not boolean)
     const content = `---\ntags: [checkpoint, session-log]\ndate: ${pastDate}\ncheckpoint: 01\ntrigger: stop\nmerged: "true"\n---\n\n## What We Worked On\n\nTest content.`;
     await writeFile(join(monthDir, fname), content, 'utf8');
     const result = await runOrphanScan(logsDir, 'current99');
-    expect(result).toEqual({ orphan_count: 0 });
+    expect(result).toEqual({ orphan_count: 1 });
   });
 
   it('skips checkpoint files matching current session token', async () => {

--- a/src/commands/internal/orphan-scan.ts
+++ b/src/commands/internal/orphan-scan.ts
@@ -145,15 +145,6 @@ async function scanMonthDir(
     // Skip tokens already counted (dedup across multiple checkpoint files per session)
     if (seenTokens.has(ftoken)) continue;
 
-    // Skip if already merged (read frontmatter)
-    try {
-      const content = await readFile(join(monthDir, fname), 'utf8');
-      const fm = parseFrontmatter(content);
-      if (fm && (fm['merged'] === true || fm['merged'] === 'true')) continue;
-    } catch {
-      // Can't read frontmatter — treat as unmerged orphan
-    }
-
     // Skip if a manual session log covers this date
     if (await hasManualSessionLog(monthDir, fdate)) continue;
 

--- a/src/lib/index.test.ts
+++ b/src/lib/index.test.ts
@@ -337,38 +337,41 @@ describe('checkOrphanCheckpoints', () => {
     expect(result.status).toBe('ok');
   });
 
-  it('returns ok when all checkpoints have merged: true', async () => {
+  it('counts every checkpoint file as an orphan, regardless of merged: field', async () => {
+    // Since v2.2.0, /wrapup deletes checkpoints directly after the session
+    // log is verified. Any checkpoint file that exists is unmerged by
+    // definition — including legacy files that still carry merged: true.
     const logsDir = join(dir, '07-logs', '2026', '04');
     await mkdir(logsDir, { recursive: true });
-    const content = '---\ntags: [checkpoint]\nmerged: true\n---\n\n## What We Worked On\nDone.';
-    await writeFile(join(logsDir, '2026-04-24-abc123-checkpoint-01.md'), content, 'utf8');
+    const legacyMerged =
+      '---\ntags: [checkpoint]\nmerged: true\n---\n\n## What We Worked On\nLegacy.';
+    await writeFile(join(logsDir, '2026-04-24-abc123-checkpoint-01.md'), legacyMerged, 'utf8');
 
     const result = await checkOrphanCheckpoints(dir, baseConfig);
-    expect(result.status).toBe('ok');
-    expect(result.message).toContain('0');
+    expect(result.status).toBe('warn');
+    expect(result.message).toContain('1');
   });
 
-  it('returns warn when unmerged checkpoint files exist', async () => {
+  it('returns warn for any checkpoint files present', async () => {
     const logsDir = join(dir, '07-logs', '2026', '04');
     await mkdir(logsDir, { recursive: true });
-    const unmerged =
-      '---\ntags: [checkpoint]\nmerged: false\n---\n\n## What We Worked On\nPending.';
-    const merged = '---\ntags: [checkpoint]\nmerged: true\n---\n\n## What We Worked On\nDone.';
-    await writeFile(join(logsDir, '2026-04-24-abc123-checkpoint-01.md'), unmerged, 'utf8');
-    await writeFile(join(logsDir, '2026-04-24-abc456-checkpoint-01.md'), merged, 'utf8');
+    const a = '---\ntags: [checkpoint]\nmerged: false\n---\n\n## What We Worked On\nA.';
+    const b = '---\ntags: [checkpoint]\nmerged: true\n---\n\n## What We Worked On\nB.';
+    await writeFile(join(logsDir, '2026-04-24-abc123-checkpoint-01.md'), a, 'utf8');
+    await writeFile(join(logsDir, '2026-04-24-abc456-checkpoint-01.md'), b, 'utf8');
 
     const result = await checkOrphanCheckpoints(dir, baseConfig);
 
     expect(result.status).toBe('warn');
-    expect(result.message).toContain('1');
+    expect(result.message).toContain('2');
     expect(result.message).toContain('07-logs');
   });
 
-  it('treats checkpoint without merged field as unmerged', async () => {
+  it('treats checkpoint without merged field as orphan', async () => {
     const logsDir = join(dir, '07-logs', '2026', '04');
     await mkdir(logsDir, { recursive: true });
-    // No merged field in frontmatter
-    const content = '---\ntags: [checkpoint]\n---\n\n## What We Worked On\nMissing merged field.';
+    // No merged field in frontmatter — same outcome as new-format checkpoints
+    const content = '---\ntags: [checkpoint]\n---\n\n## What We Worked On\nNo merged field.';
     await writeFile(join(logsDir, '2026-04-24-def789-checkpoint-01.md'), content, 'utf8');
 
     const result = await checkOrphanCheckpoints(dir, baseConfig);

--- a/src/lib/validator.ts
+++ b/src/lib/validator.ts
@@ -188,10 +188,10 @@ export async function checkQmdEmbeddings(config: VaultConfig): Promise<DoctorRes
         check: 'qmd-embeddings',
         status: 'warn',
         message: summary,
-        hint: 'Run onebrain doctor --fix to reindex and embed',
+        hint: 'Advisory: run /qmd embed when ready (or onebrain doctor --fix)',
         details: [
           `collection: ${config.qmd_collection}`,
-          'Run onebrain doctor --fix to reindex and embed',
+          'Advisory: run /qmd embed when ready (or onebrain doctor --fix)',
         ],
       };
     }
@@ -212,7 +212,9 @@ export async function checkQmdEmbeddings(config: VaultConfig): Promise<DoctorRes
 // ---------------------------------------------------------------------------
 
 /**
- * Count checkpoint files where merged is not true.
+ * Count leftover checkpoint files. Since v2.2.0, /wrapup deletes checkpoints
+ * directly after writing the session log, so any checkpoint file that exists
+ * is unmerged by definition — no `merged:` filter needed.
  */
 export async function checkOrphanCheckpoints(
   vaultRoot: string,
@@ -239,22 +241,7 @@ export async function checkOrphanCheckpoints(
     };
   }
 
-  if (checkpointFiles.length === 0) {
-    return {
-      check: 'orphan-checkpoints',
-      status: 'ok',
-      message: '0 orphans',
-    };
-  }
-
-  let orphanCount = 0;
-
-  for (const filePath of checkpointFiles) {
-    const merged = await readMergedField(filePath);
-    if (merged !== true) {
-      orphanCount++;
-    }
-  }
+  const orphanCount = checkpointFiles.length;
 
   if (orphanCount === 0) {
     return {
@@ -271,33 +258,6 @@ export async function checkOrphanCheckpoints(
     hint: 'Run /wrapup to synthesize and merge them',
     details: ['Run /wrapup to synthesize and merge them'],
   };
-}
-
-/**
- * Read YAML frontmatter from a markdown file and extract the `merged` field.
- * Returns undefined if the file cannot be read or has no frontmatter.
- */
-async function readMergedField(filePath: string): Promise<boolean | undefined> {
-  try {
-    const file = Bun.file(filePath);
-    const text = await file.text();
-
-    // Extract frontmatter between first --- pair
-    if (!text.startsWith('---')) return undefined;
-    const endIdx = text.indexOf('\n---', 3);
-    if (endIdx === -1) return undefined;
-
-    const frontmatter = text.slice(3, endIdx).trim();
-    const parsed = parse(frontmatter) as Record<string, unknown> | null;
-    if (!parsed) return undefined;
-
-    const merged = parsed['merged'];
-    if (merged === true || merged === 'true') return true;
-    if (merged === false || merged === 'false') return false;
-    return undefined;
-  } catch {
-    return undefined;
-  }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Bundles 6 scoped fixes plus a substantial banner redesign. Plugin → **v2.2.0**, CLI → **v2.1.5**.

### Plugin v2.2.0

- **`/wrapup` + AUTO-SUMMARY**: drop Step 5 (mark `merged: true`) — checkpoints deleted directly after the session log write is verified. The written log is the recovery proof.
- **INSTRUCTIONS PostCompact auto-wrapup**: rewrite to inline writes (no background-agent dispatch). Path B silently failed because background agents do not see the main agent's compacted context. Path A still consolidates leftover checkpoints into the session log and deletes them, identical to `/wrapup`.
- **qmd-first search guidance**: `INSTRUCTIONS.md` Search Strategy + `skills/startup/QMD.md` made stronger — qmd is the explicit default for vault content searches; Grep reserved for non-content lookups.
- **`/doctor` orphan check**: no longer reads `merged:` frontmatter; any leftover checkpoint is unmerged by definition. memory-health-checks straggler row removed.
- **session-formats.md**: drop `merged: false` from checkpoint frontmatter template.
- **Pre-v2.2.0 legacy notes**: 4 skill files note that older vaults may carry `merged:` field; new flow ignores it.

### CLI v2.1.5

- **3-phase banner intro** — white CRT scan ↓ (hold 600ms), diagonal rainbow flow ↗, white shimmer ↗.
- **Rotating multi-sentence tagline** via wipe-swap — `Remembers You` → `Catches Insights` → `Thinking Partner`. Prefix neon cyan; trailing neon magenta during all sentences. Final lock shimmer sweeps the full tagline and burns the trailing magenta out to neon cyan; entire tagline settles cyan. Center alignment normalized at col 15.5 (border 26 dashes, art lead 5).
- **`doctor qmd-embeddings` advisory** — plain `doctor` no longer nudges toward `--fix`; `--fix` still embeds when invoked. New `advisory?: boolean` on internal Fix interface; `fixableCount` excludes advisory fixes.
- **CLI consistency** — `orphan-scan` and `validator.checkOrphanCheckpoints` drop the `merged:` filter to match the new skill behavior; `readMergedField` removed. Tests reframed (legacy `merged: true` now counts as orphan).
- **`doctor --fix` UI cleanup** — "Nothing to fix" renders flush-left after the closed `└` summary; multi-fix application opens its own `┌` box (new `barOpen` helper) for clean separation.

### CHANGELOG hygiene

- Tightened CLI v2.1.5 to 7 single-line bullets.
- Tightened plugin v2.2.0 to 6 single-line bullets.
- Tightened legacy CLI v2.1.0 from 10 → 6 bullets to comply with the 8-bullet limit.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun test` — 232/232 pass
- [x] `bunx biome check .` — exit 0 (style warnings only, all pre-existing pattern)
- [x] 3 parallel sub-agent reviews (pre-redesign) — verdict: ship it
- [x] 3 parallel sub-agent reviews (post-redesign) — verdict: ship it (3 nits applied)
- [x] CHANGELOG / PLUGIN-CHANGELOG audited — every entry ≤ 8 bullets
- [ ] Visual confirmation of new banner animation in a true-color terminal
- [ ] Verify PostCompact auto-wrapup writes session log on next compact event in production vault

## Migration notes

A vault upgrading from plugin v2.1.x → v2.2.0 may have leftover checkpoint files with `merged: true` from the legacy flow. The new flow treats them as unmerged orphans; the next `/wrapup` (Step 1b orphan recovery) will pick them up by token, write a recovered session log, and delete them. Self-cleaning, no manual action required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)