### PR TITLE
docs: position OneBrain as the Harness OS + add architecture diagram

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,8 @@ Good contributions include:
 - New slash commands (skills)
 - New background agents (focused autonomous tasks dispatched by skills)
 - Improvements to existing skills — clearer instructions, better prompts, edge case handling
-- Bug fixes in install scripts
+- Fixes to the `onebrain` CLI binary (TypeScript / Bun source under `src/`)
+- New harness adapters (instruction file + tool-name reference for an additional AI harness)
 - README and documentation improvements
 
 ## Project Structure
@@ -46,17 +47,21 @@ Skills are plain Markdown files. The AI reads them at runtime — no compilation
 
 ## Multi-Harness Support
 
-OneBrain runs on three AI harnesses. Each has a root entrypoint file that loads harness-specific context before delegating to the shared INSTRUCTIONS.md:
+OneBrain is harness-agnostic — it ships entrypoint files for the major AI harnesses, plus a generic `AGENTS.md` for everything else. Each entrypoint loads harness-specific context before delegating to the shared `INSTRUCTIONS.md`:
 
 | File | Harness | Loads |
 |---|---|---|
-| `CLAUDE.md` | Claude Code | `INSTRUCTIONS.md` directly |
+| `CLAUDE.md` | Claude Code *(reference harness)* | `INSTRUCTIONS.md` directly |
 | `GEMINI.md` | Gemini CLI | `references/gemini-tools.md` → `INSTRUCTIONS.md` |
