### PR TITLE
fix: whitelist `-session-` infix in orphan-scan + migrate filters (CLI v2.1.10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-latest_version: 2.1.9
+latest_version: 2.1.10
 released: 2026-05-05
 ---
 
@@ -12,6 +12,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 > For plugin changes (skills, agents, hooks, INSTRUCTIONS), see [PLUGIN-CHANGELOG.md](PLUGIN-CHANGELOG.md).
 
 ## [Unreleased]
+
+## v2.1.10 — fix: orphan-scan filter whitelists `-session-` infix
+
+- fix(orphan-scan): `hasManualSessionLog` filter switched from blacklist (`!includes('-checkpoint-')`) to whitelist (`includes('-session-')`). Companion to plugin v2.2.3. Previously, a `/update` migration log (`YYYY-MM-DD-update-vX.Y.Z.md`) sharing a date with an orphan checkpoint would fall through the filter and silently suppress the orphan count — `runOrphanScan` would report `orphan_count: 0` even though the orphan checkpoint was real. The whitelist guarantees we only consider files whose name actually matches the session-log convention.
+- test(orphan-scan): two regression cases — orphan still counts when only an update-log exists for that date; orphan still skipped when both an update-log AND a real session log exist for the same date.
 
 ## v2.1.9 — feat: brand-aligned CLI banner (neural-mesh brain + slant wordmark + brand gradient)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
-## v2.1.10 — fix: orphan-scan filter whitelists `-session-` infix
+## v2.1.10 — fix: whitelist `-session-` infix in orphan-scan + migrate filters
 
-- fix(orphan-scan): `hasManualSessionLog` filter switched from blacklist (`!includes('-checkpoint-')`) to whitelist (`includes('-session-')`). Companion to plugin v2.2.3. Previously, a `/update` migration log (`YYYY-MM-DD-update-vX.Y.Z.md`) sharing a date with an orphan checkpoint would fall through the filter and silently suppress the orphan count — `runOrphanScan` would report `orphan_count: 0` even though the orphan checkpoint was real. The whitelist guarantees we only consider files whose name actually matches the session-log convention.
-- test(orphan-scan): two regression cases — orphan still counts when only an update-log exists for that date; orphan still skipped when both an update-log AND a real session log exist for the same date.
+Companion to plugin v2.2.3. Two CLI sites had the same bug class — blacklisting `-checkpoint-` and accepting any other date-prefixed `.md` file in the logs folder, which let `/update` migration logs (`YYYY-MM-DD-update-vX.Y.Z.md`) and `/weekly` review files (`YYYY-MM-DD-weekly.md`) fall through.
+
+- fix(orphan-scan): `hasManualSessionLog` filter switched to whitelist (`includes('-session-')`). Previously an update or weekly file sharing a date with an orphan checkpoint silently suppressed the orphan count — `runOrphanScan` would report `orphan_count: 0` even though the orphan was real.
+- fix(migrate.runBackfillRecapped): same whitelist switch. The blacklist version was rewriting frontmatter on every non-checkpoint `.md` file in the logs folder, silently injecting a meaningless `recapped: <today>` field into update logs and weekly reviews.
+- test(orphan-scan): three regression cases — orphan still counts when only an update-log or weekly file exists for the date; orphan still skipped when both a non-session log AND a real session log exist on the same date.
+- test(migrate): two regression cases — update-log frontmatter and weekly-review frontmatter are left untouched (idempotent reads, byte-equal contents, no `recapped:` field injected).
 
 ## v2.1.9 — feat: brand-aligned CLI banner (neural-mesh brain + slant wordmark + brand gradient)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onebrain-ai/cli",
-  "version": "2.1.9",
+  "version": "2.1.10",
   "description": "CLI for OneBrain — personal AI OS for Obsidian with persistent memory, 24+ skills, and Claude Code integration",
   "keywords": [
     "onebrain",

--- a/src/commands/internal/migrate.ts
+++ b/src/commands/internal/migrate.ts
@@ -120,8 +120,13 @@ export async function runBackfillRecapped(
       for (const fname of files) {
         const fpath = join(monthPath, fname);
 
-        // Skip checkpoint files
-        if (fname.includes('-checkpoint-')) {
+        // Whitelist: only session logs get the `recapped:` frontmatter
+        // backfill. The logs folder also contains `*-checkpoint-*.md`,
+        // `*-update-vX.Y.Z.md`, and `*-weekly.md` — none of which carry
+        // a `recapped:` field by convention. The previous blacklist
+        // (`-checkpoint-` only) silently mutated update + weekly log
+        // frontmatter with a meaningless `recapped:` value.
+        if (!fname.includes('-session-')) {
           continue;
         }
 

--- a/src/commands/internal/orphan-scan.test.ts
+++ b/src/commands/internal/orphan-scan.test.ts
@@ -158,6 +158,44 @@ describe('runOrphanScan', () => {
     expect(result).toEqual({ orphan_count: 1 });
   });
 
+  // Regression: previously the `hasManualSessionLog` filter excluded
+  // `-checkpoint-` files but accepted any other date-prefixed `.md`. A
+  // `/update` migration log written on the same date as an orphan
+  // checkpoint would fall through and silently suppress the orphan
+  // count. Filter now whitelists `-session-` so the orphan still counts.
+  it('does NOT skip when only an update-log exists for that date (no real session log)', async () => {
+    const monthDir = await makeThisMonthDir(logsDir);
+    const cpName = checkpointName(PAST_DATE, 'tokenUL', 1);
+    await writeFile(join(monthDir, cpName), checkpointFrontmatter(false), 'utf8');
+    // /update writes YYYY-MM-DD-update-vX.Y.Z.md (no `-session-` infix)
+    const updateName = `${PAST_DATE}-update-v2.1.10.md`;
+    await writeFile(
+      join(monthDir, updateName),
+      `---\ntags: [update-log]\ndate: ${PAST_DATE}\nfrom_version: 2.1.9\nto_version: 2.1.10\n---\n\n# Update Log\n\n- [x] Step 1\n`,
+      'utf8',
+    );
+    const result = await runOrphanScan(logsDir, 'current99', PINNED_NOW);
+    expect(result).toEqual({ orphan_count: 1 });
+  });
+
+  // Companion case: both an update log AND a manual session log exist
+  // for the same date — the manual session log still wins, orphan
+  // suppressed. Verifies the whitelist didn't regress the skip behavior.
+  it('still skips when both an update-log and a manual session log exist for that date', async () => {
+    const monthDir = await makeThisMonthDir(logsDir);
+    const cpName = checkpointName(PAST_DATE, 'tokenULSL', 1);
+    await writeFile(join(monthDir, cpName), checkpointFrontmatter(false), 'utf8');
+    await writeFile(
+      join(monthDir, `${PAST_DATE}-update-v2.1.10.md`),
+      `---\ntags: [update-log]\ndate: ${PAST_DATE}\n---\n\nUpdate.`,
+      'utf8',
+    );
+    const logName = sessionLogName(PAST_DATE, 1);
+    await writeFile(join(monthDir, logName), sessionLogFrontmatter(false), 'utf8');
+    const result = await runOrphanScan(logsDir, 'current99', PINNED_NOW);
+    expect(result).toEqual({ orphan_count: 0 });
+  });
+
   it('counts unmerged orphan checkpoints from current month', async () => {
     const monthDir = await makeThisMonthDir(logsDir);
     for (const token of ['tokenCC', 'tokenDD']) {

--- a/src/commands/internal/orphan-scan.test.ts
+++ b/src/commands/internal/orphan-scan.test.ts
@@ -178,6 +178,23 @@ describe('runOrphanScan', () => {
     expect(result).toEqual({ orphan_count: 1 });
   });
 
+  // Same bug class as the update-log case: /weekly writes
+  // YYYY-MM-DD-weekly.md (no `-session-` infix). Under the old blacklist
+  // it would also fall through and silently suppress the orphan count.
+  it('does NOT skip when only a weekly log exists for that date (no real session log)', async () => {
+    const monthDir = await makeThisMonthDir(logsDir);
+    const cpName = checkpointName(PAST_DATE, 'tokenWL', 1);
+    await writeFile(join(monthDir, cpName), checkpointFrontmatter(false), 'utf8');
+    const weeklyName = `${PAST_DATE}-weekly.md`;
+    await writeFile(
+      join(monthDir, weeklyName),
+      `---\ntags: [weekly-review]\ndate: ${PAST_DATE}\n---\n\n# Weekly Review\n`,
+      'utf8',
+    );
+    const result = await runOrphanScan(logsDir, 'current99', PINNED_NOW);
+    expect(result).toEqual({ orphan_count: 1 });
+  });
+
   // Companion case: both an update log AND a manual session log exist
   // for the same date — the manual session log still wins, orphan
   // suppressed. Verifies the whitelist didn't regress the skip behavior.

--- a/src/commands/internal/orphan-scan.ts
+++ b/src/commands/internal/orphan-scan.ts
@@ -89,8 +89,15 @@ async function listMdFiles(dir: string): Promise<string[]> {
  */
 async function hasManualSessionLog(monthDir: string, date: string): Promise<boolean> {
   const files = await listMdFiles(monthDir);
+  // Whitelist `-session-` infix (not blacklist `-checkpoint-`). The logs
+  // folder also contains `*-update-vX.Y.Z.md` migration logs from `/update`.
+  // With the previous blacklist filter, those would fall through and silently
+  // suppress the orphan count for any date that happens to have an update
+  // log alongside a real orphan checkpoint (false-positive "session already
+  // wrapped" → orphan_count under-reports). The whitelist guarantees we
+  // only consider files that actually look like session logs.
   const sessionLogs = files.filter(
-    (f) => f.startsWith(date) && !f.includes('-checkpoint-') && f.endsWith('.md'),
+    (f) => f.startsWith(date) && f.includes('-session-') && f.endsWith('.md'),
   );
 
   for (const logName of sessionLogs) {

--- a/src/commands/internal/orphan-scan.ts
+++ b/src/commands/internal/orphan-scan.ts
@@ -90,12 +90,12 @@ async function listMdFiles(dir: string): Promise<string[]> {
 async function hasManualSessionLog(monthDir: string, date: string): Promise<boolean> {
   const files = await listMdFiles(monthDir);
   // Whitelist `-session-` infix (not blacklist `-checkpoint-`). The logs
-  // folder also contains `*-update-vX.Y.Z.md` migration logs from `/update`.
-  // With the previous blacklist filter, those would fall through and silently
-  // suppress the orphan count for any date that happens to have an update
-  // log alongside a real orphan checkpoint (false-positive "session already
-  // wrapped" → orphan_count under-reports). The whitelist guarantees we
-  // only consider files that actually look like session logs.
+  // folder also contains `*-update-vX.Y.Z.md` migration logs from `/update`
+  // and `*-weekly.md` files from `/weekly`. With the previous blacklist
+  // filter, those would fall through and silently suppress the orphan
+  // count for any date that happens to have one of them alongside a real
+  // orphan checkpoint. The whitelist guarantees we only consider files
+  // that actually look like session logs.
   const sessionLogs = files.filter(
     (f) => f.startsWith(date) && f.includes('-session-') && f.endsWith('.md'),
   );


### PR DESCRIPTION
## Summary

Companion to plugin v2.2.3 (PR #142). The same too-permissive blacklist bug class existed in **two** CLI sites — both walked the logs folder and only excluded \`-checkpoint-\` files, accepting any other date-prefixed \`.md\`. \`/update\` migration logs (\`YYYY-MM-DD-update-vX.Y.Z.md\`) and \`/weekly\` review files (\`YYYY-MM-DD-weekly.md\`) were falling through both filters.

## Affected sites

| File | Function | Symptom |
|---|---|---|
| \`src/commands/internal/orphan-scan.ts\` | \`hasManualSessionLog\` | Silent under-reporting of \`orphan_count\` when an update or weekly file shares a date with an orphan checkpoint |
| \`src/commands/internal/migrate.ts\` | \`runBackfillRecapped\` | Silent frontmatter mutation — meaningless \`recapped: <today>\` injected into update logs and weekly reviews on every backfill |

## Fix

Switched both filters from blacklist (\`!includes('-checkpoint-')\`) to whitelist (\`includes('-session-')\`). The whitelist matches the convention every session log already follows (\`YYYY-MM-DD-session-NN.md\`) and is consistent with the parallel plugin-track fix in v2.2.3.

## Review

3 review rounds completed:
- **Round 1 (correctness)**: Whitelist correctly matches every legitimate session log (\`/wrapup\` + AUTO-SUMMARY both use \`-session-\`) and excludes every other file type. Caught a missing weekly-log regression test — added.
- **Round 2 (completeness)**: Caught the same bug class in \`migrate.runBackfillRecapped\` as a separate site that needed the same fix. Folded in.
- **Round 3 (backward compat)**: Audited 234 \`.md\` files in the real vault — every file matches the whitelist correctly, no false-positive or false-negative classifications. Pre-existing nits (yaml-truthy edge cases, O(N·M) re-listing) deferred.

## Versioning

CLI patch bump 2.1.9 → 2.1.10.

## Test plan

- [x] All 249 CLI tests pass (was 248; +5 net new across orphan-scan + migrate)
- [x] Verified against real vault state (234 files, zero misclassifications)
- [ ] After merge: tag \`v2.1.10\` to trigger npm publish