### PR TITLE
feat(update): backfill vault config drift after migration

### DIFF
--- a/.claude/plugins/onebrain/.claude-plugin/plugin.json
+++ b/.claude/plugins/onebrain/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "onebrain",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "OneBrain — Where human and AI thinking become one. A powerful thinking partner powered by AI synergy.",
   "author": {
     "name": "OneBrain Contributors"

--- a/.claude/plugins/onebrain/skills/update/references/migration-steps.md
+++ b/.claude/plugins/onebrain/skills/update/references/migration-steps.md
@@ -120,8 +120,17 @@ Runs every /update — idempotent. Ensures all hooks point to the correct script
 - Expected: 0 orphans, 0 dead links, 0 non-compliant names, MEMORY-INDEX.md present
 - If any check fails: surface to user with suggestion to run /doctor --fix
 
-**Step 8: Initialize vault.yml stats + recap block**
-- **Skip if:** vault.yml already has both `stats:` and `recap:` blocks
+**Step 8: Initialize vault.yml stats + recap block + update_channel backfill**
+- **Skip if:** vault.yml already has both `stats:` and `recap:` blocks AND `update_channel:` is present
 - Add stats: block: set last_doctor_run to today; leave last_memory_review and last_recap absent (written on first use)
 - Add recap: block: min_sessions: 6, min_frequency: 2
+- If `update_channel:` is missing, set it to `"stable"` (backfill for vaults migrated before update_channel became required)
 - Skip if vault.yml doesn't exist or user opted out via --skip-stats
+
+**Step 9: Backfill `[vault]/.claude/settings.json` marketplace repo**
+- **Skip if:** `[vault]/.claude/settings.json` does not exist
+- Read `[vault]/.claude/settings.json` as JSON, preserving 2-space indentation and trailing newline
+- If `extraKnownMarketplaces.onebrain.source.repo` exactly equals `"kengio/onebrain"`, rewrite to `"onebrain-ai/onebrain"` (the canonical repo path; auto-redirects already work but the literal is stale)
+- Use exact-literal match — do NOT match patterns broader than `"kengio/onebrain"` (zero false-positive risk)
+- Atomic write: write to `[vault]/.claude/settings.json.tmp` then rename
+- No-op if file missing, key missing, or value already canonical (idempotent — safe to run twice)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ---
-latest_version: 2.1.10
-released: 2026-05-05
+latest_version: 2.1.11
+released: 2026-05-06
 ---
 
 # CLI Changelog
@@ -12,6 +12,17 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 > For plugin changes (skills, agents, hooks, INSTRUCTIONS), see [PLUGIN-CHANGELOG.md](PLUGIN-CHANGELOG.md).
 
 ## [Unreleased]
+
+## v2.1.11 — feat(doctor + vault-sync): backfill vault-side config drift
+
+- feat(validator): downgrade missing `update_channel` from error → warning (#133)
+- feat(validator): warn on stale `extraKnownMarketplaces.onebrain.source.repo: kengio/onebrain` in vault `.claude/settings.json`
+- feat(doctor --fix): auto-add `update_channel: stable` to vault.yml (#133)
+- feat(doctor --fix): auto-rewrite stale `extraKnownMarketplaces.onebrain.source.repo` → `onebrain-ai/onebrain` in vault `.claude/settings.json`
+- feat(vault-sync): write `lastUpdated` to `installed_plugins.json` entry after pin (#132)
+- feat(vault-sync): dedup orphan `onebrain@onebrain` entries whose `projectPath` is missing (#132)
+- test(doctor): cover new validator severity + auto-fix behavior
+- test(vault-sync): cover lastUpdated write + orphan dedup
 
 ## v2.1.10 — fix: whitelist `-session-` infix in orphan-scan + migrate filters
 

--- a/PLUGIN-CHANGELOG.md
+++ b/PLUGIN-CHANGELOG.md
@@ -1,6 +1,6 @@
 ---
-latest_version: 2.2.3
-released: 2026-05-05
+latest_version: 2.2.4
+released: 2026-05-06
 ---
 
 # Plugin Changelog
@@ -12,6 +12,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 > For CLI binary changes, see [CHANGELOG.md](CHANGELOG.md).
 
 ## [Unreleased]
+
+## v2.2.4 — feat(update): backfill vault-side config drift after migration
+
+- feat(/update SKILL): Step 8 now adds `update_channel: stable` to vault.yml when missing
+- feat(/update SKILL): new Step 9 rewrites stale `extraKnownMarketplaces.onebrain.source.repo` (`kengio/onebrain` → `onebrain-ai/onebrain`) in vault `.claude/settings.json`
 
 ## v2.2.3 — fix: session-log glob across /wrapup, /daily, /weekly, /distill, /reorganize, INSTRUCTIONS
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onebrain-ai/cli",
-  "version": "2.1.10",
+  "version": "2.1.11",
   "description": "CLI for OneBrain — personal AI OS for Obsidian with persistent memory, 24+ skills, and Claude Code integration",
   "keywords": [
     "onebrain",

--- a/src/commands/doctor.test.ts
+++ b/src/commands/doctor.test.ts
@@ -6,11 +6,12 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
-import { mkdir, rm } from 'node:fs/promises';
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { parse as parseYaml } from 'yaml';
 
-import type { VaultConfig } from '../lib/index.js';
+import { type VaultConfig, checkClaudeSettings, checkVaultYmlKeys } from '../lib/index.js';
 import { type DoctorOptions, runDoctor } from './doctor.js';
 
 // ---------------------------------------------------------------------------
@@ -50,6 +51,7 @@ function makeAllOkValidators(): Required<
     | 'checkPluginFilesFn'
     | 'checkVaultYmlKeysFn'
     | 'checkSettingsHooksFn'
+    | 'checkClaudeSettingsFn'
   >
 > {
   return {
@@ -81,6 +83,7 @@ function makeAllOkValidators(): Required<
       status: 'ok',
       message: 'all hooks registered',
     }),
+    checkClaudeSettingsFn: async () => ({ check: 'claude-settings', status: 'ok', message: 'ok' }),
   };
 }
 
@@ -619,6 +622,357 @@ describe('runDoctor', () => {
       expect(result.errorCount).toBe(1);
       expect(result.warningCount).toBe(1);
       expect(result.ok).toBe(false);
+    });
+  });
+
+  // ── #133: missing update_channel → warning + auto-fix ────────────────────
+
+  describe('vault.yml missing update_channel (#133)', () => {
+    it('emits warning (not error) when only update_channel is missing; --fix backfills "stable"', async () => {
+      // Real vault.yml on disk so checkVaultYmlKeys + getFix both touch real files.
+      const vaultYmlPath = join(tempDir, 'vault.yml');
+      await writeFile(
+        vaultYmlPath,
+        `folders:
+  inbox: 00-inbox
+  projects: 01-projects
+  areas: 02-areas
+  knowledge: 03-knowledge
+  resources: 04-resources
+  agent: 05-agent
+  archive: 06-archive
+  logs: 07-logs
+`,
+        'utf8',
+      );
+
+      // 1. Validator: warning, not error
+      const validators = makeAllOkValidators();
+      validators.checkVaultYmlKeysFn = checkVaultYmlKeys;
+
+      const result = await runDoctor({ vaultDir: tempDir, isTTY: false, ...validators });
+
+      expect(result.errorCount).toBe(0);
+      expect(result.warningCount).toBe(1);
+
+      // 2. --fix runs and writes update_channel: stable
+      await runDoctor({
+        vaultDir: tempDir,
+        isTTY: false,
+        fix: true,
+        ...validators,
+      });
+
+      const after = parseYaml(await readFile(vaultYmlPath, 'utf8')) as Record<string, unknown>;
+      expect(after['update_channel']).toBe('stable');
+
+      // Idempotency: second --fix run produces byte-identical vault.yml.
+      const firstBytes = await readFile(vaultYmlPath, 'utf8');
+      await runDoctor({
+        vaultDir: tempDir,
+        isTTY: false,
+        fix: true,
+        ...validators,
+      });
+      const secondBytes = await readFile(vaultYmlPath, 'utf8');
+      expect(secondBytes).toBe(firstBytes);
+    });
+
+    // Defense in depth (#7): the validator must propagate `missing key:
+    // update_channel` into result.details — otherwise downstream getFix() at
+    // doctor.ts (which checks r.details.some(...)) silently no-ops.
+    it('checkVaultYmlKeys exposes "missing key: update_channel" in details when only that key is absent', async () => {
+      const vaultYmlPath = join(tempDir, 'vault.yml');
+      await writeFile(
+        vaultYmlPath,
+        `folders:
+  inbox: 00-inbox
+  projects: 01-projects
+  areas: 02-areas
+  knowledge: 03-knowledge
+  resources: 04-resources
+  agent: 05-agent
+  archive: 06-archive
+  logs: 07-logs
+`,
+        'utf8',
+      );
+
+      const r = await checkVaultYmlKeys(tempDir);
+      expect(r.status).toBe('warn');
+      expect(r.details).toBeDefined();
+      expect(r.details).toContain('missing key: update_channel');
+    });
+  });
+
+  // ── stale extraKnownMarketplaces.onebrain.source.repo → warn + auto-fix ──
+
+  describe('stale extraKnownMarketplaces.onebrain.source.repo', () => {
+    it('emits warning when stale repo present; --fix rewrites to canonical', async () => {
+      // Vault-level settings.json: <tempDir>/.claude/settings.json with stale repo
+      await mkdir(join(tempDir, '.claude'), { recursive: true });
+      const settingsPath = join(tempDir, '.claude', 'settings.json');
+      const initialContent = `${JSON.stringify(
+        {
+          extraKnownMarketplaces: {
+            onebrain: {
+              source: { repo: 'kengio/onebrain' },
+            },
+          },
+        },
+        null,
+        2,
+      )}\n`;
+      await writeFile(settingsPath, initialContent, 'utf8');
+
+      const validators = makeAllOkValidators();
+      // Real implementation reads vault-level settings.json
+      validators.checkClaudeSettingsFn = (vaultDir) => checkClaudeSettings(vaultDir);
+
+      const result = await runDoctor({ vaultDir: tempDir, isTTY: false, ...validators });
+
+      expect(result.errorCount).toBe(0);
+      expect(result.warningCount).toBe(1);
+
+      // --fix rewrites
+      await runDoctor({ vaultDir: tempDir, isTTY: false, fix: true, ...validators });
+
+      const after = JSON.parse(await readFile(settingsPath, 'utf8')) as Record<string, unknown>;
+      const repo = (
+        (
+          (after['extraKnownMarketplaces'] as Record<string, unknown>)?.['onebrain'] as Record<
+            string,
+            unknown
+          >
+        )?.['source'] as Record<string, unknown>
+      )?.['repo'];
+      expect(repo).toBe('onebrain-ai/onebrain');
+
+      // Trailing newline preserved
+      expect((await readFile(settingsPath, 'utf8')).endsWith('\n')).toBe(true);
+
+      // Idempotent: second --fix run is a no-op (file content unchanged)
+      const beforeSecond = await readFile(settingsPath, 'utf8');
+      await runDoctor({ vaultDir: tempDir, isTTY: false, fix: true, ...validators });
+      const afterSecond = await readFile(settingsPath, 'utf8');
+      expect(afterSecond).toBe(beforeSecond);
+    });
+
+    it('malformed JSON in [vault]/.claude/settings.json → warn, no throw', async () => {
+      await mkdir(join(tempDir, '.claude'), { recursive: true });
+      const settingsPath = join(tempDir, '.claude', 'settings.json');
+      await writeFile(settingsPath, '{not json', 'utf8');
+
+      const r = await checkClaudeSettings(tempDir);
+      expect(r.status).toBe('warn');
+      expect(r.message.toLowerCase()).toContain('json');
+
+      // runDoctor (full pipeline) must not crash either
+      const validators = makeAllOkValidators();
+      validators.checkClaudeSettingsFn = (vaultDir) => checkClaudeSettings(vaultDir);
+      const result = await runDoctor({ vaultDir: tempDir, isTTY: false, ...validators });
+      expect(result.errorCount).toBe(0);
+      expect(result.warningCount).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  // ── #5: fixFailedCount + exit code propagation ───────────────────────────
+
+  describe('--fix failure propagation', () => {
+    it('fix that throws → fixFailedCount === 1, exitCode 1, ok false', async () => {
+      // Unix-only: relies on POSIX ENOTDIR semantics for mkdir-under-regular-file.
+      // Windows surfaces a different errno and the trick isn't reliable there.
+      if (process.platform === 'win32') return;
+
+      // Set up: a missing-folder warning that will trigger getFix(), but the
+      // fix's mkdir will fail because we point at an unwritable parent.
+      const validators = makeAllOkValidators();
+      validators.checkFoldersFn = async () => ({
+        check: 'folders',
+        status: 'error',
+        message: '0/8 present',
+        hint: 'Missing: 00-inbox',
+        details: ['missing: 00-inbox'],
+      });
+
+      // Run --fix against a NON-EXISTENT vaultDir so mkdir fails
+      // (parent doesn't exist, recursive: true still succeeds — instead use a
+      // path component that's a regular file so mkdir errors with ENOTDIR).
+      const blockerFile = join(tempDir, 'blocker');
+      await writeFile(blockerFile, 'not-a-dir', 'utf8');
+      const blockedVault = join(blockerFile, 'sub-vault');
+
+      const result = await runDoctor({
+        vaultDir: blockedVault,
+        isTTY: false,
+        fix: true,
+        ...validators,
+      });
+
+      expect(result.fixFailedCount).toBe(1);
+      expect(result.exitCode).toBe(1);
+      expect(result.ok).toBe(false);
+    });
+
+    it('fix that succeeds → fixFailedCount === 0', async () => {
+      const validators = makeAllOkValidators();
+      validators.checkFoldersFn = async () => ({
+        check: 'folders',
+        status: 'error',
+        message: '0/1 present',
+        hint: 'Missing: 00-inbox',
+        details: ['missing: 00-inbox'],
+      });
+
+      const result = await runDoctor({
+        vaultDir: tempDir,
+        isTTY: false,
+        fix: true,
+        ...validators,
+      });
+
+      expect(result.fixFailedCount).toBe(0);
+      // Original folders check was an error → exitCode 1 still applies
+      expect(result.errorCount).toBe(1);
+    });
+  });
+
+  // ── #6: loadVaultConfig non-ENOENT error surfaces to stderr ──────────────
+
+  describe('loadVaultConfig error surfacing', () => {
+    it('non-ENOENT loadVaultConfig error writes warning to stderr; ENOENT stays silent', async () => {
+      const stderrChunks: string[] = [];
+      const originalWrite = process.stderr.write.bind(process.stderr);
+      // biome-ignore lint/suspicious/noExplicitAny: overriding overloaded write for test capture
+      (process.stderr as any).write = (chunk: string | Uint8Array, ...args: unknown[]): boolean => {
+        if (typeof chunk === 'string') stderrChunks.push(chunk);
+        return originalWrite(
+          chunk as string,
+          ...(args as [BufferEncoding?, ((err?: Error | null) => void)?]),
+        );
+      };
+      try {
+        const validators = makeAllOkValidators();
+        validators.loadVaultConfigFn = async () => {
+          throw new Error('parse error: unexpected token at line 3');
+        };
+        await runDoctor({ vaultDir: tempDir, isTTY: false, ...validators });
+      } finally {
+        process.stderr.write = originalWrite;
+      }
+
+      expect(stderrChunks.join('')).toContain('doctor: vault.yml load warning:');
+      expect(stderrChunks.join('')).toContain('parse error');
+    });
+
+    it('ENOENT loadVaultConfig error is silent (first-run path)', async () => {
+      const stderrChunks: string[] = [];
+      const originalWrite = process.stderr.write.bind(process.stderr);
+      // biome-ignore lint/suspicious/noExplicitAny: overriding overloaded write for test capture
+      (process.stderr as any).write = (chunk: string | Uint8Array, ...args: unknown[]): boolean => {
+        if (typeof chunk === 'string') stderrChunks.push(chunk);
+        return originalWrite(
+          chunk as string,
+          ...(args as [BufferEncoding?, ((err?: Error | null) => void)?]),
+        );
+      };
+      try {
+        const validators = makeAllOkValidators();
+        validators.loadVaultConfigFn = async () => {
+          const err = new Error('ENOENT: no such file or directory') as NodeJS.ErrnoException;
+          err.code = 'ENOENT';
+          throw err;
+        };
+        await runDoctor({ vaultDir: tempDir, isTTY: false, ...validators });
+      } finally {
+        process.stderr.write = originalWrite;
+      }
+
+      expect(stderrChunks.join('')).not.toContain('vault.yml load warning');
+    });
+  });
+
+  // ── #6: end-to-end smoke — 3 drifts at once ──────────────────────────────
+
+  describe('end-to-end: 3 drifts in one --fix pass', () => {
+    it('missing update_channel + deprecated key + stale marketplace repo all auto-fix in one run', async () => {
+      // 1. vault.yml: missing update_channel + deprecated `method:` key
+      const vaultYmlPath = join(tempDir, 'vault.yml');
+      await writeFile(
+        vaultYmlPath,
+        `method: legacy
+folders:
+  inbox: 00-inbox
+  projects: 01-projects
+  areas: 02-areas
+  knowledge: 03-knowledge
+  resources: 04-resources
+  agent: 05-agent
+  archive: 06-archive
+  logs: 07-logs
+`,
+        'utf8',
+      );
+
+      // 2. [vault]/.claude/settings.json: stale marketplace repo
+      await mkdir(join(tempDir, '.claude'), { recursive: true });
+      const settingsPath = join(tempDir, '.claude', 'settings.json');
+      const stale = `${JSON.stringify(
+        {
+          extraKnownMarketplaces: {
+            onebrain: { source: { repo: 'kengio/onebrain' } },
+          },
+        },
+        null,
+        2,
+      )}\n`;
+      await writeFile(settingsPath, stale, 'utf8');
+
+      const validators = makeAllOkValidators();
+      validators.checkVaultYmlKeysFn = checkVaultYmlKeys;
+      validators.checkClaudeSettingsFn = (vaultDir) => checkClaudeSettings(vaultDir);
+
+      // Pre-fix: at least 2 warnings (vault.yml-keys covers both update_channel
+      // missing + deprecated method: under one check; claude-settings is the 2nd).
+      const pre = await runDoctor({ vaultDir: tempDir, isTTY: false, ...validators });
+      expect(pre.warningCount).toBeGreaterThanOrEqual(2);
+
+      // --fix all
+      const result = await runDoctor({ vaultDir: tempDir, isTTY: false, fix: true, ...validators });
+      expect(result.fixFailedCount).toBe(0);
+      expect(result.errorCount).toBe(0);
+
+      // Each file shows the expected post-fix state.
+      const vaultAfter = parseYaml(await readFile(vaultYmlPath, 'utf8')) as Record<string, unknown>;
+      expect(vaultAfter['update_channel']).toBe('stable');
+      expect(vaultAfter['method']).toBeUndefined();
+
+      const settingsAfter = JSON.parse(await readFile(settingsPath, 'utf8')) as Record<
+        string,
+        unknown
+      >;
+      const repo = (
+        (
+          (settingsAfter['extraKnownMarketplaces'] as Record<string, unknown>)?.[
+            'onebrain'
+          ] as Record<string, unknown>
+        )?.['source'] as Record<string, unknown>
+      )?.['repo'];
+      expect(repo).toBe('onebrain-ai/onebrain');
+
+      // Re-run doctor (no --fix): post-fix vault is healthy on these dimensions.
+      const post = await runDoctor({ vaultDir: tempDir, isTTY: false, ...validators });
+      expect(post.errorCount).toBe(0);
+      // No warning should match any of the 3 drift signatures.
+      const warnTexts: string[] = [];
+      // We don't have direct access to results, so re-run the validators that we
+      // used for the drifts and assert they're 'ok' now.
+      const ymlKeys = await checkVaultYmlKeys(tempDir);
+      const claude = await checkClaudeSettings(tempDir);
+      warnTexts.push(JSON.stringify(ymlKeys));
+      warnTexts.push(JSON.stringify(claude));
+      expect(ymlKeys.status).toBe('ok');
+      expect(claude.status).toBe('ok');
     });
   });
 });

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -2,6 +2,8 @@ import pc from 'picocolors';
 import {
   type DoctorResult,
   type VaultConfig,
+  atomicWrite,
+  checkClaudeSettings,
   checkFolders,
   checkOrphanCheckpoints,
   checkPluginFiles,
@@ -42,6 +44,7 @@ export interface DoctorOptions {
   checkPluginFilesFn?: (vaultDir: string) => Promise<DoctorResult>;
   checkVaultYmlKeysFn?: (vaultDir: string) => Promise<DoctorResult>;
   checkSettingsHooksFn?: (vaultDir: string, config: VaultConfig) => Promise<DoctorResult>;
+  checkClaudeSettingsFn?: (vaultDir: string) => Promise<DoctorResult>;
   registerHooksFn?: (vaultDir: string) => Promise<void>;
   /** Injectable delay (for tests — pass `async () => {}` to skip animation delays). */
   delayFn?: (ms: number) => Promise<void>;
@@ -52,6 +55,8 @@ export interface DoctorCommandResult {
   exitCode: number;
   errorCount: number;
   warningCount: number;
+  /** Number of fixes that threw during `--fix`. 0 when --fix wasn't requested. */
+  fixFailedCount: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -70,6 +75,7 @@ export async function runDoctor(opts: DoctorOptions = {}): Promise<DoctorCommand
   const checkPluginFilesFn = opts.checkPluginFilesFn ?? checkPluginFiles;
   const checkVaultYmlKeysFn = opts.checkVaultYmlKeysFn ?? checkVaultYmlKeys;
   const checkSettingsHooksFn = opts.checkSettingsHooksFn ?? checkSettingsHooks;
+  const checkClaudeSettingsFn = opts.checkClaudeSettingsFn ?? checkClaudeSettings;
 
   if (isTTY) {
     await printBanner();
@@ -112,8 +118,16 @@ export async function runDoctor(opts: DoctorOptions = {}): Promise<DoctorCommand
   if (vaultYmlResult.status === 'ok') {
     try {
       config = await loadVaultConfigFn(vaultDir);
-    } catch {
-      // use default config
+    } catch (err) {
+      // ENOENT → first-run path: defaults are correct, stay silent.
+      // Any other code (YAML parse, EACCES, EIO) needs to surface so the user
+      // doesn't silently see "vault.yml ok" while the rest of doctor falls back
+      // to defaults that don't match their actual layout.
+      const code = (err as NodeJS.ErrnoException)?.code;
+      if (code !== 'ENOENT') {
+        const msg = err instanceof Error ? err.message : String(err);
+        process.stderr.write(`doctor: vault.yml load warning: ${msg}\n`);
+      }
     }
   }
   await randDelay();
@@ -129,6 +143,7 @@ export async function runDoctor(opts: DoctorOptions = {}): Promise<DoctorCommand
   let pluginFilesResult: DoctorResult;
   let vaultYmlKeysResult: DoctorResult;
   let settingsHooksResult: DoctorResult;
+  let claudeSettingsResult: DoctorResult;
 
   if (isTTY) {
     const sp2 = createStep('⚙️', 'Config schema');
@@ -160,6 +175,11 @@ export async function runDoctor(opts: DoctorOptions = {}): Promise<DoctorCommand
     qmdResult = await checkQmdEmbeddingsFn(config);
     await randDelay();
     sp7!.stop(fmtResult(qmdResult), qmdResult.details);
+
+    const sp8 = createStep('🛒', 'Marketplace config');
+    claudeSettingsResult = await checkClaudeSettingsFn(vaultDir);
+    await randDelay();
+    sp8!.stop(fmtResult(claudeSettingsResult), claudeSettingsResult.details);
   } else {
     [
       foldersResult,
@@ -168,6 +188,7 @@ export async function runDoctor(opts: DoctorOptions = {}): Promise<DoctorCommand
       pluginFilesResult,
       vaultYmlKeysResult,
       settingsHooksResult,
+      claudeSettingsResult,
     ] = await Promise.all([
       checkFoldersFn(vaultDir, config),
       checkQmdEmbeddingsFn(config),
@@ -175,6 +196,7 @@ export async function runDoctor(opts: DoctorOptions = {}): Promise<DoctorCommand
       checkPluginFilesFn(vaultDir),
       checkVaultYmlKeysFn(vaultDir),
       checkSettingsHooksFn(vaultDir, config),
+      checkClaudeSettingsFn(vaultDir),
     ]);
   }
 
@@ -186,6 +208,7 @@ export async function runDoctor(opts: DoctorOptions = {}): Promise<DoctorCommand
     settingsHooksResult,
     orphanResult,
     qmdResult,
+    claudeSettingsResult,
   ];
 
   const totalChecks = results.length;
@@ -226,15 +249,18 @@ export async function runDoctor(opts: DoctorOptions = {}): Promise<DoctorCommand
     }
   }
 
+  let fixFailedCount = 0;
   if (opts.fix) {
-    await applyFixes(vaultDir, results, isTTY, opts.registerHooksFn);
+    fixFailedCount = await applyFixes(vaultDir, results, isTTY, opts.registerHooksFn);
   }
 
+  const ok = errorCount === 0 && fixFailedCount === 0;
   return {
-    ok: errorCount === 0,
-    exitCode: errorCount > 0 ? 1 : 0,
+    ok,
+    exitCode: ok ? 0 : 1,
     errorCount,
     warningCount,
+    fixFailedCount,
   };
 }
 
@@ -324,24 +350,30 @@ function getFix(r: DoctorResult): Fix | null {
     };
   }
 
-  // vault.yml-keys: deprecated keys → remove them
+  // vault.yml-keys: deprecated keys → remove them; missing soft-required keys → backfill
   const hasDeprecatedKeys = r.details?.some(
     (d) =>
       d.includes('deprecated key: onebrain_version') ||
       d.includes('deprecated key: method') ||
       d.includes('deprecated key: runtime.harness'),
   );
-  if (r.check === 'vault.yml-keys' && r.status === 'warn' && hasDeprecatedKeys) {
+  const hasMissingUpdateChannel = r.details?.some((d) => d === 'missing key: update_channel');
+  if (
+    r.check === 'vault.yml-keys' &&
+    r.status === 'warn' &&
+    (hasDeprecatedKeys || hasMissingUpdateChannel)
+  ) {
     const deprecated = (r.details ?? [])
       .filter((d) => d.startsWith('deprecated key:'))
       .map((d) => d.slice('deprecated key: '.length).split(' ')[0] ?? d);
+    const fixParts: string[] = [];
+    if (hasMissingUpdateChannel) fixParts.push('add update_channel: stable');
+    if (deprecated.length > 0) fixParts.push(`remove deprecated: ${deprecated.join(', ')}`);
     const description =
-      deprecated.length > 0
-        ? `Remove deprecated keys from vault.yml: ${deprecated.join(', ')}`
-        : 'Remove deprecated keys from vault.yml';
+      fixParts.length > 0 ? `Fix vault.yml: ${fixParts.join('; ')}` : 'Fix vault.yml';
     return {
       fn: async (vaultDir) => {
-        const { readFile, writeFile, rename } = await import('node:fs/promises');
+        const { readFile } = await import('node:fs/promises');
         const { join } = await import('node:path');
         const { parse, stringify } = await import('yaml');
         const vaultYmlPath = join(vaultDir, 'vault.yml');
@@ -360,10 +392,10 @@ function getFix(r: DoctorResult): Fix | null {
             }
           }
         }
-        const updated = stringify(raw, { lineWidth: 0 });
-        const tmpPath = `${vaultYmlPath}.tmp`;
-        await writeFile(tmpPath, updated, 'utf8');
-        await rename(tmpPath, vaultYmlPath);
+        if (details.some((d) => d === 'missing key: update_channel')) {
+          raw['update_channel'] = 'stable';
+        }
+        await atomicWrite(vaultYmlPath, stringify(raw, { lineWidth: 0 }), 'vault.yml');
       },
       description,
     };
@@ -410,6 +442,33 @@ function getFix(r: DoctorResult): Fix | null {
     };
   }
 
+  // claude-settings: stale extraKnownMarketplaces.onebrain.source.repo → rewrite
+  if (
+    r.check === 'claude-settings' &&
+    r.status === 'warn' &&
+    r.details?.some((d) => d.startsWith('stale extraKnownMarketplaces.onebrain.source.repo:'))
+  ) {
+    return {
+      fn: async (vaultDir) => {
+        const { readFile } = await import('node:fs/promises');
+        const { join } = await import('node:path');
+        const settingsPath = join(vaultDir, '.claude', 'settings.json');
+        const text = await readFile(settingsPath, 'utf8');
+        const raw = JSON.parse(text) as Record<string, unknown>;
+        const marketplaces = raw['extraKnownMarketplaces'] as Record<string, unknown> | undefined;
+        const onebrain = marketplaces?.['onebrain'] as Record<string, unknown> | undefined;
+        const source = onebrain?.['source'] as Record<string, unknown> | undefined;
+        if (!source || source['repo'] !== 'kengio/onebrain') return; // idempotent — already canonical or absent
+        source['repo'] = 'onebrain-ai/onebrain';
+        // Preserve 2-space indentation (matches Claude Code's own formatter) + trailing newline
+        const trailingNewline = text.endsWith('\n') ? '\n' : '';
+        const updated = `${JSON.stringify(raw, null, 2)}${trailingNewline}`;
+        await atomicWrite(settingsPath, updated, '.claude/settings.json');
+      },
+      description: 'Rewrite stale marketplace repo: kengio/onebrain → onebrain-ai/onebrain',
+    };
+  }
+
   // folders missing → mkdir -p
   if (r.check === 'folders' && r.status === 'error' && r.hint) {
     const missingStr = r.hint.replace('Missing: ', '');
@@ -437,7 +496,7 @@ async function applyFixes(
   results: DoctorResult[],
   isTTY: boolean,
   registerHooksFn: ((vaultDir: string) => Promise<void>) | undefined,
-): Promise<void> {
+): Promise<number> {
   const fixable = results.filter((r) => r.status !== 'ok' && getFix(r) !== null);
 
   if (fixable.length === 0) {
@@ -445,7 +504,7 @@ async function applyFixes(
     // "Nothing to fix" as a plain line (no `│` prefix) to match that closure.
     if (isTTY) writeLine(`${pc.green('◆')}  Nothing to fix`);
     else writeLine('nothing to fix');
-    return;
+    return 0;
   }
 
   if (isTTY) {
@@ -465,13 +524,14 @@ async function applyFixes(
       barLine(pc.dim('No'));
       barBlank();
       close(`No changes made — run ${pc.cyan('onebrain doctor --fix')} to apply`);
-      return;
+      return 0;
     }
     barLine('Yes');
     barBlank();
   }
 
   let fixed = 0;
+  let fixFailed = 0;
   const unfixable: DoctorResult[] = [];
 
   for (const r of results) {
@@ -486,6 +546,7 @@ async function applyFixes(
       fixed++;
       if (isTTY) barLine(`${pc.green('◆')}  ${fix.description}`);
     } catch (err) {
+      fixFailed++;
       const errMsg = err instanceof Error ? err.message : String(err);
       if (isTTY) {
         barLine(`${pc.yellow('▲')}  Could not fix ${r.check}: ${errMsg}`);
@@ -498,6 +559,9 @@ async function applyFixes(
   if (isTTY) {
     barBlank();
     if (fixed > 0) barLine(`${pc.green('◆')}  Fixed ${fixed} issue(s)`);
+    if (fixFailed > 0) {
+      barLine(`${pc.yellow('▲')}  ${fixFailed} fix(es) failed — see warnings above`);
+    }
     if (unfixable.length > 0) {
       barLine(`${pc.yellow('▲')}  ${unfixable.length} issue(s) require manual action:`);
       for (const r of unfixable) {
@@ -508,8 +572,11 @@ async function applyFixes(
     close('Done');
   } else {
     process.stdout.write(`fixed: ${fixed}\n`);
+    if (fixFailed > 0) process.stdout.write(`fix-failed: ${fixFailed}\n`);
     if (unfixable.length > 0) {
       process.stdout.write(`manual: ${unfixable.map((r) => r.check).join(', ')}\n`);
     }
   }
+
+  return fixFailed;
 }

--- a/src/commands/internal/vault-sync.test.ts
+++ b/src/commands/internal/vault-sync.test.ts
@@ -383,6 +383,101 @@ describe('runVaultSync', () => {
     expect(result.error).toContain('403');
   });
 
+  // ── Test 14: pin writes lastUpdated (#132) ─────────────────────────────
+
+  it('pin writes lastUpdated to onebrain@onebrain entry — falls back to now() when plugin.json has none', async () => {
+    const pluginsDir = join(vaultDir, '.fake-claude-plugins');
+    const cacheDir = join(pluginsDir, 'cache');
+    const entryPath = join(cacheDir, 'onebrain', 'onebrain', '1.10.0');
+    await mkdir(entryPath, { recursive: true });
+
+    const installedJson = {
+      plugins: {
+        'onebrain@onebrain': [
+          {
+            id: 'onebrain',
+            source: 'project',
+            installPath: entryPath,
+            version: '1.10.0',
+          },
+        ],
+      },
+    };
+    const installedPath = join(pluginsDir, 'installed_plugins.json');
+    await writeFile(installedPath, JSON.stringify(installedJson, null, 2), 'utf8');
+
+    // Tarball plugin.json carries no `lastUpdated` → vault-sync falls back to now()
+    const fixedNow = new Date('2026-05-06T12:00:00.000Z');
+    const result = await runVaultSync(vaultDir, {
+      fetchFn: mockFetchWithTarball(tarball),
+      installedPluginsPath: installedPath,
+      installedPluginsCacheDir: cacheDir,
+      now: () => fixedNow,
+    });
+
+    expect(result.ok).toBe(true);
+    const after = JSON.parse(await readFile(installedPath, 'utf8'));
+    const entry = after.plugins['onebrain@onebrain'][0];
+    expect(entry.lastUpdated).toBe(fixedNow.toISOString());
+    expect(entry.version).toBe('1.11.0'); // matches tarball plugin.json
+  });
+
+  // ── Test 15: pin dedups orphan onebrain@onebrain entries (#132) ────────
+
+  it('pin removes orphan onebrain@onebrain entries whose projectPath is missing; preserves others', async () => {
+    const pluginsDir = join(vaultDir, '.fake-claude-plugins');
+    const cacheDir = join(pluginsDir, 'cache');
+    const validProject = await mkdtemp(join(tmpdir(), 'onebrain-valid-vault-'));
+
+    const installedJson = {
+      plugins: {
+        'onebrain@onebrain': [
+          {
+            id: 'onebrain',
+            source: 'project',
+            installPath: join(vaultDir, '.claude/plugins/onebrain'),
+            projectPath: validProject,
+            version: '1.10.0',
+          },
+          {
+            id: 'onebrain',
+            source: 'project',
+            installPath: join(vaultDir, '.claude/plugins/onebrain'),
+            projectPath: `/tmp/nonexistent-vault-${Date.now()}`,
+            version: '1.10.0',
+          },
+        ],
+        // Different plugin — must be preserved entirely (even orphans)
+        'other-plugin@somewhere': [
+          {
+            id: 'other-plugin',
+            source: 'project',
+            projectPath: `/tmp/another-nonexistent-${Date.now()}`,
+          },
+        ],
+      },
+    };
+    const installedPath = join(pluginsDir, 'installed_plugins.json');
+    await mkdir(pluginsDir, { recursive: true });
+    await writeFile(installedPath, JSON.stringify(installedJson, null, 2), 'utf8');
+
+    const result = await runVaultSync(vaultDir, {
+      fetchFn: mockFetchWithTarball(tarball),
+      installedPluginsPath: installedPath,
+      installedPluginsCacheDir: cacheDir,
+    });
+
+    expect(result.ok).toBe(true);
+    const after = JSON.parse(await readFile(installedPath, 'utf8'));
+    // Orphan removed; valid kept
+    expect(after.plugins['onebrain@onebrain'].length).toBe(1);
+    expect(after.plugins['onebrain@onebrain'][0].projectPath).toBe(validProject);
+    // Other plugin entry untouched even though its projectPath also doesn't exist
+    expect(after.plugins['other-plugin@somewhere'].length).toBe(1);
+
+    await rm(validProject, { recursive: true });
+  });
+
   // ── Test 13: filesRemoved counts actual deletions only ─────────────────
 
   it('filesRemoved counts actual deletions: unlinkFn throws for one of 2 stale files → filesRemoved === 1', async () => {
@@ -412,5 +507,162 @@ describe('runVaultSync', () => {
     expect(result.ok).toBe(true);
     // Only 1 of the 2 stale files was actually deleted
     expect(result.filesRemoved).toBe(1);
+  });
+
+  // ── Test 16: cross-vault isolation — syncing vault A leaves vault B alone ──
+
+  it('pin only refreshes the entry whose installPath matches THIS vault', async () => {
+    const pluginsDir = join(vaultDir, '.fake-claude-plugins');
+    const cacheDir = join(pluginsDir, 'cache');
+    await mkdir(pluginsDir, { recursive: true });
+
+    const otherVaultPluginDir = '/path/to/other/vault/.claude/plugins/onebrain';
+    const installedJson = {
+      plugins: {
+        'onebrain@onebrain': [
+          {
+            // This vault — should be refreshed
+            id: 'onebrain',
+            source: 'project',
+            installPath: join(vaultDir, '.claude/plugins/onebrain'),
+            version: '1.10.0',
+            lastUpdated: '2026-01-01T00:00:00.000Z',
+          },
+          {
+            // Different vault — must stay byte-identical
+            id: 'onebrain',
+            source: 'project',
+            installPath: otherVaultPluginDir,
+            version: '2.0.0',
+            lastUpdated: '2025-12-31T23:59:59.000Z',
+          },
+        ],
+      },
+    };
+    const installedPath = join(pluginsDir, 'installed_plugins.json');
+    await writeFile(installedPath, JSON.stringify(installedJson, null, 2), 'utf8');
+
+    const result = await runVaultSync(vaultDir, {
+      fetchFn: mockFetchWithTarball(tarball),
+      installedPluginsPath: installedPath,
+      installedPluginsCacheDir: cacheDir,
+    });
+
+    expect(result.ok).toBe(true);
+    const after = JSON.parse(await readFile(installedPath, 'utf8'));
+    const entries = after.plugins['onebrain@onebrain'];
+
+    // This vault's entry: refreshed to tarball version
+    const thisVaultEntry = entries.find(
+      (e: { installPath: string }) => e.installPath === join(vaultDir, '.claude/plugins/onebrain'),
+    );
+    expect(thisVaultEntry.version).toBe('1.11.0');
+
+    // Other vault's entry: untouched
+    const otherVaultEntry = entries.find(
+      (e: { installPath: string }) => e.installPath === otherVaultPluginDir,
+    );
+    expect(otherVaultEntry.version).toBe('2.0.0');
+    expect(otherVaultEntry.lastUpdated).toBe('2025-12-31T23:59:59.000Z');
+  });
+
+  // ── Test 17: idempotency — back-to-back syncs at same version are byte-identical ──
+
+  it('pin is idempotent: second sync at same version produces byte-identical installed_plugins.json', async () => {
+    const pluginsDir = join(vaultDir, '.fake-claude-plugins');
+    const cacheDir = join(pluginsDir, 'cache');
+    await mkdir(pluginsDir, { recursive: true });
+
+    const installedJson = {
+      plugins: {
+        'onebrain@onebrain': [
+          {
+            id: 'onebrain',
+            source: 'project',
+            installPath: join(vaultDir, '.claude/plugins/onebrain'),
+            version: '1.11.0', // matches tarball
+            lastUpdated: '2026-01-01T00:00:00.000Z',
+          },
+        ],
+      },
+    };
+    const installedPath = join(pluginsDir, 'installed_plugins.json');
+    await writeFile(installedPath, JSON.stringify(installedJson, null, 2), 'utf8');
+
+    // First sync
+    await runVaultSync(vaultDir, {
+      fetchFn: mockFetchWithTarball(tarball),
+      installedPluginsPath: installedPath,
+      installedPluginsCacheDir: cacheDir,
+    });
+    const firstBytes = await readFile(installedPath, 'utf8');
+
+    // Second sync with a different `now` — version unchanged → lastUpdated must NOT churn
+    await runVaultSync(vaultDir, {
+      fetchFn: mockFetchWithTarball(tarball),
+      installedPluginsPath: installedPath,
+      installedPluginsCacheDir: cacheDir,
+      now: () => new Date('2027-06-15T12:00:00.000Z'),
+    });
+    const secondBytes = await readFile(installedPath, 'utf8');
+
+    expect(secondBytes).toBe(firstBytes);
+  });
+
+  // ── Test 18: orphan dedup preserves entry when stat fails with EACCES (#3) ──
+
+  it('orphan dedup preserves entry when projectPath stat throws non-ENOENT (e.g. EACCES on unmounted drive)', async () => {
+    // Unix-only: chmod 0o000 doesn't yield EACCES on Windows the same way.
+    if (process.platform === 'win32') return;
+
+    const pluginsDir = join(vaultDir, '.fake-claude-plugins');
+    const cacheDir = join(pluginsDir, 'cache');
+    await mkdir(pluginsDir, { recursive: true });
+
+    // Simulate unmounted external drive: a path under macOS's /Volumes/<missing>
+    // would yield ENOENT not EACCES, so we use a path that would EACCES on a
+    // real install — e.g. a random component under /private/var/db/* which
+    // restricts access. Easier + portable: write into a directory we then
+    // chmod 000 so stat() on a nested file returns EACCES.
+    const lockedParent = join(vaultDir, 'locked-parent');
+    await mkdir(lockedParent, { recursive: true });
+    const inaccessiblePath = join(lockedParent, 'subdir');
+    await mkdir(inaccessiblePath, { recursive: true });
+    // chmod 000 on the parent → stat on inaccessiblePath throws EACCES
+    const { chmod } = await import('node:fs/promises');
+    await chmod(lockedParent, 0o000);
+
+    const installedJson = {
+      plugins: {
+        'onebrain@onebrain': [
+          {
+            id: 'onebrain',
+            source: 'project',
+            installPath: join(vaultDir, '.claude/plugins/onebrain'),
+            projectPath: inaccessiblePath,
+            version: '1.10.0',
+          },
+        ],
+      },
+    };
+    const installedPath = join(pluginsDir, 'installed_plugins.json');
+    await writeFile(installedPath, JSON.stringify(installedJson, null, 2), 'utf8');
+
+    try {
+      const result = await runVaultSync(vaultDir, {
+        fetchFn: mockFetchWithTarball(tarball),
+        installedPluginsPath: installedPath,
+        installedPluginsCacheDir: cacheDir,
+      });
+
+      expect(result.ok).toBe(true);
+      const after = JSON.parse(await readFile(installedPath, 'utf8'));
+      // Entry preserved despite EACCES
+      expect(after.plugins['onebrain@onebrain'].length).toBe(1);
+      expect(after.plugins['onebrain@onebrain'][0].projectPath).toBe(inaccessiblePath);
+    } finally {
+      // Restore perms so afterEach rm -rf can clean up
+      await chmod(lockedParent, 0o755);
+    }
   });
 });

--- a/src/commands/internal/vault-sync.ts
+++ b/src/commands/internal/vault-sync.ts
@@ -17,22 +17,13 @@
  * Non-TTY: plain text prefixed with "vault-sync:"
  */
 
-import {
-  mkdir,
-  mkdtemp,
-  readFile,
-  readdir,
-  rename,
-  rm,
-  stat,
-  unlink,
-  writeFile,
-} from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, readdir, rm, stat, unlink, writeFile } from 'node:fs/promises';
 import { homedir, tmpdir } from 'node:os';
 import { dirname, join, relative } from 'node:path';
 import { intro, outro, spinner } from '@clack/prompts';
 import pc from 'picocolors';
 import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
+import { atomicWrite } from '../../lib/index.js';
 import { makeStepFn } from './cli-ui.js';
 import { detectHarness } from './harness.js';
 
@@ -57,6 +48,8 @@ export interface VaultSyncOptions {
   includeObsidian?: boolean;
   /** When true, suppress clack intro/outro and use cli-ui bar format (called as sub-operation from init). */
   embedded?: boolean;
+  /** Injectable now (for tests — defaults to () => new Date()). */
+  now?: () => Date;
 }
 
 export interface VaultSyncResult {
@@ -335,10 +328,7 @@ async function updateVaultYml(vaultRoot: string, updateChannel: string): Promise
   const raw = (parseYaml(text) ?? {}) as Record<string, unknown>;
   raw['update_channel'] = updateChannel;
 
-  const updated = stringifyYaml(raw, { lineWidth: 0 });
-  const tmpPath = `${vaultYmlPath}.tmp`;
-  await writeFile(tmpPath, updated, 'utf8');
-  await rename(tmpPath, vaultYmlPath);
+  await atomicWrite(vaultYmlPath, stringifyYaml(raw, { lineWidth: 0 }), 'vault.yml');
 }
 
 // ---------------------------------------------------------------------------
@@ -346,9 +336,12 @@ async function updateVaultYml(vaultRoot: string, updateChannel: string): Promise
 // ---------------------------------------------------------------------------
 
 /**
- * Read plugin.json version from the synced plugin dir.
+ * Read plugin.json `version` and `lastUpdated` from the synced plugin dir.
+ * `lastUpdated` is optional in plugin.json — callers fall back to `new Date().toISOString()`.
  */
-async function readPluginVersion(vaultRoot: string): Promise<string> {
+async function readPluginMetadata(
+  vaultRoot: string,
+): Promise<{ version: string; lastUpdated: string | undefined }> {
   // plugin.json lives in .claude/plugins/onebrain/.claude-plugin/plugin.json
   const pluginJsonPath = join(
     vaultRoot,
@@ -361,9 +354,12 @@ async function readPluginVersion(vaultRoot: string): Promise<string> {
   try {
     const text = await readFile(pluginJsonPath, 'utf8');
     const parsed = JSON.parse(text) as Record<string, unknown>;
-    return typeof parsed['version'] === 'string' ? parsed['version'] : 'unknown';
+    const version = typeof parsed['version'] === 'string' ? parsed['version'] : 'unknown';
+    const lastUpdated =
+      typeof parsed['lastUpdated'] === 'string' ? parsed['lastUpdated'] : undefined;
+    return { version, lastUpdated };
   } catch {
-    return 'unknown';
+    return { version: 'unknown', lastUpdated: undefined };
   }
 }
 
@@ -375,6 +371,7 @@ async function pinToVault(
   vaultRoot: string,
   installedPluginsPath: string,
   installedPluginsCacheDir: string | undefined,
+  now: () => Date = () => new Date(),
 ): Promise<PinResult> {
   // Read installed_plugins.json
   let text: string;
@@ -403,7 +400,9 @@ async function pinToVault(
   }
 
   const vaultPluginDir = join(vaultRoot, '.claude', 'plugins', 'onebrain');
-  const pluginVersion = await readPluginVersion(vaultRoot);
+  const { version: pluginVersion, lastUpdated: pluginLastUpdated } =
+    await readPluginMetadata(vaultRoot);
+  const updatedAt = pluginLastUpdated ?? now().toISOString();
 
   // Determine cache dir: installed_plugins.json parent → plugins/ → cache/
   const cacheDir = installedPluginsCacheDir ?? join(dirname(installedPluginsPath), 'cache');
@@ -418,6 +417,40 @@ async function pinToVault(
   }
 
   let changed = false;
+
+  // Dedup orphan `onebrain@onebrain` entries whose `projectPath` no longer exists.
+  // Only ENOENT counts as orphan — any other stat error (EACCES on an unmounted
+  // external drive, EIO, etc.) preserves the entry so we don't silently delete
+  // user data. Limited to `onebrain@onebrain` plugin key (per-vault project pins).
+  const ONEBRAIN_KEY = 'onebrain@onebrain';
+  if (Array.isArray(plugins[ONEBRAIN_KEY])) {
+    const before = plugins[ONEBRAIN_KEY] as Array<Record<string, unknown>>;
+    const keep: Array<Record<string, unknown>> = [];
+    for (const entry of before) {
+      const projectPath = entry['projectPath'];
+      if (typeof projectPath !== 'string') {
+        keep.push(entry);
+        continue;
+      }
+      try {
+        await stat(projectPath);
+        keep.push(entry);
+      } catch (err) {
+        const code = (err as NodeJS.ErrnoException)?.code;
+        if (code === 'ENOENT') continue; // genuine orphan — drop
+        // Any other code (EACCES, EIO, ENOTDIR, …): preserve + warn.
+        process.stderr.write(
+          `vault-sync: pin warning: stat ${projectPath}: ${code ?? 'unknown'}\n`,
+        );
+        keep.push(entry);
+      }
+    }
+    if (keep.length !== before.length) {
+      plugins[ONEBRAIN_KEY] = keep;
+      changed = true;
+    }
+  }
+
   for (const key of onebrainKeys) {
     const entries = plugins[key] as Array<Record<string, unknown>>;
     for (const entry of entries) {
@@ -426,22 +459,34 @@ async function pinToVault(
         continue;
       }
 
-      // Only rewrite if installPath is inside the cache dir
+      // Scope refresh to the vault being synced (entries whose installPath is
+      // already this vault's plugin dir, OR that still point at the cache and
+      // will be rewritten to it). Other vaults pinned to different installPaths
+      // are left alone — syncing vault A must not stomp vault B's pinned version.
       let inCache = false;
       try {
-        // resolves any symlinks before comparison (normalize)
         inCache = installPath.startsWith(`${cacheDir}/`) || installPath === cacheDir;
       } catch {
         inCache = false;
       }
+      const isThisVault = installPath === vaultPluginDir;
 
-      if (!inCache) {
+      if (inCache) {
+        entry['installPath'] = vaultPluginDir;
+        changed = true;
+      } else if (!isThisVault) {
+        // Different vault — skip; do not touch its version/lastUpdated.
         continue;
       }
 
-      entry['installPath'] = vaultPluginDir;
-      entry['version'] = pluginVersion;
-      changed = true;
+      // Refresh version on this vault's entry; only bump lastUpdated when
+      // version actually changes so back-to-back syncs of the same version
+      // produce a byte-identical installed_plugins.json.
+      if (entry['version'] !== pluginVersion) {
+        entry['version'] = pluginVersion;
+        entry['lastUpdated'] = updatedAt;
+        changed = true;
+      }
     }
   }
 
@@ -449,11 +494,7 @@ async function pinToVault(
     return { skipped: false }; // Already pinned — no change needed
   }
 
-  // Atomic write via temp file + rename
-  const tmpPath = `${installedPluginsPath}.tmp`;
-  await writeFile(tmpPath, JSON.stringify(data, null, 4), 'utf8');
-  // rename is atomic on POSIX
-  await rename(tmpPath, installedPluginsPath);
+  await atomicWrite(installedPluginsPath, JSON.stringify(data, null, 4), 'installed_plugins.json');
 
   return { skipped: false };
 }
@@ -727,6 +768,7 @@ export async function runVaultSync(
           vaultRoot,
           installedPluginsPath,
           installedPluginsCacheDir,
+          opts.now,
         );
         result.pinSkipped = pinResult.skipped;
         if (pinResult.skipped) {

--- a/src/lib/fs-atomic.test.ts
+++ b/src/lib/fs-atomic.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { atomicWrite } from './fs-atomic.js';
+
+let workDir: string;
+
+beforeEach(async () => {
+  workDir = await mkdtemp(join(tmpdir(), 'fs-atomic-test-'));
+});
+
+afterEach(async () => {
+  await rm(workDir, { recursive: true, force: true });
+});
+
+describe('atomicWrite', () => {
+  it('writes file successfully and removes the .tmp staging file on the happy path', async () => {
+    const dest = join(workDir, 'foo.txt');
+    await atomicWrite(dest, 'bar');
+
+    expect(await readFile(dest, 'utf8')).toBe('bar');
+
+    // .tmp must not linger
+    let tmpExists = false;
+    try {
+      await stat(`${dest}.tmp`);
+      tmpExists = true;
+    } catch {
+      tmpExists = false;
+    }
+    expect(tmpExists).toBe(false);
+  });
+
+  it('overwrites an existing file atomically', async () => {
+    const dest = join(workDir, 'overwrite.txt');
+    await writeFile(dest, 'old', 'utf8');
+    await atomicWrite(dest, 'new');
+    expect(await readFile(dest, 'utf8')).toBe('new');
+  });
+
+  it('cleans up .tmp and rethrows with `cause` when rename fails', async () => {
+    // Force rename failure: pre-create dest as a non-empty directory.
+    // POSIX `rename(file, dir)` fails with EISDIR / ENOTEMPTY (Linux/macOS),
+    // Windows fails with EPERM. Either way the catch branch runs.
+    const dest = join(workDir, 'collide');
+    await mkdir(dest, { recursive: true });
+    await writeFile(join(dest, 'occupant.txt'), 'cannot-be-removed', 'utf8');
+
+    let thrown: unknown;
+    try {
+      await atomicWrite(dest, 'payload', 'collide-target');
+    } catch (err) {
+      thrown = err;
+    }
+
+    expect(thrown).toBeInstanceOf(Error);
+    expect((thrown as Error).message).toContain('rename failed for collide-target');
+    expect((thrown as Error).message).toContain('tmp cleaned up');
+    // `cause` must be the original errno error
+    expect((thrown as Error).cause).toBeDefined();
+
+    // .tmp file is gone
+    let tmpExists = false;
+    try {
+      await stat(`${dest}.tmp`);
+      tmpExists = true;
+    } catch {
+      tmpExists = false;
+    }
+    expect(tmpExists).toBe(false);
+  });
+});

--- a/src/lib/fs-atomic.ts
+++ b/src/lib/fs-atomic.ts
@@ -1,0 +1,21 @@
+import { rename, unlink, writeFile } from 'node:fs/promises';
+
+/**
+ * Atomic write: stage to `<dest>.tmp`, then rename. If rename fails (cross-
+ * device, permission, ENOSPC, dest-is-directory), remove the staged tmp file
+ * before rethrowing with context — otherwise the tmp lingers on disk forever.
+ *
+ * The thrown Error preserves the original via the `cause` property so callers
+ * can still inspect the underlying errno.
+ */
+export async function atomicWrite(dest: string, contents: string, label?: string): Promise<void> {
+  const tmpPath = `${dest}.tmp`;
+  await writeFile(tmpPath, contents, 'utf8');
+  try {
+    await rename(tmpPath, dest);
+  } catch (err) {
+    await unlink(tmpPath).catch(() => {});
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(`rename failed for ${label ?? dest}; tmp cleaned up: ${msg}`, { cause: err });
+  }
+}

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -19,4 +19,7 @@ export {
   checkPluginFiles,
   checkVaultYmlKeys,
   checkSettingsHooks,
+  checkClaudeSettings,
 } from './validator.js';
+
+export { atomicWrite } from './fs-atomic.js';

--- a/src/lib/validator.ts
+++ b/src/lib/validator.ts
@@ -371,7 +371,12 @@ export async function checkPluginFiles(vaultRoot: string): Promise<DoctorResult>
 // checkVaultYmlKeys
 // ---------------------------------------------------------------------------
 
-const REQUIRED_VAULT_YML_KEYS = ['update_channel', 'folders'] as const;
+const REQUIRED_VAULT_YML_KEYS = ['folders'] as const;
+// Keys whose absence is a recoverable warning (auto-fix supplies a default)
+// rather than a blocking error. update_channel was previously required+error;
+// downgraded to warning + auto-fix in v2.1.11 to match the migration step that
+// now backfills `update_channel: stable`.
+const SOFT_REQUIRED_VAULT_YML_KEYS = ['update_channel'] as const;
 const REQUIRED_FOLDER_KEYS = [
   'inbox',
   'projects',
@@ -419,9 +424,14 @@ export async function checkVaultYmlKeys(vaultRoot: string): Promise<DoctorResult
   const errors: string[] = [];
   const warnings: string[] = [];
 
-  // Required top-level keys
+  // Required top-level keys (hard — error)
   for (const key of REQUIRED_VAULT_YML_KEYS) {
     if (raw[key] === undefined) errors.push(`missing key: ${key}`);
+  }
+
+  // Soft-required top-level keys (warn — auto-fix supplies a default)
+  for (const key of SOFT_REQUIRED_VAULT_YML_KEYS) {
+    if (raw[key] === undefined) warnings.push(`missing key: ${key}`);
   }
 
   // Required folder sub-keys
@@ -430,7 +440,7 @@ export async function checkVaultYmlKeys(vaultRoot: string): Promise<DoctorResult
     if (folders[key] === undefined) errors.push(`missing folders.${key}`);
   }
 
-  // update_channel value validation
+  // update_channel value validation (only when present — absence handled above)
   const updateChannel = raw['update_channel'];
   if (updateChannel !== undefined && updateChannel !== 'stable' && updateChannel !== 'next') {
     errors.push(`invalid update_channel: ${String(updateChannel)} (must be stable or next)`);
@@ -475,14 +485,19 @@ export async function checkVaultYmlKeys(vaultRoot: string): Promise<DoctorResult
   }
 
   if (warnings.length > 0) {
-    const fixableWarnings = warnings.filter(
+    const hasDeprecated = warnings.some(
       (w) =>
         w.includes('onebrain_version') || w.includes('method') || w.includes('runtime.harness'),
     );
-    const hint =
-      fixableWarnings.length > 0
-        ? 'Run onebrain doctor --fix to remove deprecated keys'
-        : undefined;
+    const hasMissingSoftKey = warnings.some((w) => w.startsWith('missing key:'));
+    let hint: string | undefined;
+    if (hasMissingSoftKey && hasDeprecated) {
+      hint = 'Run onebrain doctor --fix to repair vault.yml';
+    } else if (hasMissingSoftKey) {
+      hint = 'Run onebrain doctor --fix to backfill defaults';
+    } else if (hasDeprecated) {
+      hint = 'Run onebrain doctor --fix to remove deprecated keys';
+    }
     return {
       check: 'vault.yml-keys',
       status: 'warn',
@@ -497,6 +512,59 @@ export async function checkVaultYmlKeys(vaultRoot: string): Promise<DoctorResult
     status: 'ok',
     message: 'schema ok',
   };
+}
+
+// ---------------------------------------------------------------------------
+// checkClaudeSettings — vault-level [vault]/.claude/settings.json drift
+// ---------------------------------------------------------------------------
+
+const STALE_MARKETPLACE_REPO = 'kengio/onebrain';
+const CANONICAL_MARKETPLACE_REPO = 'onebrain-ai/onebrain';
+
+/**
+ * Check vault-level `[vault]/.claude/settings.json` for stale OneBrain
+ * marketplace config. The repo was renamed `kengio/onebrain` →
+ * `onebrain-ai/onebrain`; GitHub auto-redirects, but the literal in settings
+ * is stale and worth a one-time rewrite. Skips silently when the file or key
+ * is missing.
+ */
+export async function checkClaudeSettings(vaultRoot: string): Promise<DoctorResult> {
+  const settingsPath = join(vaultRoot, '.claude', 'settings.json');
+  const file = Bun.file(settingsPath);
+
+  if (!(await file.exists())) {
+    return { check: 'claude-settings', status: 'ok', message: 'no vault settings.json' };
+  }
+
+  let raw: Record<string, unknown>;
+  try {
+    raw = JSON.parse(await file.text()) as Record<string, unknown>;
+  } catch {
+    return {
+      check: 'claude-settings',
+      status: 'warn',
+      message: 'settings.json contains invalid JSON',
+    };
+  }
+
+  const marketplaces = raw['extraKnownMarketplaces'] as Record<string, unknown> | undefined;
+  const onebrain = marketplaces?.['onebrain'] as Record<string, unknown> | undefined;
+  const source = onebrain?.['source'] as Record<string, unknown> | undefined;
+  const repo = source?.['repo'];
+
+  if (repo === STALE_MARKETPLACE_REPO) {
+    return {
+      check: 'claude-settings',
+      status: 'warn',
+      message: 'stale marketplace repo',
+      hint: 'Run onebrain doctor --fix to rewrite to onebrain-ai/onebrain',
+      details: [
+        `stale extraKnownMarketplaces.onebrain.source.repo: ${STALE_MARKETPLACE_REPO} → ${CANONICAL_MARKETPLACE_REPO}`,
+      ],
+    };
+  }
+
+  return { check: 'claude-settings', status: 'ok', message: 'ok' };
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Bundles three post-migration config-consistency fixes that previously left auto-redirect-masked drift in user vaults. All three live in the same family — "user-side config drift after `/update` or `vault-sync` runs" — and share a fix pattern (validator warns, doctor `--fix` rewrites atomically, `/update` skill prevents future drift).

Closes #133 · Closes #132

## What's in this PR

### CLI track (`v2.1.10 → v2.1.11`)

**Validator** (`src/lib/validator.ts`)
- Missing `update_channel` in vault.yml: severity downgraded from 🔴 error → 🟡 warning (#133). Value validation (must be `stable`/`next` when present) stays error.
- New `checkClaudeSettings(vaultRoot)`: warns on stale `extraKnownMarketplaces.onebrain.source.repo: kengio/onebrain` in `[vault]/.claude/settings.json`.

**Doctor** (`src/commands/doctor.ts`)
- `--fix`: backfills `update_channel: stable` to vault.yml when missing (#133)
- `--fix`: rewrites stale marketplace repo `kengio/onebrain` → `onebrain-ai/onebrain` in `[vault]/.claude/settings.json`
- New `result.fixFailedCount`: counts fixes that threw; bumps `exitCode` to 1 so CI catches `--fix` failures
- `loadVaultConfig` distinguishes `ENOENT` (silent — legitimate first-run) from other errors (stderr warning + use defaults)

**Vault-sync** (`src/commands/internal/vault-sync.ts`) — fixes #132
- `installed_plugins.json` `version` + `lastUpdated` refresh now scoped to **the current vault only** (entries whose `installPath` matches `vaultPluginDir`); other vaults' entries are byte-identical before/after sync
- `lastUpdated` only bumps when `version` actually changes — back-to-back same-version syncs produce a byte-identical file
- Orphan dedup: only `ENOENT` from `stat(projectPath)` removes the entry; other codes (EACCES/EIO/ENOTDIR) preserve the entry and write a `vault-sync: pin warning: ...` line to stderr (no silent data loss on offline drives)

**New `src/lib/fs-atomic.ts`**
- Shared `atomicWrite(dest, contents, label)` helper: writes to `*.tmp` then renames; on `rename` failure, unlinks the tmp and rethrows with `{ cause }` and label context
- Used by all four `writeFile + rename` sites in this PR (vault.yml fix, settings.json fix, vault-sync's vault.yml + installed_plugins.json writes)

### Plugin track (`v2.2.3 → v2.2.4`)

**`/update` skill** (`.claude/plugins/onebrain/skills/update/references/migration-steps.md`)
- Step 8: now also adds `update_channel: stable` to vault.yml when missing (prevention side of #133)
- Step 9 (new): rewrites stale `extraKnownMarketplaces.onebrain.source.repo: kengio/onebrain` → `onebrain-ai/onebrain` in `[vault]/.claude/settings.json` (atomic, idempotent)

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun test` — **261 → 266 pass** (+5 new tests; +1 new test file `src/lib/fs-atomic.test.ts`); 0 fail; 17 files; 630 expects
- [x] `bunx biome check` on changed files — 0 errors (9 pre-existing `noNonNullAssertion` warnings on `spN!.stop` patterns)
- [x] Idempotency: `update_channel` and `extraKnownMarketplaces` fixes both assert byte-identical second run
- [x] Cross-vault isolation: vault A sync leaves vault B's `installed_plugins.json` entry byte-identical
- [x] Vault-sync byte-idempotent at same version (no churn on `lastUpdated`)
- [x] EACCES preservation: `chmod 0o000` parent → entry preserved + stderr warning (Unix-only test, Windows-skip-gated)
- [x] `atomicWrite` cleanup-on-failure: forced rename failure → tmp removed + `error.cause` truthy
- [x] End-to-end smoke: vault with `update_channel` missing + deprecated `method:` + stale marketplace → `runDoctor({fix:true})` → re-validate returns clean
- [x] Malformed JSON in `[vault]/.claude/settings.json` → validator warns without crashing
- [x] Windows-skip gates on Unix-only tests (chmod/ENOTDIR-dependent) — addresses prior cross-platform issues (#126/#128/#129)

## Coverage notes for reviewers

- The end-to-end smoke test exercises the **two doctor-side drifts** (#133 + marketplace) since `runDoctor` does not invoke `vault-sync`. The `installed_plugins.json` drift (#132) is structurally a `vault-sync` concern and is covered separately in `src/commands/internal/vault-sync.test.ts` (cross-vault isolation, byte-idempotency, ENOENT orphan dedup, EACCES preservation).
- Single version bump per file: `package.json` 2.1.10 → 2.1.11; `plugin.json` 2.2.3 → 2.2.4.

## Review process

4 review rounds + 1 final pre-PR sanity check (5 total). Round 1 found 7 items, round 3 found 6 residuals, round 5 returned `READY — no blockers`.

Deferred (out of scope for this PR):
- YAML comment preservation in vault.yml `--fix` (fix uses `yaml.stringify(raw)` which normalizes formatting)
- `DoctorResult` discriminated-union refactor (cross-cutting; future PR)
- `readPluginMetadata` `'unknown'` sentinel collision (low priority)