### PR TITLE
fix(orphan-scan): inject now: Date to decouple tests from wall clock

### DIFF
--- a/src/commands/internal/orphan-scan.test.ts
+++ b/src/commands/internal/orphan-scan.test.ts
@@ -18,6 +18,7 @@ import { runOrphanScan } from './orphan-scan.js';
 // All other time-dependent values must derive from PINNED_NOW or be hardcoded.
 // ---------------------------------------------------------------------------
 
+// 12:00Z is mid-day in UTC — safe across all real-world TZs (≥12h from any local midnight).
 const PINNED_NOW = new Date('2026-05-15T12:00:00Z');
 const TODAY = '2026-05-15';
 const THIS_YEAR = '2026';

--- a/src/commands/internal/orphan-scan.test.ts
+++ b/src/commands/internal/orphan-scan.test.ts
@@ -54,18 +54,11 @@ async function makeMonthDir(logsDir: string, year: string, month: string): Promi
   return dir;
 }
 
-/**
- * Return a 2-digit day-of-month string that's guaranteed not to match today.
- * runOrphanScan skips checkpoints whose date === today (active-session guard),
- * so any test pinning a checkpoint to today's day would silently see 0 orphans
- * and fail. If the preferred day collides with today, shift by +14 (still
- * within month bounds for our usage range of 1–6).
- */
-function safeDay(preferred: number): string {
-  const today = new Date().getDate();
-  const day = preferred === today ? preferred + 14 : preferred;
-  return String(day).padStart(2, '0');
-}
+// A past day-of-month in this month that's guaranteed not to match today.
+// runOrphanScan skips checkpoints dated today (active-session guard), so a
+// fixture pinned to today's day silently sees 0 orphans. Day 01 works except
+// when today *is* day 01, in which case use day 15.
+const SAFE_DAY = String(new Date().getDate() === 1 ? 15 : 1).padStart(2, '0');
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -99,7 +92,7 @@ describe('runOrphanScan', () => {
     // One orphan — verifies the shape is { orphan_count: 1 }
     const { thisYear, thisMonth } = getMonthParts();
     const monthDir = await makeMonthDir(logsDir, thisYear, thisMonth);
-    const pastDate = `${thisYear}-${thisMonth}-${safeDay(1)}`;
+    const pastDate = `${thisYear}-${thisMonth}-${SAFE_DAY}`;
     await writeFile(
       join(monthDir, `${pastDate}-snaptoken-checkpoint-01.md`),
       '---\ntags: [checkpoint]\nmerged: false\n---\n\nContent.',
@@ -123,7 +116,7 @@ describe('runOrphanScan', () => {
   it('counts legacy checkpoint with merged: true as an orphan', async () => {
     const { thisYear, thisMonth } = getMonthParts();
     const monthDir = await makeMonthDir(logsDir, thisYear, thisMonth);
-    const pastDate = `${thisYear}-${thisMonth}-${safeDay(1)}`;
+    const pastDate = `${thisYear}-${thisMonth}-${SAFE_DAY}`;
     const fname = checkpointName(pastDate, 'token11', 1);
     await writeFile(join(monthDir, fname), checkpointFrontmatter(true), 'utf8');
     const result = await runOrphanScan(logsDir, 'current99');
@@ -133,7 +126,7 @@ describe('runOrphanScan', () => {
   it('counts legacy checkpoint with merged: "true" (quoted string) as an orphan', async () => {
     const { thisYear, thisMonth } = getMonthParts();
     const monthDir = await makeMonthDir(logsDir, thisYear, thisMonth);
-    const pastDate = `${thisYear}-${thisMonth}-${safeDay(1)}`;
+    const pastDate = `${thisYear}-${thisMonth}-${SAFE_DAY}`;
     const fname = checkpointName(pastDate, 'tokenStrTrue', 1);
     const content = `---\ntags: [checkpoint, session-log]\ndate: ${pastDate}\ncheckpoint: 01\ntrigger: stop\nmerged: "true"\n---\n\n## What We Worked On\n\nTest content.`;
     await writeFile(join(monthDir, fname), content, 'utf8');
@@ -144,7 +137,7 @@ describe('runOrphanScan', () => {
   it('skips checkpoint files matching current session token', async () => {
     const { thisYear, thisMonth } = getMonthParts();
     const monthDir = await makeMonthDir(logsDir, thisYear, thisMonth);
-    const pastDate = `${thisYear}-${thisMonth}-${safeDay(1)}`;
+    const pastDate = `${thisYear}-${thisMonth}-${SAFE_DAY}`;
     const fname = checkpointName(pastDate, 'current99', 1);
     await writeFile(join(monthDir, fname), checkpointFrontmatter(false), 'utf8');
     const result = await runOrphanScan(logsDir, 'current99');
@@ -154,7 +147,7 @@ describe('runOrphanScan', () => {
   it('skips checkpoint when a manual (non-auto-saved) session log exists for that date', async () => {
     const { thisYear, thisMonth } = getMonthParts();
     const monthDir = await makeMonthDir(logsDir, thisYear, thisMonth);
-    const pastDate = `${thisYear}-${thisMonth}-${safeDay(2)}`;
+    const pastDate = `${thisYear}-${thisMonth}-${SAFE_DAY}`;
     // Write checkpoint (unmerged)
     const cpName = checkpointName(pastDate, 'tokenAA', 1);
     await writeFile(join(monthDir, cpName), checkpointFrontmatter(false), 'utf8');
@@ -168,7 +161,7 @@ describe('runOrphanScan', () => {
   it('does NOT skip when only auto-saved session log exists for that date', async () => {
     const { thisYear, thisMonth } = getMonthParts();
     const monthDir = await makeMonthDir(logsDir, thisYear, thisMonth);
-    const pastDate = `${thisYear}-${thisMonth}-${safeDay(3)}`;
+    const pastDate = `${thisYear}-${thisMonth}-${SAFE_DAY}`;
     // Write checkpoint (unmerged)
     const cpName = checkpointName(pastDate, 'tokenBB', 1);
     await writeFile(join(monthDir, cpName), checkpointFrontmatter(false), 'utf8');
@@ -182,7 +175,7 @@ describe('runOrphanScan', () => {
   it('counts unmerged orphan checkpoints from current month', async () => {
     const { thisYear, thisMonth } = getMonthParts();
     const monthDir = await makeMonthDir(logsDir, thisYear, thisMonth);
-    const pastDate = `${thisYear}-${thisMonth}-${safeDay(4)}`;
+    const pastDate = `${thisYear}-${thisMonth}-${SAFE_DAY}`;
     // Two different tokens
     for (const token of ['tokenCC', 'tokenDD']) {
       const cpName = checkpointName(pastDate, token, 1);
@@ -205,7 +198,7 @@ describe('runOrphanScan', () => {
   it('multiple checkpoints for same token in same month count as one orphan session', async () => {
     const { thisYear, thisMonth } = getMonthParts();
     const monthDir = await makeMonthDir(logsDir, thisYear, thisMonth);
-    const pastDate = `${thisYear}-${thisMonth}-${safeDay(5)}`;
+    const pastDate = `${thisYear}-${thisMonth}-${SAFE_DAY}`;
     // Same token, two checkpoint files
     for (let i = 1; i <= 2; i++) {
       const cpName = checkpointName(pastDate, 'tokenFF', i);
@@ -219,7 +212,7 @@ describe('runOrphanScan', () => {
   it('handles files with missing frontmatter gracefully (counts as orphan)', async () => {
     const { thisYear, thisMonth } = getMonthParts();
     const monthDir = await makeMonthDir(logsDir, thisYear, thisMonth);
-    const pastDate = `${thisYear}-${thisMonth}-${safeDay(6)}`;
+    const pastDate = `${thisYear}-${thisMonth}-${SAFE_DAY}`;
     const cpName = checkpointName(pastDate, 'tokenGG', 1);
     await writeFile(join(monthDir, cpName), '# No frontmatter here\n\nContent.', 'utf8');
     const result = await runOrphanScan(logsDir, 'current99');
@@ -245,21 +238,14 @@ describe('runOrphanScan', () => {
     const todayFname = checkpointName(todayStr, 'todaytoken', 1);
     await writeFile(join(monthDir, todayFname), checkpointFrontmatter(false), 'utf8');
 
-    // Past date in same month: day 01 (safe to use if today isn't day 01)
-    const todayDay = new Date().getDate();
-    if (todayDay !== 1) {
-      const pastDate = `${thisYear}-${thisMonth}-${safeDay(1)}`;
-      const pastFname = checkpointName(pastDate, 'pasttoken', 1);
-      await writeFile(join(monthDir, pastFname), checkpointFrontmatter(false), 'utf8');
+    // Past date in same month — SAFE_DAY is guaranteed != today
+    const pastDate = `${thisYear}-${thisMonth}-${SAFE_DAY}`;
+    const pastFname = checkpointName(pastDate, 'pasttoken', 1);
+    await writeFile(join(monthDir, pastFname), checkpointFrontmatter(false), 'utf8');
 
-      const result = await runOrphanScan(logsDir, 'current99');
-      // today skipped, past counted
-      expect(result).toEqual({ orphan_count: 1 });
-    } else {
-      // If today IS day 01, just verify today is skipped
-      const result = await runOrphanScan(logsDir, 'current99');
-      expect(result).toEqual({ orphan_count: 0 });
-    }
+    const result = await runOrphanScan(logsDir, 'current99');
+    // today skipped, past counted
+    expect(result).toEqual({ orphan_count: 1 });
   });
 
   it('combines orphans from both months in total count', async () => {
@@ -268,7 +254,7 @@ describe('runOrphanScan', () => {
     const thisMonthDir = await makeMonthDir(logsDir, thisYear, thisMonth);
     const prevMonthDir = await makeMonthDir(logsDir, prevYear, prevMonth);
 
-    const thisDate = `${thisYear}-${thisMonth}-07`;
+    const thisDate = `${thisYear}-${thisMonth}-${SAFE_DAY}`;
     const prevDate = `${prevYear}-${prevMonth}-20`;
 
     await writeFile(

--- a/src/commands/internal/orphan-scan.test.ts
+++ b/src/commands/internal/orphan-scan.test.ts
@@ -54,6 +54,19 @@ async function makeMonthDir(logsDir: string, year: string, month: string): Promi
   return dir;
 }
 
+/**
+ * Return a 2-digit day-of-month string that's guaranteed not to match today.
+ * runOrphanScan skips checkpoints whose date === today (active-session guard),
+ * so any test pinning a checkpoint to today's day would silently see 0 orphans
+ * and fail. If the preferred day collides with today, shift by +14 (still
+ * within month bounds for our usage range of 1–6).
+ */
+function safeDay(preferred: number): string {
+  const today = new Date().getDate();
+  const day = preferred === today ? preferred + 14 : preferred;
+  return String(day).padStart(2, '0');
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -86,7 +99,7 @@ describe('runOrphanScan', () => {
     // One orphan — verifies the shape is { orphan_count: 1 }
     const { thisYear, thisMonth } = getMonthParts();
     const monthDir = await makeMonthDir(logsDir, thisYear, thisMonth);
-    const pastDate = `${thisYear}-${thisMonth}-01`;
+    const pastDate = `${thisYear}-${thisMonth}-${safeDay(1)}`;
     await writeFile(
       join(monthDir, `${pastDate}-snaptoken-checkpoint-01.md`),
       '---\ntags: [checkpoint]\nmerged: false\n---\n\nContent.',
@@ -110,7 +123,7 @@ describe('runOrphanScan', () => {
   it('counts legacy checkpoint with merged: true as an orphan', async () => {
     const { thisYear, thisMonth } = getMonthParts();
     const monthDir = await makeMonthDir(logsDir, thisYear, thisMonth);
-    const pastDate = `${thisYear}-${thisMonth}-01`;
+    const pastDate = `${thisYear}-${thisMonth}-${safeDay(1)}`;
     const fname = checkpointName(pastDate, 'token11', 1);
     await writeFile(join(monthDir, fname), checkpointFrontmatter(true), 'utf8');
     const result = await runOrphanScan(logsDir, 'current99');
@@ -120,7 +133,7 @@ describe('runOrphanScan', () => {
   it('counts legacy checkpoint with merged: "true" (quoted string) as an orphan', async () => {
     const { thisYear, thisMonth } = getMonthParts();
     const monthDir = await makeMonthDir(logsDir, thisYear, thisMonth);
-    const pastDate = `${thisYear}-${thisMonth}-01`;
+    const pastDate = `${thisYear}-${thisMonth}-${safeDay(1)}`;
     const fname = checkpointName(pastDate, 'tokenStrTrue', 1);
     const content = `---\ntags: [checkpoint, session-log]\ndate: ${pastDate}\ncheckpoint: 01\ntrigger: stop\nmerged: "true"\n---\n\n## What We Worked On\n\nTest content.`;
     await writeFile(join(monthDir, fname), content, 'utf8');
@@ -131,7 +144,7 @@ describe('runOrphanScan', () => {
   it('skips checkpoint files matching current session token', async () => {
     const { thisYear, thisMonth } = getMonthParts();
     const monthDir = await makeMonthDir(logsDir, thisYear, thisMonth);
-    const pastDate = `${thisYear}-${thisMonth}-01`;
+    const pastDate = `${thisYear}-${thisMonth}-${safeDay(1)}`;
     const fname = checkpointName(pastDate, 'current99', 1);
     await writeFile(join(monthDir, fname), checkpointFrontmatter(false), 'utf8');
     const result = await runOrphanScan(logsDir, 'current99');
@@ -141,7 +154,7 @@ describe('runOrphanScan', () => {
   it('skips checkpoint when a manual (non-auto-saved) session log exists for that date', async () => {
     const { thisYear, thisMonth } = getMonthParts();
     const monthDir = await makeMonthDir(logsDir, thisYear, thisMonth);
-    const pastDate = `${thisYear}-${thisMonth}-02`;
+    const pastDate = `${thisYear}-${thisMonth}-${safeDay(2)}`;
     // Write checkpoint (unmerged)
     const cpName = checkpointName(pastDate, 'tokenAA', 1);
     await writeFile(join(monthDir, cpName), checkpointFrontmatter(false), 'utf8');
@@ -155,7 +168,7 @@ describe('runOrphanScan', () => {
   it('does NOT skip when only auto-saved session log exists for that date', async () => {
     const { thisYear, thisMonth } = getMonthParts();
     const monthDir = await makeMonthDir(logsDir, thisYear, thisMonth);
-    const pastDate = `${thisYear}-${thisMonth}-03`;
+    const pastDate = `${thisYear}-${thisMonth}-${safeDay(3)}`;
     // Write checkpoint (unmerged)
     const cpName = checkpointName(pastDate, 'tokenBB', 1);
     await writeFile(join(monthDir, cpName), checkpointFrontmatter(false), 'utf8');
@@ -169,7 +182,7 @@ describe('runOrphanScan', () => {
   it('counts unmerged orphan checkpoints from current month', async () => {
     const { thisYear, thisMonth } = getMonthParts();
     const monthDir = await makeMonthDir(logsDir, thisYear, thisMonth);
-    const pastDate = `${thisYear}-${thisMonth}-04`;
+    const pastDate = `${thisYear}-${thisMonth}-${safeDay(4)}`;
     // Two different tokens
     for (const token of ['tokenCC', 'tokenDD']) {
       const cpName = checkpointName(pastDate, token, 1);
@@ -192,7 +205,7 @@ describe('runOrphanScan', () => {
   it('multiple checkpoints for same token in same month count as one orphan session', async () => {
     const { thisYear, thisMonth } = getMonthParts();
     const monthDir = await makeMonthDir(logsDir, thisYear, thisMonth);
-    const pastDate = `${thisYear}-${thisMonth}-05`;
+    const pastDate = `${thisYear}-${thisMonth}-${safeDay(5)}`;
     // Same token, two checkpoint files
     for (let i = 1; i <= 2; i++) {
       const cpName = checkpointName(pastDate, 'tokenFF', i);
@@ -206,7 +219,7 @@ describe('runOrphanScan', () => {
   it('handles files with missing frontmatter gracefully (counts as orphan)', async () => {
     const { thisYear, thisMonth } = getMonthParts();
     const monthDir = await makeMonthDir(logsDir, thisYear, thisMonth);
-    const pastDate = `${thisYear}-${thisMonth}-06`;
+    const pastDate = `${thisYear}-${thisMonth}-${safeDay(6)}`;
     const cpName = checkpointName(pastDate, 'tokenGG', 1);
     await writeFile(join(monthDir, cpName), '# No frontmatter here\n\nContent.', 'utf8');
     const result = await runOrphanScan(logsDir, 'current99');
@@ -235,7 +248,7 @@ describe('runOrphanScan', () => {
     // Past date in same month: day 01 (safe to use if today isn't day 01)
     const todayDay = new Date().getDate();
     if (todayDay !== 1) {
-      const pastDate = `${thisYear}-${thisMonth}-01`;
+      const pastDate = `${thisYear}-${thisMonth}-${safeDay(1)}`;
       const pastFname = checkpointName(pastDate, 'pasttoken', 1);
       await writeFile(join(monthDir, pastFname), checkpointFrontmatter(false), 'utf8');
 

--- a/src/commands/internal/orphan-scan.test.ts
+++ b/src/commands/internal/orphan-scan.test.ts
@@ -6,6 +6,28 @@ import { join } from 'node:path';
 import { runOrphanScan } from './orphan-scan.js';
 
 // ---------------------------------------------------------------------------
+// Pinned clock
+//
+// runOrphanScan reads "today" from an injected `now: Date`. Tests must pass
+// PINNED_NOW (or another explicit Date) so behavior never depends on the wall
+// clock — fixture day numbers were silently colliding with the active-session
+// guard whenever today's day matched a hardcoded fixture day.
+//
+// RULE: Do not call `new Date()` (no args) or `Date.now()` in this file.
+// `new Date('<literal ISO string>')` is fine — it's deterministic.
+// All other time-dependent values must derive from PINNED_NOW or be hardcoded.
+// ---------------------------------------------------------------------------
+
+const PINNED_NOW = new Date('2026-05-15T12:00:00Z');
+const TODAY = '2026-05-15';
+const THIS_YEAR = '2026';
+const THIS_MONTH = '05';
+const PREV_YEAR = '2026';
+const PREV_MONTH = '04';
+const PAST_DATE = '2026-05-01'; // any day in current month != TODAY
+const PREV_DATE = '2026-04-15';
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
@@ -13,39 +35,20 @@ async function makeTmpDir(): Promise<string> {
   return mkdtemp(join(tmpdir(), 'onebrain-os-test-'));
 }
 
-/**
- * Build a checkpoint filename: YYYY-MM-DD-{token}-checkpoint-{NN}.md
- */
 function checkpointName(date: string, token: string, nn: number): string {
   return `${date}-${token}-checkpoint-${String(nn).padStart(2, '0')}.md`;
 }
 
-/**
- * Build a session log filename: YYYY-MM-DD-session-{NN}.md
- */
 function sessionLogName(date: string, nn: number): string {
   return `${date}-session-${String(nn).padStart(2, '0')}.md`;
 }
 
-function checkpointFrontmatter(merged: boolean): string {
-  return `---\ntags: [checkpoint, session-log]\ndate: ${new Date().toISOString().slice(0, 10)}\ncheckpoint: 01\ntrigger: stop\nmerged: ${merged}\n---\n\n## What We Worked On\n\nTest content.`;
+function checkpointFrontmatter(merged: boolean, date = PAST_DATE): string {
+  return `---\ntags: [checkpoint, session-log]\ndate: ${date}\ncheckpoint: 01\ntrigger: stop\nmerged: ${merged}\n---\n\n## What We Worked On\n\nTest content.`;
 }
 
 function sessionLogFrontmatter(autoSaved: boolean): string {
-  return `---\ntags: [session-log]\ndate: 2026-04-20\nauto-saved: ${autoSaved}\n---\n\n## Session\n\nTest.`;
-}
-
-/**
- * Get current and previous month dirs as { thisYear, thisMonth, prevYear, prevMonth }
- */
-function getMonthParts() {
-  const now = new Date();
-  const thisYear = String(now.getFullYear());
-  const thisMonth = String(now.getMonth() + 1).padStart(2, '0');
-  const prevDate = new Date(now.getFullYear(), now.getMonth() - 1, 1);
-  const prevYear = String(prevDate.getFullYear());
-  const prevMonth = String(prevDate.getMonth() + 1).padStart(2, '0');
-  return { thisYear, thisMonth, prevYear, prevMonth };
+  return `---\ntags: [session-log]\ndate: ${PAST_DATE}\nauto-saved: ${autoSaved}\n---\n\n## Session\n\nTest.`;
 }
 
 async function makeMonthDir(logsDir: string, year: string, month: string): Promise<string> {
@@ -54,11 +57,9 @@ async function makeMonthDir(logsDir: string, year: string, month: string): Promi
   return dir;
 }
 
-// A past day-of-month in this month that's guaranteed not to match today.
-// runOrphanScan skips checkpoints dated today (active-session guard), so a
-// fixture pinned to today's day silently sees 0 orphans. Day 01 works except
-// when today *is* day 01, in which case use day 15.
-const SAFE_DAY = String(new Date().getDate() === 1 ? 15 : 1).padStart(2, '0');
+async function makeThisMonthDir(logsDir: string): Promise<string> {
+  return makeMonthDir(logsDir, THIS_YEAR, THIS_MONTH);
+}
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -79,31 +80,29 @@ describe('runOrphanScan', () => {
   });
 
   it('returns orphan_count: 0 when no checkpoint files exist', async () => {
-    const result = await runOrphanScan(logsDir, 'abc12345');
+    const result = await runOrphanScan(logsDir, 'abc12345', PINNED_NOW);
     expect(result).toEqual({ orphan_count: 0 });
   });
 
   // Update snapshots: bun test --update-snapshots
   it('output shape matches snapshot { orphan_count: N }', async () => {
     // Zero orphans — verifies the shape is { orphan_count: 0 }
-    const zeroResult = await runOrphanScan(logsDir, 'abc12345');
+    const zeroResult = await runOrphanScan(logsDir, 'abc12345', PINNED_NOW);
     expect(zeroResult).toMatchSnapshot();
 
     // One orphan — verifies the shape is { orphan_count: 1 }
-    const { thisYear, thisMonth } = getMonthParts();
-    const monthDir = await makeMonthDir(logsDir, thisYear, thisMonth);
-    const pastDate = `${thisYear}-${thisMonth}-${SAFE_DAY}`;
+    const monthDir = await makeThisMonthDir(logsDir);
     await writeFile(
-      join(monthDir, `${pastDate}-snaptoken-checkpoint-01.md`),
+      join(monthDir, `${PAST_DATE}-snaptoken-checkpoint-01.md`),
       '---\ntags: [checkpoint]\nmerged: false\n---\n\nContent.',
       'utf8',
     );
-    const oneResult = await runOrphanScan(logsDir, 'differenttoken');
+    const oneResult = await runOrphanScan(logsDir, 'differenttoken', PINNED_NOW);
     expect(oneResult).toMatchSnapshot();
   });
 
   it('returns orphan_count: 0 when logs folder does not exist', async () => {
-    const result = await runOrphanScan(join(tmpDir, 'nonexistent'), 'abc12345');
+    const result = await runOrphanScan(join(tmpDir, 'nonexistent'), 'abc12345', PINNED_NOW);
     expect(result).toEqual({ orphan_count: 0 });
   });
 
@@ -114,161 +113,147 @@ describe('runOrphanScan', () => {
   // that suppresses an orphan is a manual session log for that date or the
   // current session token match.
   it('counts legacy checkpoint with merged: true as an orphan', async () => {
-    const { thisYear, thisMonth } = getMonthParts();
-    const monthDir = await makeMonthDir(logsDir, thisYear, thisMonth);
-    const pastDate = `${thisYear}-${thisMonth}-${SAFE_DAY}`;
-    const fname = checkpointName(pastDate, 'token11', 1);
+    const monthDir = await makeThisMonthDir(logsDir);
+    const fname = checkpointName(PAST_DATE, 'token11', 1);
     await writeFile(join(monthDir, fname), checkpointFrontmatter(true), 'utf8');
-    const result = await runOrphanScan(logsDir, 'current99');
+    const result = await runOrphanScan(logsDir, 'current99', PINNED_NOW);
     expect(result).toEqual({ orphan_count: 1 });
   });
 
   it('counts legacy checkpoint with merged: "true" (quoted string) as an orphan', async () => {
-    const { thisYear, thisMonth } = getMonthParts();
-    const monthDir = await makeMonthDir(logsDir, thisYear, thisMonth);
-    const pastDate = `${thisYear}-${thisMonth}-${SAFE_DAY}`;
-    const fname = checkpointName(pastDate, 'tokenStrTrue', 1);
-    const content = `---\ntags: [checkpoint, session-log]\ndate: ${pastDate}\ncheckpoint: 01\ntrigger: stop\nmerged: "true"\n---\n\n## What We Worked On\n\nTest content.`;
+    const monthDir = await makeThisMonthDir(logsDir);
+    const fname = checkpointName(PAST_DATE, 'tokenStrTrue', 1);
+    const content = `---\ntags: [checkpoint, session-log]\ndate: ${PAST_DATE}\ncheckpoint: 01\ntrigger: stop\nmerged: "true"\n---\n\n## What We Worked On\n\nTest content.`;
     await writeFile(join(monthDir, fname), content, 'utf8');
-    const result = await runOrphanScan(logsDir, 'current99');
+    const result = await runOrphanScan(logsDir, 'current99', PINNED_NOW);
     expect(result).toEqual({ orphan_count: 1 });
   });
 
   it('skips checkpoint files matching current session token', async () => {
-    const { thisYear, thisMonth } = getMonthParts();
-    const monthDir = await makeMonthDir(logsDir, thisYear, thisMonth);
-    const pastDate = `${thisYear}-${thisMonth}-${SAFE_DAY}`;
-    const fname = checkpointName(pastDate, 'current99', 1);
+    const monthDir = await makeThisMonthDir(logsDir);
+    const fname = checkpointName(PAST_DATE, 'current99', 1);
     await writeFile(join(monthDir, fname), checkpointFrontmatter(false), 'utf8');
-    const result = await runOrphanScan(logsDir, 'current99');
+    const result = await runOrphanScan(logsDir, 'current99', PINNED_NOW);
     expect(result).toEqual({ orphan_count: 0 });
   });
 
   it('skips checkpoint when a manual (non-auto-saved) session log exists for that date', async () => {
-    const { thisYear, thisMonth } = getMonthParts();
-    const monthDir = await makeMonthDir(logsDir, thisYear, thisMonth);
-    const pastDate = `${thisYear}-${thisMonth}-${SAFE_DAY}`;
-    // Write checkpoint (unmerged)
-    const cpName = checkpointName(pastDate, 'tokenAA', 1);
+    const monthDir = await makeThisMonthDir(logsDir);
+    const cpName = checkpointName(PAST_DATE, 'tokenAA', 1);
     await writeFile(join(monthDir, cpName), checkpointFrontmatter(false), 'utf8');
-    // Write manual session log (auto-saved: false)
-    const logName = sessionLogName(pastDate, 1);
+    const logName = sessionLogName(PAST_DATE, 1);
     await writeFile(join(monthDir, logName), sessionLogFrontmatter(false), 'utf8');
-    const result = await runOrphanScan(logsDir, 'current99');
+    const result = await runOrphanScan(logsDir, 'current99', PINNED_NOW);
     expect(result).toEqual({ orphan_count: 0 });
   });
 
   it('does NOT skip when only auto-saved session log exists for that date', async () => {
-    const { thisYear, thisMonth } = getMonthParts();
-    const monthDir = await makeMonthDir(logsDir, thisYear, thisMonth);
-    const pastDate = `${thisYear}-${thisMonth}-${SAFE_DAY}`;
-    // Write checkpoint (unmerged)
-    const cpName = checkpointName(pastDate, 'tokenBB', 1);
+    const monthDir = await makeThisMonthDir(logsDir);
+    const cpName = checkpointName(PAST_DATE, 'tokenBB', 1);
     await writeFile(join(monthDir, cpName), checkpointFrontmatter(false), 'utf8');
-    // Write auto-saved session log
-    const logName = sessionLogName(pastDate, 1);
+    const logName = sessionLogName(PAST_DATE, 1);
     await writeFile(join(monthDir, logName), sessionLogFrontmatter(true), 'utf8');
-    const result = await runOrphanScan(logsDir, 'current99');
+    const result = await runOrphanScan(logsDir, 'current99', PINNED_NOW);
     expect(result).toEqual({ orphan_count: 1 });
   });
 
   it('counts unmerged orphan checkpoints from current month', async () => {
-    const { thisYear, thisMonth } = getMonthParts();
-    const monthDir = await makeMonthDir(logsDir, thisYear, thisMonth);
-    const pastDate = `${thisYear}-${thisMonth}-${SAFE_DAY}`;
-    // Two different tokens
+    const monthDir = await makeThisMonthDir(logsDir);
     for (const token of ['tokenCC', 'tokenDD']) {
-      const cpName = checkpointName(pastDate, token, 1);
+      const cpName = checkpointName(PAST_DATE, token, 1);
       await writeFile(join(monthDir, cpName), checkpointFrontmatter(false), 'utf8');
     }
-    const result = await runOrphanScan(logsDir, 'current99');
+    const result = await runOrphanScan(logsDir, 'current99', PINNED_NOW);
     expect(result).toEqual({ orphan_count: 2 });
   });
 
   it('counts orphans from previous month dir', async () => {
-    const { prevYear, prevMonth } = getMonthParts();
-    const monthDir = await makeMonthDir(logsDir, prevYear, prevMonth);
-    const pastDate = `${prevYear}-${prevMonth}-15`;
-    const cpName = checkpointName(pastDate, 'tokenEE', 1);
-    await writeFile(join(monthDir, cpName), checkpointFrontmatter(false), 'utf8');
-    const result = await runOrphanScan(logsDir, 'current99');
+    const monthDir = await makeMonthDir(logsDir, PREV_YEAR, PREV_MONTH);
+    const cpName = checkpointName(PREV_DATE, 'tokenEE', 1);
+    await writeFile(join(monthDir, cpName), checkpointFrontmatter(false, PREV_DATE), 'utf8');
+    const result = await runOrphanScan(logsDir, 'current99', PINNED_NOW);
     expect(result).toEqual({ orphan_count: 1 });
   });
 
   it('multiple checkpoints for same token in same month count as one orphan session', async () => {
-    const { thisYear, thisMonth } = getMonthParts();
-    const monthDir = await makeMonthDir(logsDir, thisYear, thisMonth);
-    const pastDate = `${thisYear}-${thisMonth}-${SAFE_DAY}`;
-    // Same token, two checkpoint files
+    const monthDir = await makeThisMonthDir(logsDir);
     for (let i = 1; i <= 2; i++) {
-      const cpName = checkpointName(pastDate, 'tokenFF', i);
+      const cpName = checkpointName(PAST_DATE, 'tokenFF', i);
       await writeFile(join(monthDir, cpName), checkpointFrontmatter(false), 'utf8');
     }
-    const result = await runOrphanScan(logsDir, 'current99');
-    // One token = one orphan session
+    const result = await runOrphanScan(logsDir, 'current99', PINNED_NOW);
     expect(result).toEqual({ orphan_count: 1 });
   });
 
   it('handles files with missing frontmatter gracefully (counts as orphan)', async () => {
-    const { thisYear, thisMonth } = getMonthParts();
-    const monthDir = await makeMonthDir(logsDir, thisYear, thisMonth);
-    const pastDate = `${thisYear}-${thisMonth}-${SAFE_DAY}`;
-    const cpName = checkpointName(pastDate, 'tokenGG', 1);
+    const monthDir = await makeThisMonthDir(logsDir);
+    const cpName = checkpointName(PAST_DATE, 'tokenGG', 1);
     await writeFile(join(monthDir, cpName), '# No frontmatter here\n\nContent.', 'utf8');
-    const result = await runOrphanScan(logsDir, 'current99');
+    const result = await runOrphanScan(logsDir, 'current99', PINNED_NOW);
     expect(result).toEqual({ orphan_count: 1 });
   });
 
   it("creates a checkpoint file with today's actual date → orphan_count: 0 (today boundary skipped)", async () => {
-    const { thisYear, thisMonth } = getMonthParts();
-    const monthDir = await makeMonthDir(logsDir, thisYear, thisMonth);
-    const todayStr = `${thisYear}-${thisMonth}-${String(new Date().getDate()).padStart(2, '0')}`;
-    const fname = checkpointName(todayStr, 'todaytoken', 1);
-    await writeFile(join(monthDir, fname), checkpointFrontmatter(false), 'utf8');
-    const result = await runOrphanScan(logsDir, 'current99');
-    // Today's checkpoints must be skipped — not orphans yet
+    const monthDir = await makeThisMonthDir(logsDir);
+    const fname = checkpointName(TODAY, 'todaytoken', 1);
+    await writeFile(join(monthDir, fname), checkpointFrontmatter(false, TODAY), 'utf8');
+    const result = await runOrphanScan(logsDir, 'current99', PINNED_NOW);
     expect(result).toEqual({ orphan_count: 0 });
   });
 
   it("today's file skipped but a past date in same month still counted", async () => {
-    const { thisYear, thisMonth } = getMonthParts();
-    const monthDir = await makeMonthDir(logsDir, thisYear, thisMonth);
-    const todayStr = `${thisYear}-${thisMonth}-${String(new Date().getDate()).padStart(2, '0')}`;
-    // Today: should be skipped
-    const todayFname = checkpointName(todayStr, 'todaytoken', 1);
-    await writeFile(join(monthDir, todayFname), checkpointFrontmatter(false), 'utf8');
-
-    // Past date in same month — SAFE_DAY is guaranteed != today
-    const pastDate = `${thisYear}-${thisMonth}-${SAFE_DAY}`;
-    const pastFname = checkpointName(pastDate, 'pasttoken', 1);
+    const monthDir = await makeThisMonthDir(logsDir);
+    const todayFname = checkpointName(TODAY, 'todaytoken', 1);
+    await writeFile(join(monthDir, todayFname), checkpointFrontmatter(false, TODAY), 'utf8');
+    const pastFname = checkpointName(PAST_DATE, 'pasttoken', 1);
     await writeFile(join(monthDir, pastFname), checkpointFrontmatter(false), 'utf8');
-
-    const result = await runOrphanScan(logsDir, 'current99');
-    // today skipped, past counted
+    const result = await runOrphanScan(logsDir, 'current99', PINNED_NOW);
     expect(result).toEqual({ orphan_count: 1 });
   });
 
   it('combines orphans from both months in total count', async () => {
-    const { thisYear, thisMonth, prevYear, prevMonth } = getMonthParts();
-
-    const thisMonthDir = await makeMonthDir(logsDir, thisYear, thisMonth);
-    const prevMonthDir = await makeMonthDir(logsDir, prevYear, prevMonth);
-
-    const thisDate = `${thisYear}-${thisMonth}-${SAFE_DAY}`;
-    const prevDate = `${prevYear}-${prevMonth}-20`;
+    const thisMonthDir = await makeThisMonthDir(logsDir);
+    const prevMonthDir = await makeMonthDir(logsDir, PREV_YEAR, PREV_MONTH);
 
     await writeFile(
-      join(thisMonthDir, checkpointName(thisDate, 'tokenHH', 1)),
+      join(thisMonthDir, checkpointName(PAST_DATE, 'tokenHH', 1)),
       checkpointFrontmatter(false),
       'utf8',
     );
     await writeFile(
-      join(prevMonthDir, checkpointName(prevDate, 'tokenII', 1)),
-      checkpointFrontmatter(false),
+      join(prevMonthDir, checkpointName(PREV_DATE, 'tokenII', 1)),
+      checkpointFrontmatter(false, PREV_DATE),
       'utf8',
     );
 
-    const result = await runOrphanScan(logsDir, 'current99');
+    const result = await runOrphanScan(logsDir, 'current99', PINNED_NOW);
     expect(result).toEqual({ orphan_count: 2 });
+  });
+
+  // Regression guard: proves the suite is wall-clock-independent.
+  // Same fixture file, three different injected `now` values, three
+  // different outcomes — confirms the today-skip is driven by the
+  // injected clock, not by `new Date()` leaking in.
+  it('today-skip is driven by injected `now`, not by wall-clock', async () => {
+    const monthDir = await makeThisMonthDir(logsDir);
+    const fixtureDate = '2026-05-10';
+    const fname = checkpointName(fixtureDate, 'reg-token', 1);
+    await writeFile(join(monthDir, fname), checkpointFrontmatter(false, fixtureDate), 'utf8');
+
+    // now = May 10 → fixture date == today → skipped
+    const sameDay = await runOrphanScan(logsDir, 'current99', new Date('2026-05-10T12:00:00Z'));
+    expect(sameDay).toEqual({ orphan_count: 0 });
+
+    // now = May 15 → fixture is a past date → counted
+    const laterSameMonth = await runOrphanScan(
+      logsDir,
+      'current99',
+      new Date('2026-05-15T12:00:00Z'),
+    );
+    expect(laterSameMonth).toEqual({ orphan_count: 1 });
+
+    // now = June 5 → fixture is in previous month → still counted
+    const nextMonth = await runOrphanScan(logsDir, 'current99', new Date('2026-06-05T12:00:00Z'));
+    expect(nextMonth).toEqual({ orphan_count: 1 });
   });
 });

--- a/src/commands/internal/orphan-scan.ts
+++ b/src/commands/internal/orphan-scan.ts
@@ -164,13 +164,15 @@ async function scanMonthDir(
  * Core logic for orphan-scan.
  * @param logsFolder - absolute path to logs folder
  * @param sessionToken - current session token to exclude
- * @param now - clock injection for tests; defaults to wall-clock `new Date()`
+ * @param now - reference time used for the today-skip and prev-month math.
+ *   Required (no default) so tests can't silently leak the wall clock by
+ *   forgetting to pass it; production callers pass `new Date()` explicitly.
  * @returns OrphanScanResult
  */
 export async function runOrphanScan(
   logsFolder: string,
   sessionToken: string,
-  now: Date = new Date(),
+  now: Date,
 ): Promise<OrphanScanResult> {
   const today = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
   const { thisYear, thisMonth, prevYear, prevMonth } = getMonthParts(now);
@@ -200,6 +202,6 @@ export async function runOrphanScan(
  * Run orphan-scan as a CLI command: print JSON to stdout, always exit 0.
  */
 export async function orphanScanCommand(logsFolder: string, sessionToken: string): Promise<void> {
-  const result = await runOrphanScan(logsFolder, sessionToken);
+  const result = await runOrphanScan(logsFolder, sessionToken, new Date());
   process.stdout.write(`${JSON.stringify(result)}\n`);
 }

--- a/src/commands/internal/orphan-scan.ts
+++ b/src/commands/internal/orphan-scan.ts
@@ -164,15 +164,16 @@ async function scanMonthDir(
  * Core logic for orphan-scan.
  * @param logsFolder - absolute path to logs folder
  * @param sessionToken - current session token to exclude
+ * @param now - clock injection for tests; defaults to wall-clock `new Date()`
  * @returns OrphanScanResult
  */
 export async function runOrphanScan(
   logsFolder: string,
   sessionToken: string,
+  now: Date = new Date(),
 ): Promise<OrphanScanResult> {
-  const now = new Date();
   const today = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
-  const { thisYear, thisMonth, prevYear, prevMonth } = getMonthParts();
+  const { thisYear, thisMonth, prevYear, prevMonth } = getMonthParts(now);
 
   const monthDirs: Array<{ year: string; month: string }> = [
     { year: thisYear, month: thisMonth },


### PR DESCRIPTION
## Summary

Fixes the failing CI test `runOrphanScan > counts unmerged orphan checkpoints from current month` that has been blocking PR #137.

## Root cause

`runOrphanScan` reads the wall clock to skip checkpoints dated today (active-session guard). The test wrote a fixture with hardcoded day `-04` in the filename. On May 4, the fixture's date matched today → guard skipped it → assertion failed.

Five other tests in the same file had the same hardcoded-day pattern (`-01` through `-06`) — each a latent bomb that fires once a month when today's day matches. The bug had been silently dormant until today's CI run.

## Fix

Introduces dependency injection: `runOrphanScan(logsFolder, sessionToken, now: Date)`. `now` is **required** (no default) so a forgotten clock argument becomes a compile error rather than a silent wall-clock leak. Production caller `orphanScanCommand` passes `new Date()` explicitly.

Tests pin the clock with `PINNED_NOW = new Date('2026-05-15T12:00:00Z')` (mid-day in UTC = ≥12h from any local midnight, stable across timezones). All fixture dates are now literal strings — no math, no collision logic.

## Anti-recurrence

- Compile-time enforcement via required `now` parameter.
- Top-of-file rule banning bare `new Date()` / `Date.now()` in the test file.
- New regression test `today-skip is driven by injected now, not by wall-clock` runs the same fixture against three different injected dates and asserts the outcomes diverge — proves a future contributor cannot silently re-introduce wall-clock coupling without breaking this test.

## Out-of-scope follow-ups

Similar wall-clock patterns flagged in round-3 review (separate PRs):
- `src/commands/internal/session-init.ts:109,275` — `new Date()` reads
- `src/commands/internal/migrate.ts:92` — `new Date().toISOString()` read

## Test plan

- [x] Failing test passes locally (`bun test src/commands/internal/orphan-scan.test.ts`)
- [x] Full suite: 229 pass, 0 fail (228 prior + 1 new regression test)
- [x] `bun run typecheck` clean
- [x] `bunx biome check` clean
- [ ] CI green on this PR
- [ ] PR #137 re-runs green after this merges