### PR TITLE
chore: migrate to onebrain-ai org (CLI v2.1.7, plugin v2.2.2)

### DIFF
--- a/.claude/plugins/onebrain/.claude-plugin/plugin.json
+++ b/.claude/plugins/onebrain/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "onebrain",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "OneBrain — Where human and AI thinking become one. A powerful thinking partner powered by AI synergy.",
   "author": {
     "name": "OneBrain Contributors"

--- a/.claude/plugins/onebrain/skills/update/SKILL.md
+++ b/.claude/plugins/onebrain/skills/update/SKILL.md
@@ -16,11 +16,11 @@ Update OneBrain system files from GitHub to the latest version.
    - `next` → `next`
    - `N.x` (e.g. `1.x`, `2.x`) → `N.x`
 3. Read new version from repo's `plugin.json` on the mapped branch using `WebFetch` — never use `git` commands (they hang on Windows waiting for credentials):
-   `https://raw.githubusercontent.com/kengio/onebrain/{branch}/.claude/plugins/onebrain/.claude-plugin/plugin.json`
+   `https://raw.githubusercontent.com/onebrain-ai/onebrain/{branch}/.claude/plugins/onebrain/.claude-plugin/plugin.json`
    where `{branch}` is the mapped branch from step 2.
    Parse the `version` field from the JSON response.
 4. If equal → say: ✅ Already up to date — v{X.X.X}. and stop
-5. If newer → WebFetch `https://raw.githubusercontent.com/kengio/onebrain/{branch}/PLUGIN-CHANGELOG.md`; display before proceeding (do not skip or summarize):
+5. If newer → WebFetch `https://raw.githubusercontent.com/onebrain-ai/onebrain/{branch}/PLUGIN-CHANGELOG.md`; display before proceeding (do not skip or summarize):
 
    ```
    ──────────────────────────────────────────────────────────────
@@ -68,14 +68,14 @@ After confirming the vault update (step 7 above), also check if the installed `o
 Skills are markdown instructions — the agent can read the new SKILL.md from GitHub and
 follow it as instructions in the same conversation. No re-invoke needed.
 
-GitHub raw URL template: `https://raw.githubusercontent.com/kengio/onebrain/{branch}/.claude/plugins/onebrain/{path}`
+GitHub raw URL template: `https://raw.githubusercontent.com/onebrain-ai/onebrain/{branch}/.claude/plugins/onebrain/{path}`
 where `{branch}` is the branch mapped from `update_channel` in step 2 of Version Check.
 
 Steps:
 1. **Early bootstrap — download the latest SKILL.md:**
    Use WebFetch + Write to download this file from GitHub and write to vault. `{vault_root}` = the vault's absolute path (the current working directory — the directory containing `.claude/`).
 
-   Raw URL: `https://raw.githubusercontent.com/kengio/onebrain/{branch}/.claude/plugins/onebrain/{path}`
+   Raw URL: `https://raw.githubusercontent.com/onebrain-ai/onebrain/{branch}/.claude/plugins/onebrain/{path}`
 
    Download and write:
    - `skills/update/SKILL.md`
@@ -88,7 +88,7 @@ Steps:
       and `[agent_folder]/context/` → `[archive_folder]/05-agent/context.YYYY-MM-DD/` (if context/ exists)
    b. Sync remaining files — run these two sub-steps in parallel, then clean cache after both complete:
       - **Full vault sync:** run `onebrain vault-sync "$PWD" --branch {branch}`. Downloads the full GitHub tarball, syncs plugin folder (with stale file cleanup), copies README.md/CONTRIBUTING.md/CHANGELOG.md/PLUGIN-CHANGELOG.md to vault root (overwrite), merges CLAUDE.md/GEMINI.md/AGENTS.md (vault is primary; injects new repo `@` imports only), pins plugin to vault, and clears plugin cache.
-      - **Settings merge:** WebFetch `https://raw.githubusercontent.com/kengio/onebrain/{branch}/.claude/settings.json`, then merge into `[vault]/.claude/settings.json`. Merge strategy (never overwrite, always additive): `permissions.allow` → union; `enabledPlugins` → merge keys (skip `onebrain@kengio` — repo-dev-only key, not valid in vault context); `extraKnownMarketplaces` → skip (repo-dev-only config, not valid in vault context); `hooks` → skip (handled by migration Step 6).
+      - **Settings merge:** WebFetch `https://raw.githubusercontent.com/onebrain-ai/onebrain/{branch}/.claude/settings.json`, then merge into `[vault]/.claude/settings.json`. Merge strategy (never overwrite, always additive): `permissions.allow` → union; `enabledPlugins` → merge keys (skip any `onebrain@*` key whose marketplace points to a `directory` source — repo-dev-only, not valid in vault context); `extraKnownMarketplaces` → skip (repo-dev-only config, not valid in vault context); `hooks` → skip (handled by migration Step 6).
    c. Once all step 3b sub-steps are complete, load `[vault]/.claude/plugins/onebrain/skills/update/references/migration-steps.md` and run all 8 migration steps
    d. Bump `plugin.json` version to `{new}` (last — completion signal; do not bump early)
 4. Write migration log to `[logs_folder]/YYYY/MM/YYYY-MM-DD-update-vX.X.X.md`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-latest_version: 2.1.6
+latest_version: 2.1.7
 released: 2026-04-30
 ---
 
@@ -12,6 +12,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 > For plugin changes (skills, agents, hooks, INSTRUCTIONS), see [PLUGIN-CHANGELOG.md](PLUGIN-CHANGELOG.md).
 
 ## [Unreleased]
+
+## v2.1.7 — chore: migrate to onebrain-ai org
+
+- chore: GitHub repo transferred from `kengio/onebrain` to `onebrain-ai/onebrain` — npm `@onebrain-ai/cli` package unchanged
+- chore(package.json): update `homepage`, `repository.url`, `bugs` URLs to new org
+- chore(postinstall): release binary download URL points to onebrain-ai/onebrain
+- chore(vault-sync): tarball API URL + extracted folder prefix (`onebrain-ai-onebrain-<sha>`) updated; tests aligned
+- chore(update): `GITHUB_REPO` constant points to onebrain-ai org
+- chore(README): badge URLs updated to new org
+- note: existing GitHub URLs auto-redirect — no breaking change for users with current install
 
 ## v2.1.6 — fix: drop PostCompact hook; trust Stop hook threshold
 

--- a/PLUGIN-CHANGELOG.md
+++ b/PLUGIN-CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-latest_version: 2.2.1
+latest_version: 2.2.2
 released: 2026-04-30
 ---
 
@@ -12,6 +12,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 > For CLI binary changes, see [CHANGELOG.md](CHANGELOG.md).
 
 ## [Unreleased]
+
+## v2.2.2 — chore: migrate to onebrain-ai org
+
+- chore(/update SKILL): raw GitHub URL templates updated to `onebrain-ai/onebrain` for plugin file fetches
+- chore(plugin.json): version bump aligned with CLI v2.1.7 org migration
+- note: existing vaults still work via GitHub auto-redirect; `/update` will pick up new URLs going forward
 
 ## v2.2.1 — fix: align with CLI v2.1.6 (Stop-hook-only)
 

--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/kengio/onebrain/releases"><img src="https://img.shields.io/badge/dynamic/json?url=https://raw.githubusercontent.com/kengio/onebrain/main/.claude/plugins/onebrain/.claude-plugin/plugin.json&query=%24.version&label=version&style=flat-square&color=blue" alt="Version" /></a>
-  <a href="LICENSE"><img src="https://img.shields.io/github/license/kengio/onebrain?style=flat-square" alt="License" /></a>
-  <a href="https://github.com/kengio/onebrain/stargazers"><img src="https://img.shields.io/github/stars/kengio/onebrain?style=flat-square" alt="GitHub Stars" /></a>
-  <a href="https://github.com/kengio/onebrain/commits/main"><img src="https://img.shields.io/github/last-commit/kengio/onebrain?style=flat-square" alt="Last Commit" /></a>
+  <a href="https://github.com/onebrain-ai/onebrain/releases"><img src="https://img.shields.io/badge/dynamic/json?url=https://raw.githubusercontent.com/onebrain-ai/onebrain/main/.claude/plugins/onebrain/.claude-plugin/plugin.json&query=%24.version&label=version&style=flat-square&color=blue" alt="Version" /></a>
+  <a href="LICENSE"><img src="https://img.shields.io/github/license/onebrain-ai/onebrain?style=flat-square" alt="License" /></a>
+  <a href="https://github.com/onebrain-ai/onebrain/stargazers"><img src="https://img.shields.io/github/stars/onebrain-ai/onebrain?style=flat-square" alt="GitHub Stars" /></a>
+  <a href="https://github.com/onebrain-ai/onebrain/commits/main"><img src="https://img.shields.io/github/last-commit/onebrain-ai/onebrain?style=flat-square" alt="Last Commit" /></a>
 </p>
 
 <h1 align="center">OneBrain</h1>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onebrain-ai/cli",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "description": "CLI for OneBrain — personal AI OS for Obsidian with persistent memory, 24+ skills, and Claude Code integration",
   "keywords": [
     "onebrain",
@@ -15,12 +15,12 @@
     "productivity",
     "vault"
   ],
-  "homepage": "https://github.com/kengio/onebrain",
+  "homepage": "https://github.com/onebrain-ai/onebrain",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/kengio/onebrain.git"
+    "url": "git+https://github.com/onebrain-ai/onebrain.git"
   },
