### PR TITLE
docs(readme): align Co-Evolution diagram + copy with website 3-step loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,9 +111,9 @@ The agent reaches outward FROM the vault to every surface where the work actuall
 
 ---
 
-## The Path to Co-Evolution
+## Every Session Sharpens Both
 
-A tightening 3-step loop that sharpens with every cycle.
+OneBrain runs as a tight 3-step loop. Each cycle, both sides sharpen.
 
 <p align="center">
   <picture>
@@ -122,7 +122,7 @@ A tightening 3-step loop that sharpens with every cycle.
   </picture>
 </p>
 
-1. **Capture** — Talk in natural language. The agent writes, classifies, and links your thoughts in real time. → `/braindump` · `/capture` · `/bookmark`
+1. **Capture** — Talk to the agent in natural language. It writes, classifies, and links your thoughts in real time. → `/braindump` · `/capture` · `/bookmark`
 2. **Evolve** — `/research` and `/distill` expand your knowledge. `/learn` deepens the agent. The loop tightens. → `/research` · `/distill` · `/learn`
 3. **Wrapup** — `/wrapup` consolidates the session log. `/recap` promotes lessons to memory. → `/wrapup` · `/recap`
 

--- a/README.md
+++ b/README.md
@@ -118,13 +118,13 @@ A tightening 3-step loop that sharpens with every cycle.
 <p align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="assets/diagrams/coevo-loop-dark.svg">
-    <img alt="Co-Evolution loop — three nodes (01 INITIATE at top, 02 CAPTURE_INTENT at bottom-right, 03 MUTUAL_EVOLUTION at bottom-left) connected by curved arrows flowing clockwise" src="assets/diagrams/coevo-loop-light.svg" width="540">
+    <img alt="Co-Evolution loop — three nodes (01 CAPTURE at top, 02 EVOLVE at bottom-right, 03 WRAPUP at bottom-left) connected by curved arrows flowing clockwise" src="assets/diagrams/coevo-loop-light.svg" width="540">
   </picture>
 </p>
 
-1. **Initiate** — Install the CLI, run `/onboarding`. The agent learns your name, vault, and identity. → `npm install -g @onebrain-ai/cli`
-2. **Capture intent** — Talk in natural language. The agent writes, classifies, and links in real time. → `/braindump` · `/capture` · `/bookmark`
-3. **Mutual evolution** — `/research` and `/distill` expand your knowledge. `/learn` deepens the agent. The loop tightens. → `/research` · `/distill` · `/learn`
+1. **Capture** — Talk in natural language. The agent writes, classifies, and links your thoughts in real time. → `/braindump` · `/capture` · `/bookmark`
+2. **Evolve** — `/research` and `/distill` expand your knowledge. `/learn` deepens the agent. The loop tightens. → `/research` · `/distill` · `/learn`
+3. **Wrapup** — `/wrapup` consolidates the session log. `/recap` promotes lessons to memory. → `/wrapup` · `/recap`
 
 ### Behind the loop
 

--- a/assets/diagrams/coevo-loop-dark.svg
+++ b/assets/diagrams/coevo-loop-dark.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="-225 -200 450 395" width="450" height="395" role="img" aria-labelledby="title desc" font-family="'Chakra Petch', 'Inter', ui-sans-serif, system-ui, sans-serif">
   <title id="title">The Path to Co-Evolution — three-step loop</title>
-  <desc id="desc">Three nodes arranged in a triangle: 01 INITIATE at top, 02 CAPTURE_INTENT at bottom-right, 03 MUTUAL_EVOLUTION at bottom-left. Curved arrows flow clockwise between them, visualizing the recurring co-evolution loop.</desc>
+  <desc id="desc">Three nodes arranged in a triangle: 01 CAPTURE at top, 02 EVOLVE at bottom-right, 03 WRAPUP at bottom-left. Curved arrows flow clockwise between them, visualizing the recurring co-evolution loop.</desc>
 
   <style>
     .text-strong { fill: #ffffff; }
@@ -48,27 +48,35 @@
     <path d="M -85.6 18.2 Q -82.2 -47.5 -27 -83.2" fill="none" stroke="#00f3ff" stroke-width="1.6" marker-end="url(#ah-3)"/>
   </g>
 
+  <!-- Node 01 — CAPTURE (top): single-line name + short cmd inside the
+       circle. The 01→02 arrow exits the bottom of this circle, so an
+       outside-bottom cmd label would collide with the arrow path —
+       hence cmd stays inside, abbreviated to one command. The README
+       prose carries the full triple. -->
   <g transform="translate(0,-130)">
     <circle cx="0" cy="0" r="54" fill="rgba(2,2,4,0.92)" stroke="#ff2d92" stroke-width="1.5"/>
     <text x="0" y="-12" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-size="11" font-weight="700" fill="#ff2d92" letter-spacing="0.18em">01</text>
-    <text x="0" y="6" text-anchor="middle" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="14" letter-spacing="0.05em" class="text-strong">INITIATE</text>
-    <text x="0" y="22" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-size="8" letter-spacing="0.30em" fill="#ff2d92">/onboarding</text>
+    <text x="0" y="6" text-anchor="middle" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="14" letter-spacing="0.05em" class="text-strong">CAPTURE</text>
+    <text x="0" y="22" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-size="8" letter-spacing="0.28em" fill="#ff2d92">/braindump</text>
   </g>
 
+  <!-- Node 02 — EVOLVE (bottom-right): cmd outside below the circle.
+       The 02→03 arrow's apex sits at y=110 (well above the cmd at
+       abs y=141), so no overlap. -->
   <g transform="translate(112.6,65)">
     <circle cx="0" cy="0" r="54" fill="rgba(2,2,4,0.92)" stroke="#bc13fe" stroke-width="1.5"/>
     <text x="0" y="-12" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-size="11" font-weight="700" fill="#bc13fe" letter-spacing="0.18em">02</text>