-| `AGENTS.md` | Codex CLI | `references/codex-tools.md` → `INSTRUCTIONS.md` |
+| `AGENTS.md` | OpenAI Codex · Qwen Code · any AGENTS-spec harness | `references/codex-tools.md` → `INSTRUCTIONS.md` |
+
+Users can also drive any of the above with a different LLM behind it (local via litellm/ollama proxy, or any cloud BYOK). See [README → The Harness OS Architecture](README.md#the-harness-os-architecture) for the user-facing flow.
 
 **INSTRUCTIONS.md is harness-neutral** — it uses Claude Code tool names throughout. The `references/` files translate those names to each harness's equivalents.
 
 When editing INSTRUCTIONS.md or skills, use Claude Code tool names (`Read`, `Write`, `Edit`, `Bash`, `Agent`, etc.) — the harness mapping handles translation automatically.
+
+**Adding a new harness:** create a root entrypoint file (e.g. `MYHARNESS.md`) that points to `INSTRUCTIONS.md`, plus an optional `references/myharness-tools.md` for tool-name remapping. Update the table above and the install matrix in `README.md`.
 
 ## Skills vs Agents — When to Use Which
 
@@ -226,12 +231,15 @@ MEMORY-INDEX.md must be kept in sync at all times. Every skill that creates, upd
 - Update → update row Description and Type columns if changed
 - After any change: set MEMORY-INDEX.md frontmatter `updated:` to today
 
-## Install Scripts
+## Vault Bootstrap
 
-- [`install.sh`](install.sh) — bash, targets macOS and Linux
-- [`install.ps1`](install.ps1) — PowerShell 5+, targets Windows
+Vault setup is owned by the `onebrain` CLI binary (`src/`), **not** by shell scripts in this repo. The user flow is:
 
-Both scripts download the repo tarball, extract it, remove themselves from the vault, and install community plugins. Keep them simple — vault setup belongs in `/onboarding`, not here.
+1. `npm install -g @onebrain-ai/cli` — installs the CLI globally
+2. `onebrain init` — in a new or existing folder, writes `vault.yml`, scaffolds the 8 standard folders, downloads the latest plugin bundle, installs the recommended Obsidian community plugins, and registers Stop / PostCompact hooks. Aborts safely if a `vault.yml` already exists
+3. `/onboarding` — inside the chosen harness, personalises identity + active projects
+
+There are no `install.sh` or `install.ps1` scripts to maintain — the equivalent logic lives in the CLI's `init` and `update` commands and ships with each release. Bug fixes for vault bootstrap belong in `src/commands/init.ts` and `src/commands/update.ts`.
 
 ## Pull Request Guidelines
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,66 @@ Unlike chat-based AI tools, OneBrain lives in plain Markdown files you own forev
 - **Human → Agent** — Every preference, decision, and correction becomes persistent memory. The agent calibrates to you with every interaction.
 - **Agent → Human** — Captures, classifies, links, and synthesizes the noise of your day — so your attention stays on what only you can do.
 
-**Works with:** Claude Code · Gemini CLI · any agent that reads Markdown
+**Harness-agnostic** — Claude Code · Gemini CLI · OpenAI Codex · Qwen · or BYO LLM via API key. [See the architecture ↓](#the-harness-os-architecture)
+
+---
+
+## The Harness OS Architecture
+
+OneBrain doesn't compete with Claude Code, Gemini CLI, or any other AI harness. It sits **underneath them** — the OS layer that keeps your context, memory, and skills consistent no matter which harness you're driving.
+
+<p align="center">
+  <img alt="OneBrain Harness OS — 5-layer architecture: Obsidian Vault, OneBrain Plugin, OneBrain CLI, Harness, LLM" src="assets/diagrams/harness-os-stack.svg" width="780">
+</p>
+
+| # | Layer | Role | What lives here |
+|---|---|---|---|
+| 01 | **Obsidian Vault** | Cognitive interface | Plain Markdown — notes, memory, decisions, knowledge graph |
+| 02 | **OneBrain Plugin** | Skills + hooks | 24+ skills + lifecycle hooks, loaded into any harness |
+| 03 | **OneBrain CLI** | Harness orchestrator | Indexing, checkpoints, vault sync, harness routing |
+| 04 | **Harness** | Agentic runtime | Bring your own — Claude Code · Gemini CLI · Codex · Qwen · ... |
+| 05 | **LLM** | Intelligence source | Local (mlx, ollama) · cloud (claude, gemini, gpt) · raw API |
+
+The **Harness** layer is where most AI tools pick a fight with each other. We don't — pick whichever harness you love. By familiarity, by task, or by cost. Your vault stays the same.
+
+### Pick Your Harness
+
+Each harness reads OneBrain's instruction file automatically. Install it, run it inside your vault, and the plugin loads on first prompt.
+
+| Harness | Install | Run | Reads |
+|---|---|---|---|
+| **Claude Code** *(recommended)* | `npm install -g @anthropic-ai/claude-code` | `claude` | `CLAUDE.md` |
+| **Gemini CLI** | `npm install -g @google/gemini-cli` | `gemini` | `GEMINI.md` |
+| **OpenAI Codex** | `npm install -g @openai/codex` | `codex` | `AGENTS.md` |
+| **Qwen Code** | `npm install -g @qwen-code/qwen-code` | `qwen` | `AGENTS.md` |
+
+> Auto-checkpoint and the Stop hook are wired up for Claude Code today. The other harnesses get the rest of the skill surface (24+ commands) immediately, and gain hook coverage as upstream support lands.
+
+### Bring Your Own LLM (via Claude Code)
+
+Already love Claude Code? Use it as a universal frontend. Point `ANTHROPIC_BASE_URL` at any OpenAI-compatible endpoint — Claude Code stays the harness, the LLM behind it changes per task.
+
+```bash
+# Recommended: claude-code-router handles Anthropic ↔ provider translation
+npx @musistudio/claude-code-router          # interactive provider config
+
+# Direct: point ANTHROPIC_BASE_URL at any Anthropic-protocol endpoint
+export ANTHROPIC_BASE_URL=https://your-router-or-anthropic-compatible-host
+export ANTHROPIC_API_KEY=sk-byok-key
+cd vault && claude
+
+# Switch back to native Claude any time
+unset ANTHROPIC_BASE_URL ANTHROPIC_API_KEY
+claude
+```
+
+| Route | What it gets you |
+|---|---|
+| **Local** (mlx, ollama, llama.cpp) | Cost-free routine work, full privacy. Pair with [`litellm`](https://github.com/BerriAI/litellm) or [`claude-code-router`](https://github.com/musistudio/claude-code-router). |
+| **Cloud BYOK** (Claude, Gemini, GPT, Groq, OpenRouter) | Pay-as-you-go premium reasoning. One env-var swap, no code changes. |
+| **Hybrid** (route by task or by cost) | Cheap models for routine, premium when it counts. |
+
+Same vault. Same skills. Same memory. The LLM swaps; OneBrain doesn't notice.
 
 ---
 
@@ -57,7 +116,7 @@ OneBrain doesn't just store markdown. Every feature exists to make you and the a
 | 🖥️ | **Personal AI OS** | Full local stack: Claude Code + Obsidian + tmux + Telegram — no cloud infra needed |
 | ⚡ | **24+ Skills** | Braindump, research, consolidate, bookmark, import files, daily briefing, and more |
 | 📂 | **Vault-native Markdown** | Plain Markdown, no lock-in. Your data stays yours forever |
-| 🤖 | **Multi-agent** | Works with Claude Code, Gemini CLI, or any agent that reads Markdown |
+| 🔀 | **Multi-Harness OS** | Switch between Claude Code, Gemini CLI, Codex, Qwen, or BYO LLM — context never breaks. [See architecture ↑](#the-harness-os-architecture) |
 | 🔌 | **Zero Config** | Clone, open in Obsidian, run `/onboarding`. Ready in under 2 minutes |
 | 📓 | **Session Logs & Checkpoints** | Every conversation saved with summaries and action items. Auto-checkpoints fire every 15 messages or 30 min so nothing is lost mid-session *(auto-checkpoint requires Claude Code)* |
 | 💾 | **Auto Session Summary** | When you say "bye", the agent silently saves a complete session log — no `/wrapup` needed |
@@ -235,13 +294,7 @@ In Claude Code: `/onboarding`
 
 ---
 
-## Supported Agents
-
-| Agent | Instruction file | Setup |
-|-------|-----------------|-------|
-| Claude Code | `CLAUDE.md` | Loaded automatically |
-| Gemini CLI | `GEMINI.md` | Loaded automatically |
-| Any agent | `AGENTS.md` | Read manually or via system prompt |
+> **Choosing a harness?** See [The Harness OS Architecture ↑](#the-harness-os-architecture) for install commands per harness, BYO-LLM via Claude Code, and the full 5-layer stack.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -84,14 +84,16 @@ Already love Claude Code? Use it as a universal frontend. Point `ANTHROPIC_BASE_
 
 ```bash
 # Recommended: claude-code-router handles Anthropic ↔ provider translation
-npx @musistudio/claude-code-router          # interactive provider config
+npm install -g @musistudio/claude-code-router
+ccr code                                    # first-run config, then launches Claude Code via the router
+# (later) ccr stop                          # tear down the router before going native again
 
-# Direct: point ANTHROPIC_BASE_URL at any Anthropic-protocol endpoint
+# Or direct: point ANTHROPIC_BASE_URL at any Anthropic-protocol endpoint
 export ANTHROPIC_BASE_URL=https://your-router-or-anthropic-compatible-host
 export ANTHROPIC_API_KEY=sk-byok-key
 cd vault && claude
 
-# Switch back to native Claude any time
+# Switch back to native Claude any time (manual-export route)
 unset ANTHROPIC_BASE_URL ANTHROPIC_API_KEY
 claude
 ```

--- a/assets/diagrams/harness-os-stack.svg
+++ b/assets/diagrams/harness-os-stack.svg
@@ -1,0 +1,204 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 740" width="880" height="740" role="img" aria-labelledby="title desc" font-family="'Chakra Petch', 'Inter', ui-sans-serif, system-ui, sans-serif">
+  <title id="title">OneBrain Harness OS — 5-Layer Architecture</title>
+  <desc id="desc">Five stacked layers from top to bottom: Obsidian Vault (cognitive interface), OneBrain Plugin (skills and hooks), OneBrain CLI (harness orchestrator), Harness (Claude Code, Gemini CLI, Codex, Qwen), and LLM (local, cloud, or API).</desc>
+
+  <defs>
+    <linearGradient id="g-vault" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#00f3ff" stop-opacity="0.95"/>
+      <stop offset="100%" stop-color="#00f3ff" stop-opacity="0.05"/>
+    </linearGradient>
+    <linearGradient id="g-plugin" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#ff2d92" stop-opacity="0.95"/>
+      <stop offset="100%" stop-color="#ff2d92" stop-opacity="0.05"/>
+    </linearGradient>
+    <linearGradient id="g-cli" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#ffb000" stop-opacity="0.95"/>
+      <stop offset="100%" stop-color="#ffb000" stop-opacity="0.05"/>
+    </linearGradient>
+    <linearGradient id="g-harness" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#bc13fe" stop-opacity="0.95"/>
+      <stop offset="100%" stop-color="#bc13fe" stop-opacity="0.05"/>
+    </linearGradient>
+    <linearGradient id="g-llm" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#c8ff00" stop-opacity="0.95"/>
+      <stop offset="100%" stop-color="#c8ff00" stop-opacity="0.05"/>
+    </linearGradient>
+
+    <linearGradient id="block-fill" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0c0c18"/>
+      <stop offset="100%" stop-color="#06060d"/>
+    </linearGradient>
+
+    <linearGradient id="spine-grad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#00f3ff" stop-opacity="0.6"/>
+      <stop offset="25%" stop-color="#ff2d92" stop-opacity="0.6"/>
+      <stop offset="50%" stop-color="#ffb000" stop-opacity="0.6"/>
+      <stop offset="75%" stop-color="#bc13fe" stop-opacity="0.6"/>
+      <stop offset="100%" stop-color="#c8ff00" stop-opacity="0.6"/>
+    </linearGradient>
+
+    <pattern id="grid-pattern" width="40" height="40" patternUnits="userSpaceOnUse">
+      <path d="M 40 0 L 0 0 0 40" fill="none" stroke="#ffffff" stroke-width="0.5" opacity="0.04"/>
+    </pattern>
+
+    <filter id="soft-glow" x="-20%" y="-50%" width="140%" height="200%">
+      <feGaussianBlur stdDeviation="2" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+
+  <!-- Background -->
+  <rect width="880" height="740" fill="#050507"/>
+  <rect width="880" height="740" fill="url(#grid-pattern)"/>
+
+  <!-- HUD frame corners -->
+  <g stroke="rgba(255,255,255,0.18)" stroke-width="1" fill="none">
+    <path d="M 24 40 L 24 24 L 40 24"/>
+    <path d="M 840 24 L 856 24 L 856 40"/>
+    <path d="M 856 700 L 856 716 L 840 716"/>
+    <path d="M 40 716 L 24 716 L 24 700"/>
+  </g>
+
+  <!-- Top eyebrow row -->
+  <g font-family="'JetBrains Mono', ui-monospace, monospace" font-size="10" letter-spacing="0.3em" fill="rgba(255,255,255,0.45)">
+    <circle cx="44" cy="55" r="3" fill="#00f3ff"/>
+    <text x="56" y="59">ONEBRAIN // HARNESS_OS_STACK</text>
+    <text x="836" y="59" text-anchor="end">ARCH_v1.0 · 05_LAYERS</text>
+  </g>
+
+  <!-- Section divider line under header -->
+  <line x1="24" y1="78" x2="856" y2="78" stroke="rgba(255,255,255,0.08)" stroke-width="1"/>
+
+  <!-- Top side label: INTERFACE -->
+  <g font-family="'Chakra Petch', sans-serif" font-weight="700" font-size="11" letter-spacing="0.25em" fill="rgba(255,255,255,0.55)">
+    <text x="56" y="100">↑ INTERFACE · WHERE YOU WORK</text>
+  </g>
+
+  <!-- Vertical accent spine running through all layers -->
+  <line x1="48" y1="110" x2="48" y2="660" stroke="url(#spine-grad)" stroke-width="2" stroke-dasharray="2 4" opacity="0.55"/>
+
+  <!-- ════════ LAYER 01 — OBSIDIAN VAULT ════════ -->
+  <g transform="translate(60, 110)">
+    <rect width="780" height="100" fill="url(#block-fill)" stroke="#00f3ff" stroke-opacity="0.35" stroke-width="1"/>
+    <rect width="780" height="3" fill="url(#g-vault)" filter="url(#soft-glow)"/>
+    <!-- accent corner glyphs -->
+    <path d="M 0 0 L 14 0 M 0 0 L 0 14" stroke="#00f3ff" stroke-width="1.5" fill="none"/>
+    <path d="M 766 100 L 780 100 M 780 86 L 780 100" stroke="#00f3ff" stroke-width="1.5" fill="none"/>
+    <!-- left index -->
+    <text x="22" y="34" font-family="'JetBrains Mono', monospace" font-size="11" font-weight="700" fill="#00f3ff" letter-spacing="0.08em">LAYER_01</text>
+    <text x="22" y="64" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="22" fill="#ffffff" letter-spacing="0.04em">OBSIDIAN VAULT</text>
+    <text x="22" y="80" font-family="'JetBrains Mono', monospace" font-size="9" fill="#00f3ff" letter-spacing="0.3em">COGNITIVE_INTERFACE</text>
+    <!-- description (right block) -->
+    <text x="320" y="50" font-family="'JetBrains Mono', monospace" font-size="11" fill="rgba(255,255,255,0.7)" letter-spacing="0.02em">Plain Markdown — your single source of truth.</text>
+    <text x="320" y="68" font-family="'JetBrains Mono', monospace" font-size="11" fill="rgba(255,255,255,0.5)">Notes · memory · decisions · knowledge graph</text>
+    <!-- right tag chip -->
+    <g transform="translate(640, 38)">
+      <rect width="124" height="22" fill="rgba(0,243,255,0.08)" stroke="#00f3ff" stroke-opacity="0.4" stroke-width="1"/>
+      <text x="62" y="15" font-family="'JetBrains Mono', monospace" font-size="9" fill="#00f3ff" letter-spacing="0.18em" text-anchor="middle">USER_FACING</text>
+    </g>
+  </g>
+
+  <!-- flow arrow between 01 and 02 -->
+  <g transform="translate(440, 213)" opacity="0.5">
+    <line x1="0" y1="0" x2="0" y2="8" stroke="rgba(255,255,255,0.5)" stroke-width="1"/>
+    <path d="M -3 6 L 0 10 L 3 6" fill="none" stroke="rgba(255,255,255,0.6)" stroke-width="1"/>
+  </g>
+
+  <!-- ════════ LAYER 02 — ONEBRAIN PLUGIN ════════ -->
+  <g transform="translate(60, 226)">
+    <rect width="780" height="100" fill="url(#block-fill)" stroke="#ff2d92" stroke-opacity="0.35" stroke-width="1"/>
+    <rect width="780" height="3" fill="url(#g-plugin)" filter="url(#soft-glow)"/>
+    <path d="M 0 0 L 14 0 M 0 0 L 0 14" stroke="#ff2d92" stroke-width="1.5" fill="none"/>
+    <path d="M 766 100 L 780 100 M 780 86 L 780 100" stroke="#ff2d92" stroke-width="1.5" fill="none"/>
+    <text x="22" y="34" font-family="'JetBrains Mono', monospace" font-size="11" font-weight="700" fill="#ff2d92" letter-spacing="0.08em">LAYER_02</text>
+    <text x="22" y="64" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="22" fill="#ffffff" letter-spacing="0.04em">ONEBRAIN PLUGIN</text>
+    <text x="22" y="80" font-family="'JetBrains Mono', monospace" font-size="9" fill="#ff2d92" letter-spacing="0.3em">SKILLS_AND_HOOKS</text>
+    <text x="320" y="50" font-family="'JetBrains Mono', monospace" font-size="11" fill="rgba(255,255,255,0.7)">24+ skills + lifecycle hooks. Loaded into any harness.</text>
+    <text x="320" y="68" font-family="'JetBrains Mono', monospace" font-size="11" fill="rgba(255,255,255,0.5)">braindump · capture · research · distill · doctor · ...</text>
+    <g transform="translate(640, 38)">
+      <rect width="124" height="22" fill="rgba(255,45,146,0.08)" stroke="#ff2d92" stroke-opacity="0.4" stroke-width="1"/>
+      <text x="62" y="15" font-family="'JetBrains Mono', monospace" font-size="9" fill="#ff2d92" letter-spacing="0.18em" text-anchor="middle">BEHAVIOR_DEF</text>
+    </g>
+  </g>
+
+  <g transform="translate(440, 329)" opacity="0.5">
+    <line x1="0" y1="0" x2="0" y2="8" stroke="rgba(255,255,255,0.5)" stroke-width="1"/>
+    <path d="M -3 6 L 0 10 L 3 6" fill="none" stroke="rgba(255,255,255,0.6)" stroke-width="1"/>
+  </g>
+
+  <!-- ════════ LAYER 03 — ONEBRAIN CLI ════════ -->
+  <g transform="translate(60, 342)">
+    <rect width="780" height="100" fill="url(#block-fill)" stroke="#ffb000" stroke-opacity="0.35" stroke-width="1"/>
+    <rect width="780" height="3" fill="url(#g-cli)" filter="url(#soft-glow)"/>
+    <path d="M 0 0 L 14 0 M 0 0 L 0 14" stroke="#ffb000" stroke-width="1.5" fill="none"/>
+    <path d="M 766 100 L 780 100 M 780 86 L 780 100" stroke="#ffb000" stroke-width="1.5" fill="none"/>
+    <text x="22" y="34" font-family="'JetBrains Mono', monospace" font-size="11" font-weight="700" fill="#ffb000" letter-spacing="0.08em">LAYER_03</text>
+    <text x="22" y="64" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="22" fill="#ffffff" letter-spacing="0.04em">ONEBRAIN CLI</text>
+    <text x="22" y="80" font-family="'JetBrains Mono', monospace" font-size="9" fill="#ffb000" letter-spacing="0.3em">HARNESS_ORCHESTRATOR</text>
+    <text x="320" y="50" font-family="'JetBrains Mono', monospace" font-size="11" fill="rgba(255,255,255,0.7)">Vault sync · indexing · checkpoints · routing.</text>
+    <text x="320" y="68" font-family="'JetBrains Mono', monospace" font-size="11" fill="rgba(255,255,255,0.5)">The OS that keeps every harness on the same page.</text>
+    <g transform="translate(640, 38)">
+      <rect width="124" height="22" fill="rgba(255,176,0,0.08)" stroke="#ffb000" stroke-opacity="0.4" stroke-width="1"/>
+      <text x="62" y="15" font-family="'JetBrains Mono', monospace" font-size="9" fill="#ffb000" letter-spacing="0.18em" text-anchor="middle">CONTEXT_BRIDGE</text>
+    </g>
+  </g>
+
+  <g transform="translate(440, 445)" opacity="0.5">
+    <line x1="0" y1="0" x2="0" y2="8" stroke="rgba(255,255,255,0.5)" stroke-width="1"/>
+    <path d="M -3 6 L 0 10 L 3 6" fill="none" stroke="rgba(255,255,255,0.6)" stroke-width="1"/>
+  </g>
+
+  <!-- ════════ LAYER 04 — HARNESS ════════ -->
+  <g transform="translate(60, 458)">
+    <rect width="780" height="100" fill="url(#block-fill)" stroke="#bc13fe" stroke-opacity="0.35" stroke-width="1"/>
+    <rect width="780" height="3" fill="url(#g-harness)" filter="url(#soft-glow)"/>
+    <path d="M 0 0 L 14 0 M 0 0 L 0 14" stroke="#bc13fe" stroke-width="1.5" fill="none"/>
+    <path d="M 766 100 L 780 100 M 780 86 L 780 100" stroke="#bc13fe" stroke-width="1.5" fill="none"/>
+    <text x="22" y="34" font-family="'JetBrains Mono', monospace" font-size="11" font-weight="700" fill="#bc13fe" letter-spacing="0.08em">LAYER_04</text>
+    <text x="22" y="64" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="22" fill="#ffffff" letter-spacing="0.04em">HARNESS</text>
+    <text x="22" y="80" font-family="'JetBrains Mono', monospace" font-size="9" fill="#bc13fe" letter-spacing="0.3em">AGENTIC_RUNTIME</text>
+    <text x="320" y="50" font-family="'JetBrains Mono', monospace" font-size="11" fill="rgba(255,255,255,0.7)">Bring your own. Switch any time.</text>
+    <text x="320" y="68" font-family="'JetBrains Mono', monospace" font-size="11" fill="rgba(255,255,255,0.5)">claude code · gemini cli · codex · qwen · cursor · ...</text>
+    <g transform="translate(640, 38)">
+      <rect width="124" height="22" fill="rgba(188,19,254,0.08)" stroke="#bc13fe" stroke-opacity="0.4" stroke-width="1"/>
+      <text x="62" y="15" font-family="'JetBrains Mono', monospace" font-size="9" fill="#bc13fe" letter-spacing="0.18em" text-anchor="middle">BYO_HARNESS</text>
+    </g>
+  </g>
+
+  <g transform="translate(440, 561)" opacity="0.5">
+    <line x1="0" y1="0" x2="0" y2="8" stroke="rgba(255,255,255,0.5)" stroke-width="1"/>
+    <path d="M -3 6 L 0 10 L 3 6" fill="none" stroke="rgba(255,255,255,0.6)" stroke-width="1"/>
+  </g>
+
+  <!-- ════════ LAYER 05 — LLM ════════ -->
+  <g transform="translate(60, 574)">
+    <rect width="780" height="100" fill="url(#block-fill)" stroke="#c8ff00" stroke-opacity="0.35" stroke-width="1"/>
+    <rect width="780" height="3" fill="url(#g-llm)" filter="url(#soft-glow)"/>
+    <path d="M 0 0 L 14 0 M 0 0 L 0 14" stroke="#c8ff00" stroke-width="1.5" fill="none"/>
+    <path d="M 766 100 L 780 100 M 780 86 L 780 100" stroke="#c8ff00" stroke-width="1.5" fill="none"/>
+    <text x="22" y="34" font-family="'JetBrains Mono', monospace" font-size="11" font-weight="700" fill="#c8ff00" letter-spacing="0.08em">LAYER_05</text>
+    <text x="22" y="64" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="22" fill="#ffffff" letter-spacing="0.04em">LLM</text>
+    <text x="22" y="80" font-family="'JetBrains Mono', monospace" font-size="9" fill="#c8ff00" letter-spacing="0.3em">INTELLIGENCE_SOURCE</text>
+    <text x="320" y="50" font-family="'JetBrains Mono', monospace" font-size="11" fill="rgba(255,255,255,0.7)">Whatever powers the harness. OneBrain stays consistent.</text>
+    <text x="320" y="68" font-family="'JetBrains Mono', monospace" font-size="11" fill="rgba(255,255,255,0.5)">local (mlx · ollama) · cloud (claude · gemini · gpt) · raw api</text>
+    <g transform="translate(640, 38)">
+      <rect width="124" height="22" fill="rgba(200,255,0,0.08)" stroke="#c8ff00" stroke-opacity="0.4" stroke-width="1"/>
+      <text x="62" y="15" font-family="'JetBrains Mono', monospace" font-size="9" fill="#c8ff00" letter-spacing="0.18em" text-anchor="middle">RAW_TOKENS</text>
+    </g>
+  </g>
+
+  <!-- Bottom side label: INTELLIGENCE -->
+  <g font-family="'Chakra Petch', sans-serif" font-weight="700" font-size="11" letter-spacing="0.25em" fill="rgba(255,255,255,0.55)">
+    <text x="56" y="694">↓ INTELLIGENCE · WHERE THE THINKING HAPPENS</text>
+  </g>
+
+  <!-- Bottom divider + footer -->
+  <line x1="24" y1="704" x2="856" y2="704" stroke="rgba(255,255,255,0.08)" stroke-width="1"/>
+  <g font-family="'JetBrains Mono', ui-monospace, monospace" font-size="9" letter-spacing="0.25em" fill="rgba(255,255,255,0.35)">
+    <text x="56" y="724">CONTEXT_FLOWS_BOTH_WAYS · VAULT_REMAINS_HARNESS_AGNOSTIC</text>
+    <text x="836" y="724" text-anchor="end">ONEBRAIN.RUN</text>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary

Repositions OneBrain as the **OS layer underneath any AI harness** — Claude Code, Gemini CLI, OpenAI Codex, Qwen Code, or Claude Code with a BYO LLM behind it. Adds a visual architecture diagram + harness install matrix to the README, and brings CONTRIBUTING.md back in sync with the current CLI-based bootstrap (no more \`install.sh\` / \`install.ps1\`).

### What changed

- **README.md** — new \`## The Harness OS Architecture\` section right after the intro:
  - 5-layer stack diagram (Vault · Plugin · CLI · Harness · LLM) embedded as a static SVG
  - Per-harness install matrix
  - \`Bring Your Own LLM via Claude Code\` subsection (claude-code-router + \`ANTHROPIC_BASE_URL\` examples)
  - \"Multi-agent\" feature row renamed to \"Multi-Harness OS\"
  - Minimal \"Supported Agents\" table folded into the new section
- **CONTRIBUTING.md** — drops the obsolete \`Install Scripts\` section (install.sh / install.ps1 no longer ship); replaces with \`Vault Bootstrap\` describing the \`onebrain init\` / \`onebrain update\` CLI flow; expands \`Multi-Harness Support\` to cover Qwen + BYO-LLM
- **assets/diagrams/harness-os-stack.svg** — new branded static diagram (cyberpunk theme matching the website)

### Companion PR

Live website mirror lives in [onebrain-ai/website#harness-os-positioning](https://github.com/onebrain-ai/website) — animated version of the same diagram + a new \`#harness-setup\` section.

## Test plan

- [ ] Visual: open README on github.com/onebrain-ai/onebrain — confirm SVG renders, anchor links resolve, tables read cleanly
- [ ] Anchor: \`#the-harness-os-architecture\` jumps from both the intro link and the Built-for-Synergy table back-link
- [ ] Verify Qwen Code + Codex install commands stay accurate (npm package names)
- [ ] CONTRIBUTING.md \`Vault Bootstrap\` section matches actual \`src/commands/init.ts\` behavior