-  "bugs": "https://github.com/kengio/onebrain/issues",
+  "bugs": "https://github.com/onebrain-ai/onebrain/issues",
   "license": "MIT",
   "type": "module",
   "bin": {

--- a/src/commands/internal/vault-sync.test.ts
+++ b/src/commands/internal/vault-sync.test.ts
@@ -30,7 +30,7 @@ interface TarballOpts {
 /**
  * Build a minimal fake tarball (.tar.gz) using the tar CLI.
  * Layout mirrors a real GitHub archive:
- *   kengio-onebrain-<sha>/
+ *   onebrain-ai-onebrain-<sha>/
  *     .claude/plugins/onebrain/.claude-plugin/plugin.json
  *     .claude/plugins/onebrain/INSTRUCTIONS.md
  *     .claude/plugins/onebrain/skills/example/SKILL.md
@@ -38,7 +38,7 @@ interface TarballOpts {
  *     CLAUDE.md  GEMINI.md  AGENTS.md
  */
 function buildMockTarball(opts: TarballOpts = {}): Buffer {
-  const prefix = opts.prefix ?? 'kengio-onebrain-abc1234';
+  const prefix = opts.prefix ?? 'onebrain-ai-onebrain-abc1234';
   const version = opts.pluginVersion ?? '1.11.0';
 
   const files: Record<string, string> = {

--- a/src/commands/internal/vault-sync.ts
+++ b/src/commands/internal/vault-sync.ts
@@ -88,7 +88,7 @@ async function downloadTarball(
   branch: string,
   fetchFn: typeof fetch,
 ): Promise<{ tarball: ArrayBuffer; tmpDir: string }> {
-  const url = `https://api.github.com/repos/kengio/onebrain/tarball/${branch}`;
+  const url = `https://api.github.com/repos/onebrain-ai/onebrain/tarball/${branch}`;
   const response = await fetchFn(url);
   if (!response.ok) {
     const hints: Partial<Record<number, string>> = {
@@ -126,7 +126,7 @@ async function extractTarball(tarball: ArrayBuffer, destDir: string): Promise<st
   // Delete the tarball file now we've extracted
   await unlink(tarPath);
 
-  // Find the top-level directory (should be kengio-onebrain-<sha>/)
+  // Find the top-level directory (should be onebrain-ai-onebrain-<sha>/)
   const entries = await readdir(destDir);
   const topLevel = entries.find((e) => e !== 'bundle.tar.gz');
   if (!topLevel) {
@@ -649,7 +649,7 @@ export async function runVaultSync(
       // Keep 'unknown'
     }
 
-    stopSpinner(`kengio/onebrain@${branch} (v${result.version})`);
+    stopSpinner(`onebrain-ai/onebrain@${branch} (v${result.version})`);
 
     // ── Step 2: Sync plugin files ─────────────────────────────────────────
     startSpinner('📂', 'Syncing files');

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -50,7 +50,7 @@ export interface UpdateResult {
 // Constants
 // ---------------------------------------------------------------------------
 
-const GITHUB_REPO = 'https://api.github.com/repos/kengio/onebrain';
+const GITHUB_REPO = 'https://api.github.com/repos/onebrain-ai/onebrain';
 const GITHUB_RELEASES_URL = `${GITHUB_REPO}/releases/latest`;
 
 // ---------------------------------------------------------------------------

--- a/src/scripts/postinstall.ts
+++ b/src/scripts/postinstall.ts
@@ -122,7 +122,7 @@ async function main(): Promise<void> {
   }
 
   const destPath = join(__dirname, 'onebrain');
-  const url = `https://github.com/kengio/onebrain/releases/download/v${version}/${binaryName}`;
+  const url = `https://github.com/onebrain-ai/onebrain/releases/download/v${version}/${binaryName}`;
 
   process.stdout.write(`[onebrain] Downloading ${binaryName} v${version}…\n`);
 


### PR DESCRIPTION
## Summary

GitHub repo transferred from `kengio/onebrain` to `onebrain-ai/onebrain`. This PR updates all hardcoded references that GitHub's auto-redirect doesn't transparently cover (npm metadata, source code constants, CHANGELOG cross-links, README badges) and bumps versions on both tracks.

- CLI **v2.1.6 → v2.1.7** — `package.json` URLs, postinstall release URL, `vault-sync` tarball API + folder prefix (`onebrain-ai-onebrain-<sha>`), `update.ts` GITHUB_REPO constant, test fixtures
- Plugin **v2.2.1 → v2.2.2** — `/update` SKILL.md raw URL templates (5 occurrences), `plugin.json` version, generalized stale `enabledPlugins` skip rule (was hardcoded `onebrain@kengio`)
- README — 4 badge URLs

## Why

Hardcoded `kengio/onebrain` in source files would silently rely on GitHub's auto-redirect indefinitely. Updating eliminates the redirect dependency and keeps tooling (npm, install scripts, vault-sync) pointing at the canonical source.

## Marketplace key — no change

Verified `.claude-plugin/marketplace.json.name = "onebrain"` — Claude Code reads the friendly name from this manifest, not from the GitHub owner. Existing users keep `onebrain@onebrain` working; new users adding `/plugin marketplace add onebrain-ai/onebrain` also resolve to the same key. No breaking change for users.

## Test plan

- [x] `bunx tsc --noEmit` — clean
- [x] `bun test src/commands/internal/vault-sync.test.ts` — 13/13 pass
- [x] `bun test` (full suite) — 228/228 pass
- [x] `grep -rn "kengio/onebrain"` excluding CHANGELOG history — empty
- [x] Live tarball probe `curl -sIL https://api.github.com/repos/onebrain-ai/onebrain/tarball/main` — 302 → codeload (expected)
- [x] Manual 3-round review (subagents hit org's monthly usage limit; manual review passed)

## Migration safety

- GitHub auto-redirects all old `kengio/onebrain` URLs (issues, raw, API, tarball) so existing `git remote`, installed CLI, and vaults with old `extraKnownMarketplaces.onebrain.source.repo: kengio/onebrain` keep working.
- npm package `@onebrain-ai/cli` unchanged — no reinstall needed.
- After merge: tag `v2.1.7`, publish CLI to npm, run `/update` in vaults to pick up new SKILL.md URL templates.