-    <text x="0" y="3" text-anchor="middle" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="13" letter-spacing="0.05em" class="text-strong">CAPTURE</text>
-    <text x="0" y="17" text-anchor="middle" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="13" letter-spacing="0.05em" class="text-strong">INTENT</text>
-    <text x="0" y="68" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-size="8" letter-spacing="0.28em" fill="#bc13fe">/braindump · /capture</text>
+    <text x="0" y="6" text-anchor="middle" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="14" letter-spacing="0.05em" class="text-strong">EVOLVE</text>
+    <text x="0" y="68" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-size="8" letter-spacing="0.28em" fill="#bc13fe">/distill · /learn</text>
   </g>
 
+  <!-- Node 03 — WRAPUP (bottom-left): cmd outside below the circle.
+       Mirror of node 02 — no arrow path crosses this cmd region. -->
   <g transform="translate(-112.6,65)">
     <circle cx="0" cy="0" r="54" fill="rgba(2,2,4,0.92)" stroke="#00f3ff" stroke-width="1.5"/>
     <text x="0" y="-12" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-size="11" font-weight="700" fill="#00f3ff" letter-spacing="0.18em">03</text>
-    <text x="0" y="3" text-anchor="middle" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="13" letter-spacing="0.05em" class="text-strong">MUTUAL</text>
-    <text x="0" y="17" text-anchor="middle" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="13" letter-spacing="0.05em" class="text-strong">EVOLUTION</text>
-    <text x="0" y="68" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-size="8" letter-spacing="0.28em" fill="#00f3ff">/recap · /distill · /learn</text>
+    <text x="0" y="6" text-anchor="middle" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="14" letter-spacing="0.05em" class="text-strong">WRAPUP</text>
+    <text x="0" y="68" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-size="8" letter-spacing="0.28em" fill="#00f3ff">/wrapup · /recap</text>
   </g>
 
 </svg>

--- a/assets/diagrams/coevo-loop-light.svg
+++ b/assets/diagrams/coevo-loop-light.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="-225 -200 450 395" width="450" height="395" role="img" aria-labelledby="title desc" font-family="'Chakra Petch', 'Inter', ui-sans-serif, system-ui, sans-serif">
   <title id="title">The Path to Co-Evolution — three-step loop</title>
-  <desc id="desc">Three nodes arranged in a triangle: 01 INITIATE at top, 02 CAPTURE_INTENT at bottom-right, 03 MUTUAL_EVOLUTION at bottom-left. Curved arrows flow clockwise between them, visualizing the recurring co-evolution loop.</desc>
+  <desc id="desc">Three nodes arranged in a triangle: 01 CAPTURE at top, 02 EVOLVE at bottom-right, 03 WRAPUP at bottom-left. Curved arrows flow clockwise between them, visualizing the recurring co-evolution loop.</desc>
 
   <style>
     .text-strong { fill: #0a0a14; }
@@ -54,30 +54,35 @@
     <path d="M -85.6 18.2 Q -82.2 -47.5 -27 -83.2" fill="none" stroke="#00788c" stroke-width="1.6" marker-end="url(#ah-3)"/>
   </g>
 
-  <!-- Node 01 — INITIATE -->
+  <!-- Node 01 — CAPTURE (top): single-line name + short cmd inside the
+       circle. The 01→02 arrow exits the bottom of this circle, so an
+       outside-bottom cmd label would collide with the arrow path —
+       hence cmd stays inside, abbreviated to one command. The README
+       prose carries the full triple. -->
   <g transform="translate(0,-130)">
     <circle cx="0" cy="0" r="54" fill="#ffffff" stroke="#c91075" stroke-width="1.5"/>
     <text x="0" y="-12" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-size="11" font-weight="700" fill="#c91075" letter-spacing="0.18em">01</text>
-    <text x="0" y="6" text-anchor="middle" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="14" letter-spacing="0.05em" class="text-strong">INITIATE</text>
-    <text x="0" y="22" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-size="8" letter-spacing="0.30em" fill="#c91075">/onboarding</text>
+    <text x="0" y="6" text-anchor="middle" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="14" letter-spacing="0.05em" class="text-strong">CAPTURE</text>
+    <text x="0" y="22" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-size="8" letter-spacing="0.28em" fill="#c91075">/braindump</text>
   </g>
 
-  <!-- Node 02 — CAPTURE INTENT -->
+  <!-- Node 02 — EVOLVE (bottom-right): cmd outside below the circle.
+       The 02→03 arrow's apex sits at y=110 (well above the cmd at
+       abs y=141), so no overlap. -->
   <g transform="translate(112.6,65)">
     <circle cx="0" cy="0" r="54" fill="#ffffff" stroke="#7c1ade" stroke-width="1.5"/>
     <text x="0" y="-12" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-size="11" font-weight="700" fill="#7c1ade" letter-spacing="0.18em">02</text>
