### PR TITLE
chore: point npm homepage to onebrain.run (CLI v2.1.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-latest_version: 2.1.7
+latest_version: 2.1.8
 released: 2026-04-30
 ---
 
@@ -12,6 +12,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 > For plugin changes (skills, agents, hooks, INSTRUCTIONS), see [PLUGIN-CHANGELOG.md](PLUGIN-CHANGELOG.md).
 
 ## [Unreleased]
+
+## v2.1.8 — chore: point npm `homepage` to onebrain.run
+
+- chore(package.json): `homepage` field updated from `github.com/onebrain-ai/onebrain` → `https://onebrain.run` so npm registry links to the marketing site
+- note: `repository.url` and `bugs` still point to GitHub (correct for npm metadata)
 
 ## v2.1.7 — chore: migrate to onebrain-ai org
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onebrain-ai/cli",
-  "version": "2.1.7",
+  "version": "2.1.8",
   "description": "CLI for OneBrain — personal AI OS for Obsidian with persistent memory, 24+ skills, and Claude Code integration",
   "keywords": [
     "onebrain",
@@ -15,7 +15,7 @@
     "productivity",
     "vault"
   ],
-  "homepage": "https://github.com/onebrain-ai/onebrain",
+  "homepage": "https://onebrain.run",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/onebrain-ai/onebrain.git"


### PR DESCRIPTION
## Summary

- Update `package.json` `homepage` field: `github.com/onebrain-ai/onebrain` → `https://onebrain.run`
- Bump CLI version `2.1.7` → `2.1.8`
- CHANGELOG entry under v2.1.8

## Why

After registering `onebrain.run` and shipping the marketing landing page, the npm registry's "Homepage" link (visible at https://www.npmjs.com/package/@onebrain-ai/cli) should point to the public marketing site, not the GitHub repo. The `repository` and `bugs` fields still point to GitHub — they describe source location and issue tracker, which are correctly the GitHub repo.

## Verification

- `bunx tsc --noEmit` clean
- `bun test` 228/228 pass
- Diff: 2 files (package.json + CHANGELOG.md), +8 -3

## Test plan

- [ ] CI passes (typecheck + test)
- [ ] After merge: tag pushed, npm release workflow publishes v2.1.8
- [ ] Verify https://www.npmjs.com/package/@onebrain-ai/cli "Homepage" → onebrain.run