### PR TITLE
fix: session-log glob across /wrapup, /daily, /weekly, /distill, /reorganize, INSTRUCTIONS (v2.2.3)

### DIFF
--- a/.claude/plugins/onebrain/.claude-plugin/plugin.json
+++ b/.claude/plugins/onebrain/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "onebrain",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "OneBrain — Where human and AI thinking become one. A powerful thinking partner powered by AI synergy.",
   "author": {
     "name": "OneBrain Contributors"

--- a/.claude/plugins/onebrain/INSTRUCTIONS.md
+++ b/.claude/plugins/onebrain/INSTRUCTIONS.md
@@ -273,7 +273,7 @@ When the user asks you to recall something (a decision, preference, fact, or pas
 
 1. **`[agent_folder]/MEMORY.md`** : already in context; check here first
 2. **`[agent_folder]/memory/`** : MEMORY-INDEX.md is already in context — match query keywords against its Topics column to identify relevant files, then read those files. If no topic match, grep memory/ directly. Use qmd if available for broader semantic search.
-3. **`[logs_folder]/`** : grep session logs for past decisions and discussions
+3. **`[logs_folder]/`** : grep session logs (`**/*-session-*.md` only — exclude `*-checkpoint-*.md` and `*-update-*.md` which carry no decisions) for past decisions and discussions
 
 Stop as soon as you find a confident answer. If the answer spans multiple layers, synthesize across them.
 

--- a/.claude/plugins/onebrain/skills/daily/SKILL.md
+++ b/.claude/plugins/onebrain/skills/daily/SKILL.md
@@ -23,7 +23,7 @@ Determine today's date (`YYYY-MM-DD`) and current local time (local machine time
 
 ### Previous Session Recap (Morning Mode Only)
 
-Glob `[logs_folder]/**/*.md`. Find the most recent session log (today or earlier). On Mondays this will typically be Friday's log unless there is already a session today. If no prior session exists, skip this section silently.
+Glob `[logs_folder]/**/*-session-*.md` (session logs only — never bare `*.md`, which would also match checkpoints, recovered-orphan files, and `/update` migration logs and could pick the wrong file as "most recent"). Find the most recent session log (today or earlier). On Mondays this will typically be Friday's log unless there is already a session today. If no prior session exists, skip this section silently.
 
 Read that session log. Extract main topics and any unchecked action items.
 
@@ -36,7 +36,7 @@ Grep `[projects_folder]/**/*.md` and `[inbox_folder]/*.md` for task lines matchi
 
 **Source 2 : Open action items from last session:**
 If morning mode: already loaded from recap step above; extract unchecked `- [ ]` items from the `## Action Items` section.
-If normal mode: Glob `[logs_folder]/**/*.md`. Find the most recent session log (today or earlier). Read that log and extract unchecked `- [ ]` items from the `## Action Items` section.
+If normal mode: Glob `[logs_folder]/**/*-session-*.md` (session logs only — never bare `*.md`, which would also match checkpoints, recovered-orphan files, and `/update` migration logs and could pick the wrong file as "most recent"). Find the most recent session log (today or earlier). Read that log and extract unchecked `- [ ]` items from the `## Action Items` section.
 
 ### Display the Briefing
 

--- a/.claude/plugins/onebrain/skills/daily/SKILL.md
+++ b/.claude/plugins/onebrain/skills/daily/SKILL.md
@@ -23,7 +23,7 @@ Determine today's date (`YYYY-MM-DD`) and current local time (local machine time
 
 ### Previous Session Recap (Morning Mode Only)
 
-Glob `[logs_folder]/**/*-session-*.md` (session logs only — never bare `*.md`, which would also match checkpoints, recovered-orphan files, and `/update` migration logs and could pick the wrong file as "most recent"). Find the most recent session log (today or earlier). On Mondays this will typically be Friday's log unless there is already a session today. If no prior session exists, skip this section silently.
+Glob `[logs_folder]/**/*-session-*.md` (session logs only — never bare `*.md`, which would also match `*-checkpoint-*.md` and `*-update-*.md` files in the same folder and could pick the wrong file as "most recent"). Find the most recent session log (today or earlier). On Mondays this will typically be Friday's log unless there is already a session today. If no prior session exists, skip this section silently.
 
 Read that session log. Extract main topics and any unchecked action items.
 
@@ -36,7 +36,7 @@ Grep `[projects_folder]/**/*.md` and `[inbox_folder]/*.md` for task lines matchi
 
 **Source 2 : Open action items from last session:**
 If morning mode: already loaded from recap step above; extract unchecked `- [ ]` items from the `## Action Items` section.
-If normal mode: Glob `[logs_folder]/**/*-session-*.md` (session logs only — never bare `*.md`, which would also match checkpoints, recovered-orphan files, and `/update` migration logs and could pick the wrong file as "most recent"). Find the most recent session log (today or earlier). Read that log and extract unchecked `- [ ]` items from the `## Action Items` section.
+If normal mode: Glob `[logs_folder]/**/*-session-*.md` (session logs only — never bare `*.md`, which would also match `*-checkpoint-*.md` and `*-update-*.md` files in the same folder and could pick the wrong file as "most recent"). Find the most recent session log (today or earlier). Read that log and extract unchecked `- [ ]` items from the `## Action Items` section.
 
 ### Display the Briefing
 

--- a/.claude/plugins/onebrain/skills/distill/SKILL.md
+++ b/.claude/plugins/onebrain/skills/distill/SKILL.md
@@ -25,7 +25,7 @@ Search across the vault for notes related to the topic. Use 2–3 specific keywo
 
 Use qmd if available for content searches; Grep/Glob as fallback.
 
-1. **Session logs**: Search `[logs_folder]/**/*.md` for topic keywords — extract matching `## Key Decisions`, `## Action Items`, `## Open Questions` sections
+1. **Session logs**: Search `[logs_folder]/**/*-session-*.md` for topic keywords — extract matching `## Key Decisions`, `## Action Items`, `## Open Questions` sections. (Use the `*-session-*.md` pattern, not bare `*.md` — checkpoint/update logs in the same folder shouldn't contribute distillation content.)
 2. **Inbox**: Search `[inbox_folder]/*.md` for related content
 3. **memory/ files**: Search `[agent_folder]/memory/` for related entries — match topic keywords against filename and frontmatter `topics:` field
 4. **Project/knowledge notes**: Search `[projects_folder]/**/*.md`, `[knowledge_folder]/**/*.md`, and `[resources_folder]/**/*.md` — filter by note title or first 100 words

--- a/.claude/plugins/onebrain/skills/distill/SKILL.md
+++ b/.claude/plugins/onebrain/skills/distill/SKILL.md
@@ -25,7 +25,7 @@ Search across the vault for notes related to the topic. Use 2–3 specific keywo
 
 Use qmd if available for content searches; Grep/Glob as fallback.
 
-1. **Session logs**: Search `[logs_folder]/**/*-session-*.md` for topic keywords — extract matching `## Key Decisions`, `## Action Items`, `## Open Questions` sections. (Use the `*-session-*.md` pattern, not bare `*.md` — checkpoint/update logs in the same folder shouldn't contribute distillation content.)
+1. **Session logs**: Search `[logs_folder]/**/*-session-*.md` for topic keywords — extract matching `## Key Decisions`, `## Action Items`, `## Open Questions` sections. (Use the `*-session-*.md` pattern, not bare `*.md` — `*-checkpoint-*.md` and `*-update-*.md` files in the same folder shouldn't contribute distillation content.)
 2. **Inbox**: Search `[inbox_folder]/*.md` for related content
 3. **memory/ files**: Search `[agent_folder]/memory/` for related entries — match topic keywords against filename and frontmatter `topics:` field
 4. **Project/knowledge notes**: Search `[projects_folder]/**/*.md`, `[knowledge_folder]/**/*.md`, and `[resources_folder]/**/*.md` — filter by note title or first 100 words

--- a/.claude/plugins/onebrain/skills/reorganize/SKILL.md
+++ b/.claude/plugins/onebrain/skills/reorganize/SKILL.md
@@ -61,7 +61,7 @@ Find notes that are directly in a top-level folder (not already in a subfolder):
 - `[areas_folder]/*.md` : glob top-level only
 - `[knowledge_folder]/*.md` : glob top-level only
 - `[resources_folder]/*.md` : glob top-level only
-- `[logs_folder]/*.md` : flat session log files not yet in a `YYYY/MM/` subfolder
+- `[logs_folder]/*-session-*.md` : flat session log files not yet in a `YYYY/MM/` subfolder (use the `*-session-*.md` pattern so a flat-root `*-checkpoint-*.md` or `*-update-*.md` file is not treated as a session log to migrate)
 
 Also check `[archive_folder]/*.md` for any flat archive files.
 

--- a/.claude/plugins/onebrain/skills/weekly/SKILL.md
+++ b/.claude/plugins/onebrain/skills/weekly/SKILL.md
@@ -15,7 +15,7 @@ Best run on Friday afternoon or over the weekend.
 
 Determine the current week's date range (Mon–Sun).
 
-List all session log files in `[logs_folder]/**/*-session-*.md` from this week. If there are none, check the past 7 days. (Use the `*-session-*.md` pattern, not bare `*.md` — the logs folder also contains checkpoint files, recovered-orphan placeholders, and `/update` migration logs that would inflate the weekly review.)
+List all session log files in `[logs_folder]/**/*-session-*.md` from this week. If there are none, check the past 7 days. (Use the `*-session-*.md` pattern, not bare `*.md` — the logs folder also contains `*-checkpoint-*.md` and `*-update-*.md` files that would inflate the weekly review.)
 
 Report:
 > I found N sessions this week:

--- a/.claude/plugins/onebrain/skills/weekly/SKILL.md
+++ b/.claude/plugins/onebrain/skills/weekly/SKILL.md
@@ -15,7 +15,7 @@ Best run on Friday afternoon or over the weekend.
 
 Determine the current week's date range (Mon–Sun).
 
-List all files in `[logs_folder]/**/*.md` from this week. If there are none, check the past 7 days.
+List all session log files in `[logs_folder]/**/*-session-*.md` from this week. If there are none, check the past 7 days. (Use the `*-session-*.md` pattern, not bare `*.md` — the logs folder also contains checkpoint files, recovered-orphan placeholders, and `/update` migration logs that would inflate the weekly review.)
 
 Report:
 > I found N sessions this week:

--- a/.claude/plugins/onebrain/skills/wrapup/SKILL.md
+++ b/.claude/plugins/onebrain/skills/wrapup/SKILL.md
@@ -200,8 +200,11 @@ Guard: only delete AFTER confirming the session log write succeeded. Never delet
 At the end of every /wrapup, compute `unrecapped_count` and `last_recapped`:
 
 **Fast path:** read `stats.last_recap` from `vault.yml` if available.
-**Fallback:** if `vault.yml` stats missing, glob session logs from last 6 months only
-(`07-logs/YYYY/MM/*.md`) and check `recapped:` field.
+**Glob session logs only:** match the `*-session-*.md` file pattern, never bare
+`*.md` — the logs folder also contains checkpoint files, recovered-orphan
+fallbacks, and update logs that never carry `recapped:` and would inflate
+the count if matched. Use `[logs_folder]/YYYY/MM/*-session-*.md` over the
+last 6 months and check the `recapped:` field on each.
 
 Compute:
 - `unrecapped_count` — number of session logs without `recapped:` field

--- a/.claude/plugins/onebrain/skills/wrapup/SKILL.md
+++ b/.claude/plugins/onebrain/skills/wrapup/SKILL.md
@@ -201,10 +201,10 @@ At the end of every /wrapup, compute `unrecapped_count` and `last_recapped`:
 
 **Fast path:** read `stats.last_recap` from `vault.yml` if available.
 **Glob session logs only:** match the `*-session-*.md` file pattern, never bare
-`*.md` — the logs folder also contains checkpoint files, recovered-orphan
-fallbacks, and update logs that never carry `recapped:` and would inflate
-the count if matched. Use `[logs_folder]/YYYY/MM/*-session-*.md` over the
-last 6 months and check the `recapped:` field on each.
+`*.md` — the logs folder also contains checkpoint files (`*-checkpoint-*.md`)
+and `/update` migration logs (`*-update-*.md`) that would inflate the count
+if matched. Use `[logs_folder]/YYYY/MM/*-session-*.md` over the last 6 months
+and check the `recapped:` field on each.
 
 Compute:
 - `unrecapped_count` — number of session logs without `recapped:` field

--- a/PLUGIN-CHANGELOG.md
+++ b/PLUGIN-CHANGELOG.md
@@ -13,14 +13,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
-## v2.2.3 — fix: session-log glob across /wrapup, /daily, /weekly, /distill
+## v2.2.3 — fix: session-log glob across /wrapup, /daily, /weekly, /distill, /reorganize, INSTRUCTIONS
 
-Same class of bug across four skills: globbing `[logs_folder]/.../*.md` matches checkpoint files, recovered-orphan placeholders, and `/update` migration logs in addition to actual session logs. Tightened every affected pattern to `*-session-*.md` and added an inline note explaining why so it doesn't drift back.
+Same class of bug across multiple skills: globbing `[logs_folder]/.../*.md` matches checkpoint files (`*-checkpoint-*.md`) and `/update` migration logs (`*-update-*.md`) in addition to actual session logs. Tightened every affected pattern to `*-session-*.md` and added an inline note explaining why so it doesn't drift back.
 
-- fix(/wrapup SKILL): Step 6 recap-reminder glob narrowed from `07-logs/YYYY/MM/*.md` to `*-session-*.md`. The bare `*.md` pattern was inflating the displayed unrecapped count (e.g. reporting 10 unrecapped when only 2 actual session logs were unrecapped).
+- fix(/wrapup SKILL): Step 6 recap-reminder glob narrowed from `07-logs/YYYY/MM/*.md` to `*-session-*.md`. The bare `*.md` pattern was inflating the displayed unrecapped count (reporting 10 unrecapped when only 2 actual session logs were unrecapped).
 - fix(/daily SKILL): Phase 1 "find most recent session log" glob narrowed to `*-session-*.md`. Previously a more recent checkpoint or `/update` log could be picked as "most recent", causing the briefing to read the wrong file.
 - fix(/weekly SKILL): Step 1 weekly file list narrowed to `*-session-*.md` so the review doesn't include checkpoint or update logs.
 - fix(/distill SKILL): Step 2 session-log search narrowed to `*-session-*.md` so non-session files in the logs folder don't contribute distillation content.
+- fix(/reorganize SKILL): flat-root logs glob narrowed from `[logs_folder]/*.md` to `*-session-*.md` so a flat checkpoint or update log isn't treated as a legacy session log to migrate.
+- fix(INSTRUCTIONS Recalling Information): Step 3 grep hint now specifies `**/*-session-*.md` so the agent doesn't default to bare `*.md` when searching past decisions.
 
 ## v2.2.2 — chore: migrate to onebrain-ai org
 

--- a/PLUGIN-CHANGELOG.md
+++ b/PLUGIN-CHANGELOG.md
@@ -13,9 +13,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
-## v2.2.3 — fix: /wrapup recap-count glob
+## v2.2.3 — fix: session-log glob across /wrapup, /daily, /weekly, /distill
 
-- fix(/wrapup SKILL): Step 6 recap-reminder glob narrowed from `07-logs/YYYY/MM/*.md` to `*-session-*.md`. The bare `*.md` pattern was matching checkpoint files, recovered-orphan placeholders, and `/update` migration logs — none of which carry `recapped:` — so the displayed unrecapped count was wildly inflated (e.g. reporting 10 unrecapped when only 2 actual session logs were unrecapped).
+Same class of bug across four skills: globbing `[logs_folder]/.../*.md` matches checkpoint files, recovered-orphan placeholders, and `/update` migration logs in addition to actual session logs. Tightened every affected pattern to `*-session-*.md` and added an inline note explaining why so it doesn't drift back.
+
+- fix(/wrapup SKILL): Step 6 recap-reminder glob narrowed from `07-logs/YYYY/MM/*.md` to `*-session-*.md`. The bare `*.md` pattern was inflating the displayed unrecapped count (e.g. reporting 10 unrecapped when only 2 actual session logs were unrecapped).
+- fix(/daily SKILL): Phase 1 "find most recent session log" glob narrowed to `*-session-*.md`. Previously a more recent checkpoint or `/update` log could be picked as "most recent", causing the briefing to read the wrong file.
+- fix(/weekly SKILL): Step 1 weekly file list narrowed to `*-session-*.md` so the review doesn't include checkpoint or update logs.
+- fix(/distill SKILL): Step 2 session-log search narrowed to `*-session-*.md` so non-session files in the logs folder don't contribute distillation content.
 
 ## v2.2.2 — chore: migrate to onebrain-ai org
 

--- a/PLUGIN-CHANGELOG.md
+++ b/PLUGIN-CHANGELOG.md
@@ -1,6 +1,6 @@
 ---
-latest_version: 2.2.2
-released: 2026-04-30
+latest_version: 2.2.3
+released: 2026-05-05
 ---
 
 # Plugin Changelog
@@ -12,6 +12,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 > For CLI binary changes, see [CHANGELOG.md](CHANGELOG.md).
 
 ## [Unreleased]
+
+## v2.2.3 — fix: /wrapup recap-count glob
+
+- fix(/wrapup SKILL): Step 6 recap-reminder glob narrowed from `07-logs/YYYY/MM/*.md` to `*-session-*.md`. The bare `*.md` pattern was matching checkpoint files, recovered-orphan placeholders, and `/update` migration logs — none of which carry `recapped:` — so the displayed unrecapped count was wildly inflated (e.g. reporting 10 unrecapped when only 2 actual session logs were unrecapped).
 
 ## v2.2.2 — chore: migrate to onebrain-ai org
 


### PR DESCRIPTION
## Summary

Same bug class across **6 plugin-track locations**: globbing \`[logs_folder]/.../*.md\` matches \`*-checkpoint-*.md\` and \`*-update-*.md\` files in addition to actual session logs. Real-world repro: \`/wrapup\` reported \`⚠️ 10 session logs not yet recapped\` when only **2** actually lacked the \`recapped:\` field (the other 8 were checkpoint + update logs in the same folder).

## Affected locations

| Skill / Doc | What broke |
|---|---|
| \`/wrapup\` Step 6 | Inflated unrecapped count (10 vs 2) |
| \`/daily\` Phase 1 | Picks the wrong file when a checkpoint or \`/update\` log is the newest in the folder |
| \`/weekly\` Step 1 | Review includes checkpoint + update logs |
| \`/distill\` Step 2 | Topic search drags in noise from non-session files |
| \`/reorganize\` Step 1 | Flat-root checkpoint/update logs would be migrated as session logs |
| \`INSTRUCTIONS.md\` "Recalling Information" Step 3 | "grep session logs" with no pattern hint → agent defaults to bare \`*.md\` |

## Fix

Tightened every affected glob from \`*.md\` → \`*-session-*.md\` (the convention session logs already follow). Added inline rationale in each location.

## Review

3 review rounds completed:
- **Round 1 (correctness)**: caught the inline notes incorrectly listing "recovered-orphan files" as a separate excluded class — recovered-orphan session logs use the standard \`YYYY-MM-DD-session-NN.md\` filename and ARE legitimate session logs. Fixed wording in 4 files.
- **Round 2 (completeness)**: caught \`/reorganize\` and \`INSTRUCTIONS.md\` as same-class instances; folded both into this PR. Also caught a parallel bug in the CLI binary (\`src/commands/internal/orphan-scan.ts\` filter is too permissive) — flagged as **follow-up PR** since it belongs to the CLI track and would mix versioning.
- **Round 3 (backward compat)**: no blocking issues. Pre-\`YYYY/MM/\` legacy session logs still match (the \`-session-\` infix predates the directory convention).

## Versioning

Plugin patch bump 2.2.2 → 2.2.3.

## Follow-up (separate PR)

Same bug class in the CLI binary (\`src/commands/internal/orphan-scan.ts\` \`hasManualSessionLog\` filter excludes \`-checkpoint-\` but accepts ANY other date-prefixed \`.md\`). Will fix + add regression tests in a CLI-track PR.

## Test plan

- [ ] \`/wrapup\` count matches \`grep -L "^recapped:" 07-logs/YYYY/MM/*-session-*.md | wc -l\` exactly
- [ ] \`/daily\` morning briefing reads the latest **session** log even if a more recent checkpoint or \`/update\` log exists
- [ ] \`/weekly\` lists only session logs
- [ ] \`/distill\` topic search excludes checkpoint + update content