### PR TITLE
fix(vault-sync): registry matching by projectPath + test isolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-latest_version: 2.1.11
+latest_version: 2.1.12
 released: 2026-05-06
 ---
 
@@ -12,6 +12,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 > For plugin changes (skills, agents, hooks, INSTRUCTIONS), see [PLUGIN-CHANGELOG.md](PLUGIN-CHANGELOG.md).
 
 ## [Unreleased]
+
+## v2.1.12 — fix(vault-sync): registry matching by projectPath + test isolation
+
+- fix(vault-sync): broaden per-vault registry match — fall back to projectPath when installPath is stale (#147)
+- fix(vault-sync): on projectPath fallback, rewrite stale installPath to canonical vaultPluginDir (#147)
+- fix(vault-sync): inject `installedPluginsPath` option so tests don't pollute real `~/.claude/plugins/installed_plugins.json` (#146)
+- fix(init): same `installedPluginsPath` injection (#146)
+- test(vault-sync): cover stale-installPath + matching-projectPath case
+- test: assert real registry is byte-identical before/after `bun test`
 
 ## v2.1.11 — feat(doctor + vault-sync): backfill vault-side config drift
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onebrain-ai/cli",
-  "version": "2.1.11",
+  "version": "2.1.12",
   "description": "CLI for OneBrain — personal AI OS for Obsidian with persistent memory, 24+ skills, and Claude Code integration",
   "keywords": [
     "onebrain",

--- a/src/commands/init.integration.test.ts
+++ b/src/commands/init.integration.test.ts
@@ -9,12 +9,56 @@
  * error cases where the exit would abort the test process.
  */
 
-import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
 import { mkdir, readFile, rm, stat, writeFile } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
+import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { type InitOptions, runInit } from './init.js';
+
+// ---------------------------------------------------------------------------
+// Suite-level guard: real ~/.claude/plugins/installed_plugins.json must NOT
+// be touched by any test in this file (#146 regression hardening).
+// ---------------------------------------------------------------------------
+
+const REAL_REGISTRY_PATH = join(homedir(), '.claude', 'plugins', 'installed_plugins.json');
+let realRegistrySnapshot: { mtimeMs: number; bytes: string } | null = null;
+let realRegistryWasMissing = false;
+
+beforeAll(async () => {
+  try {
+    const s = await stat(REAL_REGISTRY_PATH);
+    const bytes = await readFile(REAL_REGISTRY_PATH, 'utf8');
+    realRegistrySnapshot = { mtimeMs: s.mtimeMs, bytes };
+  } catch {
+    realRegistryWasMissing = true;
+  }
+});
+
+afterAll(async () => {
+  if (realRegistryWasMissing) {
+    let exists = false;
+    try {
+      await stat(REAL_REGISTRY_PATH);
+      exists = true;
+    } catch {
+      exists = false;
+    }
+    if (exists) {
+      throw new Error(
+        `Test suite created ${REAL_REGISTRY_PATH} which did not exist before tests ran (#146 regression).`,
+      );
+    }
+    return;
+  }
+  if (!realRegistrySnapshot) return;
+  const after = await readFile(REAL_REGISTRY_PATH, 'utf8');
+  if (after !== realRegistrySnapshot.bytes) {
+    throw new Error(
+      `Test suite mutated ${REAL_REGISTRY_PATH} (#146 regression). Some test omitted installedPluginsPath injection. Bytes differ: before=${realRegistrySnapshot.bytes.length}, after=${after.length}.`,
+    );
+  }
+});
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -59,9 +103,13 @@ const STANDARD_FOLDERS = [
 ];
 
 let tempDir: string;
+// Per-test isolated installed_plugins.json. Tests must NEVER fall back to
+// the real ~/.claude/plugins/installed_plugins.json (#146).
+let isolatedInstalledPath: string;
 
 beforeEach(async () => {
   tempDir = await makeTempVault();
+  isolatedInstalledPath = join(tempDir, '.isolated-installed_plugins.json');
 });
 
 afterEach(async () => {
@@ -79,6 +127,7 @@ describe('init integration: fresh vault (non-TTY)', () => {
       isTTY: false,
       vaultSyncFn: noopVaultSync,
       registerHooksFn: noopRegisterHooks,
+      installedPluginsPath: isolatedInstalledPath,
     };
 
     const result = await runInit(opts);
@@ -98,6 +147,7 @@ describe('init integration: fresh vault (non-TTY)', () => {
       isTTY: false,
       vaultSyncFn: noopVaultSync,
       registerHooksFn: noopRegisterHooks,
+      installedPluginsPath: isolatedInstalledPath,
     };
 
     const result = await runInit(opts);
@@ -122,6 +172,7 @@ describe('init integration: fresh vault (non-TTY)', () => {
       isTTY: false,
       vaultSyncFn: noopVaultSync,
       registerHooksFn: noopRegisterHooks,
+      installedPluginsPath: isolatedInstalledPath,
     };
 
     // Should not throw
@@ -142,6 +193,7 @@ describe('init integration: existing vault.yml, no --force (non-TTY)', () => {
       isTTY: false,
       vaultSyncFn: noopVaultSync,
       registerHooksFn: noopRegisterHooks,
+      installedPluginsPath: isolatedInstalledPath,
     };
 
     const result = await runInit(opts);
@@ -162,6 +214,7 @@ describe('init integration: existing vault.yml, no --force (non-TTY)', () => {
       isTTY: false,
       vaultSyncFn: noopVaultSync,
       registerHooksFn: noopRegisterHooks,
+      installedPluginsPath: isolatedInstalledPath,
     };
 
     await runInit(opts);
@@ -201,6 +254,7 @@ describe('init integration: plugin files present (skip vault-sync)', () => {
       force: true,
       vaultSyncFn: trackingVaultSync,
       registerHooksFn: noopRegisterHooks,
+      installedPluginsPath: isolatedInstalledPath,
     };
 
     const result = await runInit(opts);
@@ -225,6 +279,7 @@ describe('init integration: plugin files present (skip vault-sync)', () => {
       force: true,
       vaultSyncFn: noopVaultSync,
       registerHooksFn: noopRegisterHooks,
+      installedPluginsPath: isolatedInstalledPath,
     };
 
     const result = await runInit(opts);

--- a/src/commands/init.test.ts
+++ b/src/commands/init.test.ts
@@ -7,12 +7,56 @@
  * Vault-sync and register-hooks are mocked so tests stay offline and fast.
  */
 
-import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
 import { mkdir, readFile, rm, stat, writeFile } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
+import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { type InitOptions, runInit } from './init.js';
+
+// ---------------------------------------------------------------------------
+// Suite-level guard: real ~/.claude/plugins/installed_plugins.json must NOT
+// be touched by any test in this file (#146 regression hardening).
+// ---------------------------------------------------------------------------
+
+const REAL_REGISTRY_PATH = join(homedir(), '.claude', 'plugins', 'installed_plugins.json');
+let realRegistrySnapshot: { mtimeMs: number; bytes: string } | null = null;
+let realRegistryWasMissing = false;
+
+beforeAll(async () => {
+  try {
+    const s = await stat(REAL_REGISTRY_PATH);
+    const bytes = await readFile(REAL_REGISTRY_PATH, 'utf8');
+    realRegistrySnapshot = { mtimeMs: s.mtimeMs, bytes };
+  } catch {
+    realRegistryWasMissing = true;
+  }
+});
+
+afterAll(async () => {
+  if (realRegistryWasMissing) {
+    let exists = false;
+    try {
+      await stat(REAL_REGISTRY_PATH);
+      exists = true;
+    } catch {
+      exists = false;
+    }
+    if (exists) {
+      throw new Error(
+        `Test suite created ${REAL_REGISTRY_PATH} which did not exist before tests ran (#146 regression).`,
+      );
+    }
+    return;
+  }
+  if (!realRegistrySnapshot) return;
+  const after = await readFile(REAL_REGISTRY_PATH, 'utf8');
+  if (after !== realRegistrySnapshot.bytes) {
+    throw new Error(
+      `Test suite mutated ${REAL_REGISTRY_PATH} (#146 regression). Some test omitted installedPluginsPath injection. Bytes differ: before=${realRegistrySnapshot.bytes.length}, after=${after.length}.`,
+    );
+  }
+});
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -52,9 +96,13 @@ const noopRegisterHooks = async (_vaultDir: string) => {
 };
 
 let tempDir: string;
+// Per-test isolated installed_plugins.json. Tests must NEVER fall back to
+// the real ~/.claude/plugins/installed_plugins.json (#146).
+let isolatedInstalledPath: string;
 
 beforeEach(async () => {
   tempDir = await makeTempVault();
+  isolatedInstalledPath = join(tempDir, '.isolated-installed_plugins.json');
 });
 
 afterEach(async () => {
@@ -76,6 +124,7 @@ describe('runInit', () => {
       vaultDir: tempDir,
       vaultSyncFn: mockVaultSync,
       registerHooksFn: noopRegisterHooks,
+      installedPluginsPath: isolatedInstalledPath,
     };
 
     const result = await runInit(opts);
@@ -120,6 +169,7 @@ describe('runInit', () => {
       isTTY: false,
       vaultSyncFn: noopVaultSync,
       registerHooksFn: noopRegisterHooks,
+      installedPluginsPath: isolatedInstalledPath,
     };
 
     const result = await runInit(opts);
@@ -138,6 +188,7 @@ describe('runInit', () => {
       force: true,
       vaultSyncFn: noopVaultSync,
       registerHooksFn: noopRegisterHooks,
+      installedPluginsPath: isolatedInstalledPath,
     };
 
     const result = await runInit(opts);
@@ -166,6 +217,7 @@ describe('runInit', () => {
       vaultDir: tempDir,
       vaultSyncFn: mockVaultSync,
       registerHooksFn: noopRegisterHooks,
+      installedPluginsPath: isolatedInstalledPath,
     };
 
     const result = await runInit(opts);
@@ -212,6 +264,7 @@ describe('runInit', () => {
       vaultDir: tempDir,
       vaultSyncFn: noopVaultSync,
       registerHooksFn: noopRegisterHooks,
+      installedPluginsPath: isolatedInstalledPath,
     };
 
     const result = await runInit(opts);
@@ -241,6 +294,7 @@ describe('runInit', () => {
         isTTY: false,
         vaultSyncFn: noopVaultSync,
         registerHooksFn: noopRegisterHooks,
+        installedPluginsPath: isolatedInstalledPath,
       };
       const result = await runInit(opts);
       expect(result.ok).toBe(true);
@@ -258,6 +312,7 @@ describe('runInit', () => {
       isTTY: false,
       vaultSyncFn: noopVaultSync,
       registerHooksFn: noopRegisterHooks,
+      installedPluginsPath: isolatedInstalledPath,
       installPluginsFn: async (_vaultDir, _opts) => {
         // community-plugins.json doesn't exist — return empty
         return { installed: [], failed: [] };
@@ -275,6 +330,7 @@ describe('runInit', () => {
       isTTY: false,
       vaultSyncFn: noopVaultSync,
       registerHooksFn: noopRegisterHooks,
+      installedPluginsPath: isolatedInstalledPath,
       installPluginsFn: async (_vaultDir, _opts) => {
         // Invalid ID rejected
         return { installed: [], failed: [{ id: 'bad/id', reason: 'invalid id' }] };
@@ -294,6 +350,7 @@ describe('runInit', () => {
         throw new Error('network error');
       },
       registerHooksFn: noopRegisterHooks,
+      installedPluginsPath: isolatedInstalledPath,
     });
 
     expect(result.ok).toBe(false);
@@ -307,6 +364,7 @@ describe('runInit', () => {
       confirmFn: async () => false,
       vaultSyncFn: noopVaultSync,
       registerHooksFn: noopRegisterHooks,
+      installedPluginsPath: isolatedInstalledPath,
     });
 
     expect(result.ok).toBe(true);
@@ -331,6 +389,7 @@ describe('runInit', () => {
       },
       vaultSyncFn: noopVaultSync,
       registerHooksFn: noopRegisterHooks,
+      installedPluginsPath: isolatedInstalledPath,
     });
 
     expect(result.ok).toBe(true);
@@ -352,6 +411,7 @@ describe('runInit', () => {
       },
       vaultSyncFn: noopVaultSync,
       registerHooksFn: noopRegisterHooks,
+      installedPluginsPath: isolatedInstalledPath,
       installPluginsFn: async () => ({ installed: [], failed: [] }),
       delayFn: async () => {},
     });

--- a/src/commands/internal/vault-sync.test.ts
+++ b/src/commands/internal/vault-sync.test.ts
@@ -5,14 +5,61 @@
  * Verifies all 7 steps with a temp vault dir.
  */
 
-import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
 import { spawnSync } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
 import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
+import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { runVaultSync } from './vault-sync.js';
+
+// ---------------------------------------------------------------------------
+// Suite-level guard: real ~/.claude/plugins/installed_plugins.json must NOT
+// be touched by any test in this file (#146 regression hardening). Snapshot
+// at suite start, assert byte-identical at suite end. ANY test that omits
+// `installedPluginsPath` injection will fail the whole suite.
+// ---------------------------------------------------------------------------
+
+const REAL_REGISTRY_PATH = join(homedir(), '.claude', 'plugins', 'installed_plugins.json');
+let realRegistrySnapshot: { mtimeMs: number; bytes: string } | null = null;
+let realRegistryWasMissing = false;
+
+beforeAll(async () => {
+  try {
+    const s = await stat(REAL_REGISTRY_PATH);
+    const bytes = await readFile(REAL_REGISTRY_PATH, 'utf8');
+    realRegistrySnapshot = { mtimeMs: s.mtimeMs, bytes };
+  } catch {
+    realRegistryWasMissing = true;
+  }
+});
+
+afterAll(async () => {
+  if (realRegistryWasMissing) {
+    let exists = false;
+    try {
+      await stat(REAL_REGISTRY_PATH);
+      exists = true;
+    } catch {
+      exists = false;
+    }
+    if (exists) {
+      throw new Error(
+        `Test suite created ${REAL_REGISTRY_PATH} which did not exist before tests ran (#146 regression).`,
+      );
+    }
+    return;
+  }
+  if (!realRegistrySnapshot) return;
+  const after = await readFile(REAL_REGISTRY_PATH, 'utf8');
+  if (after !== realRegistrySnapshot.bytes) {
+    throw new Error(
+      `Test suite mutated ${REAL_REGISTRY_PATH} (#146 regression). Some test omitted installedPluginsPath injection. Bytes differ: before=${realRegistrySnapshot.bytes.length}, after=${after.length}.`,
+    );
+  }
+});
 
 // ---------------------------------------------------------------------------
 // Tarball builder helpers (uses tar CLI — available on macOS/Linux)
@@ -114,12 +161,17 @@ const VALID_VAULT_YML = 'update_channel: stable\nfolders:\n  inbox: 00-inbox\n  
 describe('runVaultSync', () => {
   let vaultDir: string;
   let tarball: Buffer;
+  // Per-test isolated installed_plugins.json path. Tests that don't override
+  // this default still get a temp path — production fallback to ~/.claude/...
+  // must NEVER fire from tests (#146).
+  let isolatedInstalledPath: string;
 
   beforeEach(async () => {
     vaultDir = await makeVaultDir();
     await mkdir(join(vaultDir, '.claude'), { recursive: true });
     await writeFile(join(vaultDir, 'vault.yml'), VALID_VAULT_YML, 'utf8');
     tarball = buildMockTarball({});
+    isolatedInstalledPath = join(vaultDir, '.isolated-installed_plugins.json');
   });
 
   afterEach(async () => {
@@ -131,6 +183,7 @@ describe('runVaultSync', () => {
   it('fresh sync: syncs all plugin files and root docs', async () => {
     const result = await runVaultSync(vaultDir, {
       fetchFn: mockFetchWithTarball(tarball),
+      installedPluginsPath: isolatedInstalledPath,
     });
 
     expect(result.ok).toBe(true);
@@ -157,6 +210,7 @@ describe('runVaultSync', () => {
 
     const result = await runVaultSync(vaultDir, {
       fetchFn: mockFetchWithTarball(tarball),
+      installedPluginsPath: isolatedInstalledPath,
     });
 
     expect(result.ok).toBe(true);
@@ -223,6 +277,7 @@ describe('runVaultSync', () => {
 
     const result = await runVaultSync(vaultDir, {
       fetchFn: mockFetchWithTarball(tarballWithNewImport),
+      installedPluginsPath: isolatedInstalledPath,
     });
 
     expect(result.ok).toBe(true);
@@ -256,6 +311,7 @@ describe('runVaultSync', () => {
 
     const result = await runVaultSync(vaultDir, {
       fetchFn: mockFetchWithTarball(tarballSameImport),
+      installedPluginsPath: isolatedInstalledPath,
     });
 
     expect(result.ok).toBe(true);
@@ -272,6 +328,7 @@ describe('runVaultSync', () => {
   it('preserves update_channel in vault.yml', async () => {
     const result = await runVaultSync(vaultDir, {
       fetchFn: mockFetchWithTarball(tarball),
+      installedPluginsPath: isolatedInstalledPath,
     });
 
     expect(result.ok).toBe(true);
@@ -349,6 +406,7 @@ describe('runVaultSync', () => {
 
     const result = await runVaultSync(vaultDir2, {
       fetchFn: (async () => new Response('Not Found', { status: 404 })) as unknown as typeof fetch,
+      installedPluginsPath: join(vaultDir2, '.isolated-installed_plugins.json'),
     });
 
     expect(result.ok).toBe(false);
@@ -365,6 +423,7 @@ describe('runVaultSync', () => {
           status: 200,
           headers: { 'content-type': 'application/x-gzip' },
         })) as unknown as typeof fetch,
+      installedPluginsPath: isolatedInstalledPath,
     });
 
     expect(result.ok).toBe(false);
@@ -376,6 +435,7 @@ describe('runVaultSync', () => {
   it('HTTP 403 response → result.ok is false, error contains 403', async () => {
     const result = await runVaultSync(vaultDir, {
       fetchFn: (async () => new Response('Forbidden', { status: 403 })) as unknown as typeof fetch,
+      installedPluginsPath: isolatedInstalledPath,
     });
 
     expect(result.ok).toBe(false);
@@ -502,6 +562,7 @@ describe('runVaultSync', () => {
     const result = await runVaultSync(vaultDir, {
       fetchFn: mockFetchWithTarball(tarball),
       unlinkFn: partialUnlink,
+      installedPluginsPath: isolatedInstalledPath,
     });
 
     expect(result.ok).toBe(true);
@@ -664,5 +725,176 @@ describe('runVaultSync', () => {
       // Restore perms so afterEach rm -rf can clean up
       await chmod(lockedParent, 0o755);
     }
+  });
+
+  // ── Test 19: stale installPath, matching projectPath → refresh + canonicalize (#147) ──
+
+  it('pin matches by projectPath when installPath is stale; rewrites installPath to vaultPluginDir', async () => {
+    const pluginsDir = join(vaultDir, '.fake-claude-plugins');
+    const cacheDir = join(pluginsDir, 'cache');
+    await mkdir(pluginsDir, { recursive: true });
+
+    // A different vault that should NOT be touched (sibling entry).
+    const otherProject = await mkdtemp(join(tmpdir(), 'onebrain-other-vault-'));
+    const otherInstall = join(otherProject, '.claude', 'plugins', 'onebrain');
+
+    const stalePath = `/tmp/gone-${randomUUID()}`; // does not exist
+    const installedJson = {
+      plugins: {
+        'onebrain@onebrain': [
+          {
+            id: 'onebrain',
+            source: 'project',
+            installPath: stalePath, // stale — directory has been deleted
+            projectPath: vaultDir, // identifies THIS vault
+            version: '1.10.0',
+            lastUpdated: '2025-01-01T00:00:00.000Z',
+          },
+          {
+            // Sibling entry — DIFFERENT projectPath, must stay byte-identical
+            id: 'onebrain',
+            source: 'project',
+            installPath: otherInstall,
+            projectPath: otherProject,
+            version: '2.0.0',
+            lastUpdated: '2025-12-31T23:59:59.000Z',
+          },
+        ],
+      },
+    };
+    const installedPath = join(pluginsDir, 'installed_plugins.json');
+    await writeFile(installedPath, JSON.stringify(installedJson, null, 2), 'utf8');
+
+    const fixedNow = new Date('2026-05-06T12:00:00.000Z');
+    const result = await runVaultSync(vaultDir, {
+      fetchFn: mockFetchWithTarball(tarball),
+      installedPluginsPath: installedPath,
+      installedPluginsCacheDir: cacheDir,
+      now: () => fixedNow,
+    });
+
+    expect(result.ok).toBe(true);
+    const after = JSON.parse(await readFile(installedPath, 'utf8'));
+    const entries = after.plugins['onebrain@onebrain'];
+
+    // Find this-vault entry by projectPath (installPath was rewritten)
+    const thisEntry = entries.find((e: { projectPath?: string }) => e.projectPath === vaultDir);
+    expect(thisEntry).toBeDefined();
+    expect(thisEntry.installPath).toBe(join(vaultDir, '.claude/plugins/onebrain'));
+    expect(thisEntry.version).toBe('1.11.0'); // refreshed to tarball
+    expect(thisEntry.lastUpdated).toBe(fixedNow.toISOString()); // bumped
+
+    // Sibling entry untouched
+    const sibling = entries.find((e: { projectPath?: string }) => e.projectPath === otherProject);
+    expect(sibling).toBeDefined();
+    expect(sibling.installPath).toBe(otherInstall);
+    expect(sibling.version).toBe('2.0.0');
+    expect(sibling.lastUpdated).toBe('2025-12-31T23:59:59.000Z');
+
+    await rm(otherProject, { recursive: true, force: true });
+  });
+
+  // ── Test 20: trailing-slash on projectPath still matches (#147 path normalization) ──
+
+  it('pin matches projectPath with trailing slash via path normalization', async () => {
+    const pluginsDir = join(vaultDir, '.fake-claude-plugins');
+    const cacheDir = join(pluginsDir, 'cache');
+    await mkdir(pluginsDir, { recursive: true });
+
+    const stalePath = `/tmp/gone-${randomUUID()}`;
+    const installedJson = {
+      plugins: {
+        'onebrain@onebrain': [
+          {
+            id: 'onebrain',
+            source: 'project',
+            installPath: stalePath,
+            projectPath: `${vaultDir}/`, // trailing slash
+            version: '1.10.0',
+            lastUpdated: '2025-01-01T00:00:00.000Z',
+          },
+        ],
+      },
+    };
+    const installedPath = join(pluginsDir, 'installed_plugins.json');
+    await writeFile(installedPath, JSON.stringify(installedJson, null, 2), 'utf8');
+
+    const result = await runVaultSync(vaultDir, {
+      fetchFn: mockFetchWithTarball(tarball),
+      installedPluginsPath: installedPath,
+      installedPluginsCacheDir: cacheDir,
+    });
+
+    expect(result.ok).toBe(true);
+    const after = JSON.parse(await readFile(installedPath, 'utf8'));
+    const entry = after.plugins['onebrain@onebrain'][0];
+    expect(entry.installPath).toBe(join(vaultDir, '.claude/plugins/onebrain'));
+    expect(entry.version).toBe('1.11.0');
+  });
+
+  // ── Test 21: malformed entry (non-string installPath) → warn, skip, don't crash ──
+
+  it('pin warns and skips entries with non-string installPath/projectPath; processes siblings normally', async () => {
+    const pluginsDir = join(vaultDir, '.fake-claude-plugins');
+    const cacheDir = join(pluginsDir, 'cache');
+    await mkdir(pluginsDir, { recursive: true });
+
+    const installedJson = {
+      plugins: {
+        'onebrain@onebrain': [
+          {
+            // Malformed — installPath is a number, not a string.
+            id: 'onebrain',
+            source: 'project',
+            installPath: 12345 as unknown as string,
+            version: '0.0.0',
+          },
+          {
+            // Sibling — valid, must process normally.
+            id: 'onebrain',
+            source: 'project',
+            installPath: join(vaultDir, '.claude/plugins/onebrain'),
+            version: '1.10.0',
+            lastUpdated: '2025-01-01T00:00:00.000Z',
+          },
+        ],
+      },
+    };
+    const installedPath = join(pluginsDir, 'installed_plugins.json');
+    await writeFile(installedPath, JSON.stringify(installedJson, null, 2), 'utf8');
+
+    // Capture stderr to assert the warning surfaces.
+    const stderrChunks: string[] = [];
+    const originalWrite = process.stderr.write.bind(process.stderr);
+    // biome-ignore lint/suspicious/noExplicitAny: overriding overloaded write for test capture
+    (process.stderr as any).write = (chunk: string | Uint8Array): boolean => {
+      stderrChunks.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8'));
+      return true;
+    };
+
+    let result: Awaited<ReturnType<typeof runVaultSync>>;
+    try {
+      result = await runVaultSync(vaultDir, {
+        fetchFn: mockFetchWithTarball(tarball),
+        installedPluginsPath: installedPath,
+        installedPluginsCacheDir: cacheDir,
+      });
+    } finally {
+      process.stderr.write = originalWrite;
+    }
+
+    expect(result.ok).toBe(true);
+    const stderr = stderrChunks.join('');
+    expect(stderr).toContain('malformed entry');
+    expect(stderr).toContain('onebrain@onebrain');
+
+    const after = JSON.parse(await readFile(installedPath, 'utf8'));
+    const entries = after.plugins['onebrain@onebrain'];
+    // Malformed entry preserved (we don't delete user data).
+    expect(entries[0].installPath).toBe(12345);
+    expect(entries[0].version).toBe('0.0.0');
+    // Sibling refreshed to tarball version.
+    expect(entries[1].installPath).toBe(join(vaultDir, '.claude/plugins/onebrain'));
+    expect(entries[1].version).toBe('1.11.0');
   });
 });

--- a/src/commands/internal/vault-sync.ts
+++ b/src/commands/internal/vault-sync.ts
@@ -19,7 +19,7 @@
 
 import { mkdir, mkdtemp, readFile, readdir, rm, stat, unlink, writeFile } from 'node:fs/promises';
 import { homedir, tmpdir } from 'node:os';
-import { dirname, join, relative } from 'node:path';
+import { dirname, join, sep as pathSep, relative, resolve as resolvePath } from 'node:path';
 import { intro, outro, spinner } from '@clack/prompts';
 import pc from 'picocolors';
 import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
@@ -62,6 +62,21 @@ export interface VaultSyncResult {
   pinSkipped: boolean;
   cacheRemoved: number;
   error?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Path normalization
+// ---------------------------------------------------------------------------
+
+// Strict `===` between paths is fragile: trailing-slash drift, mixed
+// relative/absolute, repeated separators. `path.resolve` collapses those
+// without I/O. We deliberately do NOT realpath — that would touch fs per
+// entry on every sync.
+function normalizePath(p: string): string {
+  const resolved = resolvePath(p);
+  return resolved.endsWith(pathSep) && resolved.length > pathSep.length
+    ? resolved.slice(0, -pathSep.length)
+    : resolved;
 }
 
 // ---------------------------------------------------------------------------
@@ -400,12 +415,15 @@ async function pinToVault(
   }
 
   const vaultPluginDir = join(vaultRoot, '.claude', 'plugins', 'onebrain');
+  const normalizedVaultRoot = normalizePath(vaultRoot);
+  const normalizedVaultPluginDir = normalizePath(vaultPluginDir);
   const { version: pluginVersion, lastUpdated: pluginLastUpdated } =
     await readPluginMetadata(vaultRoot);
   const updatedAt = pluginLastUpdated ?? now().toISOString();
 
   // Determine cache dir: installed_plugins.json parent → plugins/ → cache/
   const cacheDir = installedPluginsCacheDir ?? join(dirname(installedPluginsPath), 'cache');
+  const normalizedCacheDir = normalizePath(cacheDir);
 
   // If ANY onebrain entry has source: marketplace, Claude Code owns it — skip entirely.
   const hasMarketplace = onebrainKeys.some((k) => {
@@ -454,29 +472,52 @@ async function pinToVault(
   for (const key of onebrainKeys) {
     const entries = plugins[key] as Array<Record<string, unknown>>;
     for (const entry of entries) {
-      const installPath = entry['installPath'];
-      if (typeof installPath !== 'string') {
+      const installPathRaw = entry['installPath'];
+      const projectPathRaw = entry['projectPath'];
+
+      // Surface malformed entries: a non-string path field is broken data,
+      // not a "different vault" signal. Silent skip → same class of bug
+      // as #147. Continue (don't throw — registry is user data).
+      const installPathBad = installPathRaw !== undefined && typeof installPathRaw !== 'string';
+      const projectPathBad = projectPathRaw !== undefined && typeof projectPathRaw !== 'string';
+      if (installPathBad || projectPathBad) {
+        process.stderr.write(
+          `vault-sync: pin warning: malformed entry — non-string installPath/projectPath in installed_plugins.json[${key}]\n`,
+        );
         continue;
       }
 
-      // Scope refresh to the vault being synced (entries whose installPath is
-      // already this vault's plugin dir, OR that still point at the cache and
-      // will be rewritten to it). Other vaults pinned to different installPaths
-      // are left alone — syncing vault A must not stomp vault B's pinned version.
-      let inCache = false;
-      try {
-        inCache = installPath.startsWith(`${cacheDir}/`) || installPath === cacheDir;
-      } catch {
-        inCache = false;
-      }
-      const isThisVault = installPath === vaultPluginDir;
+      const installPath = typeof installPathRaw === 'string' ? installPathRaw : undefined;
+      const projectPath = typeof projectPathRaw === 'string' ? projectPathRaw : undefined;
+      const normalizedInstallPath =
+        installPath !== undefined ? normalizePath(installPath) : undefined;
+      const normalizedProjectPath =
+        projectPath !== undefined ? normalizePath(projectPath) : undefined;
 
-      if (inCache) {
+      // Scope refresh to the vault being synced. An entry belongs to this
+      // vault if any of:
+      //   1. installPath === this vault's plugin dir (canonical, post-pin)
+      //   2. installPath is under the plugins cache dir (will be rewritten)
+      //   3. projectPath === this vault root (installPath may be stale —
+      //      e.g. old install location that no longer exists; #147)
+      // Other vaults pinned to different paths are left alone — syncing
+      // vault A must not stomp vault B's pinned version.
+      const inCache =
+        normalizedInstallPath !== undefined &&
+        (normalizedInstallPath === normalizedCacheDir ||
+          normalizedInstallPath.startsWith(`${normalizedCacheDir}${pathSep}`));
+      const isThisVault = normalizedInstallPath === normalizedVaultPluginDir;
+      const isThisProject = normalizedProjectPath === normalizedVaultRoot;
+
+      if (!isThisVault && !inCache && !isThisProject) {
+        continue;
+      }
+
+      // Canonicalize installPath when it's stale (cache dir, or projectPath
+      // matched but installPath drifted from vaultPluginDir).
+      if (normalizedInstallPath !== normalizedVaultPluginDir) {
         entry['installPath'] = vaultPluginDir;
         changed = true;
-      } else if (!isThisVault) {
-        // Different vault — skip; do not touch its version/lastUpdated.
-        continue;
       }
 
       // Refresh version on this vault's entry; only bump lastUpdated when


### PR DESCRIPTION
## Summary

Fixes two regressions surfaced during real-world `/update` smoke testing of the just-merged PR #145. Both bugs are about the user's `~/.claude/plugins/installed_plugins.json` registry: one made it stale (silently), the other made tests pollute it (silently).

Closes #147 · Closes #146

## What's in this PR

### `#147` — `pinToVault` registry refresh missed entries with stale `installPath`

PR #145 added per-vault scoping that matched only `installPath === vaultPluginDir` (or in-cache). Real users with any historical drift in `installPath` (deleted dir, prior install location, test artifact) had their entry's `version`/`lastUpdated` stay stale forever even after `vault-sync` to a newer plugin version.

**Fix in `src/commands/internal/vault-sync.ts`:**
- Add `projectPath === vaultRoot` as a third per-vault match condition
- On match, canonicalize stale `installPath` → `vaultPluginDir`
- Normalize all paths via `path.resolve` + trailing-separator strip before `===` (catches macOS `/private/var` symlink drift, trailing-slash variance, absolute/relative form variance — same silent-skip class as the original #147 bug)
- Drop dead `try/catch` around `string.startsWith` (theatre — never throws on a string)
- Surface stderr warning `pin warning: malformed entry — non-string installPath/projectPath in installed_plugins.json[<key>]` instead of silently skipping

### `#146` — test pollution into the user's real registry

Tests in `vault-sync.test.ts`, `init.test.ts`, `init.integration.test.ts` invoked `runVaultSync` / `runInit` without injecting `installedPluginsPath` (a seam that existed since PR #145), so writes leaked to `~/.claude/plugins/installed_plugins.json`. After the PR #145 dev cycle, the user's real registry accumulated 3 stale entries — including a `scope: project` entry that masked the #147 bug above.

**Fix in `src/commands/{internal/vault-sync,init,init.integration}.test.ts`:**
- Every test now passes `isolatedInstalledPath` (per-test temp file) into options
- **Suite-level pollution guard**: `beforeAll` snapshots `~/.claude/plugins/installed_plugins.json` mtime + bytes once per file; `afterAll` re-reads and asserts byte-identity. Any future test that omits the seam fails the suite — not just one slot like a per-test guard would
- Old per-test Test 20 deleted in favor of the suite-level guard

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun test` — **266 → 269 pass** (+3 new tests: projectPath fallback with rewrite, trailing-slash normalization, malformed-entry warn-and-preserve); 0 fail; 17 files; 649 expects
- [x] `bunx biome check` on changed files — 0 errors (1 pre-existing `noNonNullAssertion` warning at vault-sync.ts:676 unchanged from `main`)
- [x] **Manual #146 byte-identity proof:** snapshot `~/.claude/plugins/installed_plugins.json` before, run full `bun test`, diff after → `Files are identical` ✓ The new `beforeAll/afterAll` guards are themselves non-polluting.
- [x] Cross-vault isolation (Test 16) and idempotency (Test 17) from PR #145 still pass — refactor preserved their semantics

## Coverage notes for reviewers

- The orphan-dedup loop (`stat(projectPath)` for ENOENT detection) was left untouched — that loop operates on raw `projectPath` and only its `typeof !== 'string'` guard exists. `stat` itself canonicalizes, so path normalization buys nothing there. Symmetric malformed-warn could be added but expands scope; flagged as defer-defensible by round 3 reviewer.
- Path normalization uses `path.resolve` + trailing-sep strip (no `realpathSync` — that triggers fs lookups per registry entry). If symlink-realpath drift becomes an issue in practice, file as a follow-up.

## Review process

3 review rounds:
1. **Round 1** (3 parallel reviewers — code-reviewer, silent-failure-hunter, pr-test-analyzer): code-reviewer clean; silent-failure-hunter found 2 critical (path normalization fragility, suite-guard fails-open); test-analyzer agreed on suite guard
2. **Round 2** (implementation): all 3 must-fix items addressed (path normalization, suite-level guard, malformed-entry warn)
3. **Round 3** (final): `READY — no blockers`

Single version bump: CLI `2.1.11 → 2.1.12`. No plugin changes.