-    <text x="0" y="3" text-anchor="middle" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="13" letter-spacing="0.05em" class="text-strong">CAPTURE</text>
-    <text x="0" y="17" text-anchor="middle" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="13" letter-spacing="0.05em" class="text-strong">INTENT</text>
-    <text x="0" y="68" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-size="8" letter-spacing="0.28em" fill="#7c1ade">/braindump · /capture</text>
+    <text x="0" y="6" text-anchor="middle" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="14" letter-spacing="0.05em" class="text-strong">EVOLVE</text>
+    <text x="0" y="68" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-size="8" letter-spacing="0.28em" fill="#7c1ade">/distill · /learn</text>
   </g>
 
-  <!-- Node 03 — MUTUAL EVOLUTION -->
+  <!-- Node 03 — WRAPUP (bottom-left): cmd outside below the circle.
+       Mirror of node 02 — no arrow path crosses this cmd region. -->
   <g transform="translate(-112.6,65)">
     <circle cx="0" cy="0" r="54" fill="#ffffff" stroke="#00788c" stroke-width="1.5"/>
     <text x="0" y="-12" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-size="11" font-weight="700" fill="#00788c" letter-spacing="0.18em">03</text>
-    <text x="0" y="3" text-anchor="middle" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="13" letter-spacing="0.05em" class="text-strong">MUTUAL</text>
-    <text x="0" y="17" text-anchor="middle" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="13" letter-spacing="0.05em" class="text-strong">EVOLUTION</text>
-    <text x="0" y="68" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-size="8" letter-spacing="0.28em" fill="#00788c">/recap · /distill · /learn</text>
+    <text x="0" y="6" text-anchor="middle" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="14" letter-spacing="0.05em" class="text-strong">WRAPUP</text>
+    <text x="0" y="68" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-size="8" letter-spacing="0.28em" fill="#00788c">/wrapup · /recap</text>
   </g>
 
 </svg>


### PR DESCRIPTION
## Summary

Brings the README's \"Co-Evolution\" section in lockstep with the website's HowItWorks section that just shipped in [onebrain-ai/website#8](https://github.com/onebrain-ai/website/pull/8). Both the visual diagram and the surrounding copy are now aligned so anyone reading either surface gets the same words and the same shape.

## Changes

### Diagram (both \`coevo-loop-{dark,light}.svg\`)

- Replaced INITIATE → CAPTURE_INTENT → MUTUAL_EVOLUTION with **CAPTURE → EVOLVE → WRAPUP** (renumbered 01–03). Same node positions, same curved arrow paths, same color palette. The cmd labels match the website's diagram pattern exactly: top node carries cmd inside (single \`/braindump\` — outside-bottom would collide with the 01→02 arrow), bottom nodes carry cmd outside below the circle (\`/distill · /learn\`, \`/wrapup · /recap\`).
- \`<title>\` and \`<desc>\` accessibility metadata renamed to match.

### Copy (README.md)

Section heading + sub-line + step 1 description now match the website verbatim:

- Heading: \`## The Path to Co-Evolution\` → \`## Every Session Sharpens Both\`
- Sub-line: \"A tightening 3-step loop that sharpens with every cycle.\" → \"OneBrain runs as a tight 3-step loop. Each cycle, both sides sharpen.\"
- Step 1: \"Talk in natural language. The agent writes…\" → \"Talk to the agent in natural language. It writes…\"

Steps 2 + 3 already matched. The \`/onboarding\` references elsewhere in README (Behind the loop subsection, install instructions, command list, etc.) are intentionally untouched — onboarding still happens, it's just not part of the recurring loop diagram anymore (it's a one-time bootstrap).

## Reviewed across 4 rounds

- Cross-file consistency (README ↔ SVG ↔ alt text)
- Accessibility text (alt + aria-desc accuracy + tone)
- Cross-repo parity (website canonical ↔ README mirror)
- SVG geometry verification — caught a y=22 cmd-label placement bug that would have overflowed the r=54 circle's chord for any cmd longer than ~14 chars; fixed by mirroring the website's outside-bottom placement on the two bottom nodes and keeping the top node's cmd short and inside.

## Test plan

- [ ] Render both SVGs in GitHub README preview (light + dark auto-switch)
- [ ] Confirm node order CAPTURE (top, magenta) → EVOLVE (bottom-right, violet) → WRAPUP (bottom-left, cyan), arrows clockwise
- [ ] No text/arrow overlap; cmd labels readable
- [ ] \`/onboarding\` mentions in \"Behind the loop\" / install / command list still read coherently
- [ ] Section heading + sub-line + step 1 wording match https://onebrain.run HowItWorks section