### PR TITLE
fix(session-init): walk process tree to find claude PID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-latest_version: 2.1.12
+latest_version: 2.1.13
 released: 2026-05-06
 ---
 
@@ -12,6 +12,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 > For plugin changes (skills, agents, hooks, INSTRUCTIONS), see [PLUGIN-CHANGELOG.md](PLUGIN-CHANGELOG.md).
 
 ## [Unreleased]
+
+## v2.1.13 — fix(session-init): walk process tree to find claude PID
+
+- fix(session-init): walk parent chain to resolve the claude ancestor PID, matching what the bash hook's `$PPID` already sees
+- fix(session-init): eliminate token collisions across Claude sessions on terminals that set no session env vars (notably Obsidian terminal plugin on macOS) — every session now gets a distinct token instead of sharing the day-scoped cache
+- refactor(session-init): inject a `ProcLookup` into `resolveSessionToken` / `runSessionInit` for deterministic walk-up tests
+- test(session-init): add unit coverage for `findClaudeAncestorPid` (chain walk, basename + `.exe` strip, depth bound, cycles) and walk-up integration in `resolveSessionToken`
 
 ## v2.1.12 — fix(vault-sync): registry matching by projectPath + test isolation
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onebrain-ai/cli",
-  "version": "2.1.12",
+  "version": "2.1.13",
   "description": "CLI for OneBrain — personal AI OS for Obsidian with persistent memory, 24+ skills, and Claude Code integration",
   "keywords": [
     "onebrain",

--- a/src/commands/internal/session-init.test.ts
+++ b/src/commands/internal/session-init.test.ts
@@ -5,7 +5,15 @@ import { join } from 'node:path';
 
 // We test the runSessionInit function which returns the payload rather than printing it,
 // so we can assert against the returned value in tests.
-import { formatDatetime, resolveSessionToken, runSessionInit } from './session-init.js';
+import {
+  type ProcInfo,
+  type ProcLookup,
+  commBasenameOf,
+  findClaudeAncestorPid,
+  formatDatetime,
+  resolveSessionToken,
+  runSessionInit,
+} from './session-init.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -25,6 +33,21 @@ function setPpid(value: number): number {
 /** Restore process.ppid to its original value. */
 function restorePpid(original: number): void {
   Object.defineProperty(process, 'ppid', { value: original, configurable: true });
+}
+
+/**
+ * ProcLookup that always returns null — simulates "no claude ancestor found".
+ * Use this in tests that exercise non-walk-up branches (env vars, cache, ppid).
+ */
+const noClaudeAncestor: ProcLookup = () => null;
+
+/**
+ * Build a ProcLookup from a static map of pid → ProcInfo. Returns null for
+ * any PID not in the map, matching how the real lookup behaves when `ps -p`
+ * cannot find the process.
+ */
+function makeProcLookup(tree: Record<number, ProcInfo>): ProcLookup {
+  return (pid: number) => tree[pid] ?? null;
 }
 
 const VALID_VAULT_YML = `
@@ -118,7 +141,7 @@ describe('resolveSessionToken', () => {
   it('uses PPID when > 1', async () => {
     clearTokenEnvVars();
     setPpid(12345);
-    const token = await resolveSessionToken(tmpDir);
+    const token = await resolveSessionToken(tmpDir, noClaudeAncestor);
     expect(token).toBe('12345');
   });
 
@@ -126,7 +149,7 @@ describe('resolveSessionToken', () => {
     clearTokenEnvVars();
     setPpid(1);
     // Should fall through to cache
-    const token = await resolveSessionToken(tmpDir);
+    const token = await resolveSessionToken(tmpDir, noClaudeAncestor);
     // Token should be a 5-digit number or numeric string from cache
     expect(token).toMatch(/^\d+$/);
   });
@@ -134,7 +157,7 @@ describe('resolveSessionToken', () => {
   it('prefers WT_SESSION over PPID', async () => {
     process.env['WT_SESSION'] = 'abc-123-def-456-ghi';
     setPpid(99999);
-    const token = await resolveSessionToken(tmpDir);
+    const token = await resolveSessionToken(tmpDir, noClaudeAncestor);
     // WT_SESSION stripped to alphanumeric, first 8 chars: 'abc123de'
     expect(token).toBe('abc123de');
   });
@@ -142,7 +165,7 @@ describe('resolveSessionToken', () => {
   it('strips non-alphanumeric from WT_SESSION and takes first 8 chars', async () => {
     process.env['WT_SESSION'] = '{a1b2c3d4-e5f6-7890-abcd-ef1234567890}';
     setPpid(1); // force PPID fallthrough if WT_SESSION somehow fails
-    const token = await resolveSessionToken(tmpDir);
+    const token = await resolveSessionToken(tmpDir, noClaudeAncestor);
     expect(token).toBe('a1b2c3d4');
     expect(token.length).toBe(8);
   });
@@ -151,7 +174,7 @@ describe('resolveSessionToken', () => {
     clearTokenEnvVars();
     process.env['TMUX_PANE'] = '%3';
     setPpid(99999);
-    const token = await resolveSessionToken(tmpDir);
+    const token = await resolveSessionToken(tmpDir, noClaudeAncestor);
     expect(token).toBe('3');
   });
 
@@ -159,7 +182,7 @@ describe('resolveSessionToken', () => {
     clearTokenEnvVars();
     process.env['TERM_SESSION_ID'] = 'C2C99E7B-1780-4A88-9FEC-E1B4DA00A47C';
     setPpid(99999);
-    const token = await resolveSessionToken(tmpDir);
+    const token = await resolveSessionToken(tmpDir, noClaudeAncestor);
     expect(token).toBe('C2C99E7B');
   });
 
@@ -167,7 +190,7 @@ describe('resolveSessionToken', () => {
     process.env['WT_SESSION'] = 'wtsession1';
     process.env['TMUX_PANE'] = '%5';
     setPpid(99999);
-    const token = await resolveSessionToken(tmpDir);
+    const token = await resolveSessionToken(tmpDir, noClaudeAncestor);
     // 'wtsession1' → strip non-alphanum → 'wtsession1' → first 8 → 'wtsessio'
     expect(token).toBe('wtsessio');
   });
@@ -177,7 +200,7 @@ describe('resolveSessionToken', () => {
     process.env['TMUX_PANE'] = '%7';
     process.env['TERM_SESSION_ID'] = 'ABCD1234-EFGH-5678';
     setPpid(99999);
-    const token = await resolveSessionToken(tmpDir);
+    const token = await resolveSessionToken(tmpDir, noClaudeAncestor);
     expect(token).toBe('7');
   });
 
@@ -187,7 +210,7 @@ describe('resolveSessionToken', () => {
     const today = new Date().toISOString().slice(0, 10).replace(/-/g, '');
     const cacheFile = join(tmpDir, `onebrain-day-${today}.token`);
     await writeFile(cacheFile, '54321', 'utf8');
-    const token = await resolveSessionToken(tmpDir);
+    const token = await resolveSessionToken(tmpDir, noClaudeAncestor);
     expect(token).toBe('54321');
   });
 
@@ -197,14 +220,14 @@ describe('resolveSessionToken', () => {
     const today = new Date().toISOString().slice(0, 10).replace(/-/g, '');
     const cacheFile = join(tmpDir, `onebrain-day-${today}.token`);
     await writeFile(cacheFile, '54321', 'utf8');
-    const token = await resolveSessionToken(tmpDir);
+    const token = await resolveSessionToken(tmpDir, noClaudeAncestor);
     expect(token).toBe('54321'); // cache wins over ppid
   });
 
   it('ppid result is written to day-scoped cache for deterministic re-runs', async () => {
     clearTokenEnvVars();
     setPpid(99888);
-    const token = await resolveSessionToken(tmpDir);
+    const token = await resolveSessionToken(tmpDir, noClaudeAncestor);
     expect(token).toBe('99888');
     const today = new Date().toISOString().slice(0, 10).replace(/-/g, '');
     const cacheFile = join(tmpDir, `onebrain-day-${today}.token`);
@@ -215,7 +238,7 @@ describe('resolveSessionToken', () => {
   it('writes new cache file when none exists', async () => {
     clearTokenEnvVars();
     setPpid(1); // force fallthrough
-    const token = await resolveSessionToken(tmpDir);
+    const token = await resolveSessionToken(tmpDir, noClaudeAncestor);
     // Should be a 5-digit number
     expect(token).toMatch(/^\d{5}$/);
     // Cache file should exist
@@ -223,6 +246,215 @@ describe('resolveSessionToken', () => {
     const cacheFile = join(tmpDir, `onebrain-day-${today}.token`);
     const cached = await Bun.file(cacheFile).text();
     expect(cached.trim()).toBe(token);
+  });
+
+  // ---- walk-up integration ------------------------------------------------
+
+  it('walk-up: returns claude ancestor PID and skips cache write', async () => {
+    clearTokenEnvVars();
+    setPpid(20001); // bash wrapper
+    // Simulated tree: bash(20001) → claude(30002) → init(1)
+    const lookup = makeProcLookup({
+      20001: { ppid: 30002, commBasename: 'bash' },
+      30002: { ppid: 1, commBasename: 'claude' },
+    });
+    const token = await resolveSessionToken(tmpDir, lookup);
+    expect(token).toBe('30002');
+
+    // Cache file must NOT be written when walk-up succeeds — that's the whole
+    // point of walk-up: deterministic per-session, no shared cache collisions.
+    const today = new Date().toISOString().slice(0, 10).replace(/-/g, '');
+    const cacheFile = join(tmpDir, `onebrain-day-${today}.token`);
+    const exists = await Bun.file(cacheFile).exists();
+    expect(exists).toBe(false);
+  });
+
+  it('walk-up: prefers claude ancestor over existing cached token', async () => {
+    // Simulates the bug fix: even if a stale cache from another session sits
+    // in $TMPDIR, walk-up's claude PID wins.
+    clearTokenEnvVars();
+    setPpid(20001);
+    const today = new Date().toISOString().slice(0, 10).replace(/-/g, '');
+    const cacheFile = join(tmpDir, `onebrain-day-${today}.token`);
+    await writeFile(cacheFile, '99999', 'utf8'); // stale cached token
+    const lookup = makeProcLookup({
+      20001: { ppid: 30002, commBasename: 'bash' },
+      30002: { ppid: 1, commBasename: 'claude' },
+    });
+    const token = await resolveSessionToken(tmpDir, lookup);
+    expect(token).toBe('30002'); // walk-up wins, ignores cache
+  });
+
+  it('walk-up: env vars (WT_SESSION) still win over walk-up', async () => {
+    process.env['WT_SESSION'] = 'wtwins00';
+    setPpid(20001);
+    const lookup = makeProcLookup({
+      20001: { ppid: 30002, commBasename: 'bash' },
+      30002: { ppid: 1, commBasename: 'claude' },
+    });
+    const token = await resolveSessionToken(tmpDir, lookup);
+    expect(token).toBe('wtwins00');
+  });
+
+  it('walk-up: falls through to cache/ppid when no claude ancestor exists', async () => {
+    clearTokenEnvVars();
+    setPpid(20001);
+    // Simulated tree contains no `claude` process anywhere.
+    const lookup = makeProcLookup({
+      20001: { ppid: 20002, commBasename: 'bash' },
+      20002: { ppid: 1, commBasename: 'launchd' },
+    });
+    const token = await resolveSessionToken(tmpDir, lookup);
+    // Falls through to step 6 (process.ppid), writes to cache.
+    expect(token).toBe('20001');
+    const today = new Date().toISOString().slice(0, 10).replace(/-/g, '');
+    const cacheFile = join(tmpDir, `onebrain-day-${today}.token`);
+    const cached = (await Bun.file(cacheFile).text()).trim();
+    expect(cached).toBe('20001');
+  });
+
+  it('walk-up: tolerates broken lookup (returns null) and falls through', async () => {
+    clearTokenEnvVars();
+    setPpid(20001);
+    // Lookup always fails — simulates `ps` unavailable or unexpected output.
+    const brokenLookup: ProcLookup = () => null;
+    const token = await resolveSessionToken(tmpDir, brokenLookup);
+    expect(token).toBe('20001'); // falls through to ppid
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findClaudeAncestorPid
+// ---------------------------------------------------------------------------
+
+describe('findClaudeAncestorPid', () => {
+  it('returns the PID of the first claude ancestor walking up', () => {
+    const lookup = makeProcLookup({
+      100: { ppid: 200, commBasename: 'bash' },
+      200: { ppid: 300, commBasename: 'claude' },
+      300: { ppid: 1, commBasename: 'launchd' },
+    });
+    expect(findClaudeAncestorPid(100, lookup)).toBe(200);
+  });
+
+  // The basename normalization (path strip + `.exe` trim) is performed by
+  // `defaultProcLookup` before it returns ProcInfo; `findClaudeAncestorPid`
+  // itself does direct equality on commBasename. The lookup-side contract
+  // is verified by `commBasenameOf` tests below.
+
+  it('returns null when no claude ancestor exists in the chain', () => {
+    const lookup = makeProcLookup({
+      100: { ppid: 200, commBasename: 'bash' },
+      200: { ppid: 300, commBasename: 'zsh' },
+      300: { ppid: 1, commBasename: 'launchd' },
+    });
+    expect(findClaudeAncestorPid(100, lookup)).toBeNull();
+  });
+
+  it('returns null when startPid is <= 1 (init/zero)', () => {
+    const neverCalled: ProcLookup = () => {
+      throw new Error('lookup must not be called for startPid <= 1');
+    };
+    expect(findClaudeAncestorPid(1, neverCalled)).toBeNull();
+    expect(findClaudeAncestorPid(0, neverCalled)).toBeNull();
+  });
+
+  it('returns null and stops walking when lookup fails mid-chain', () => {
+    const lookup = makeProcLookup({
+      100: { ppid: 200, commBasename: 'bash' },
+      // 200 missing from tree (lookup returns null)
+    });
+    expect(findClaudeAncestorPid(100, lookup)).toBeNull();
+  });
+
+  it('respects maxDepth — stops walking after depth limit', () => {
+    // Build a chain: 100 → 101 → ... → 119 → 120, with claude at 120
+    // (the function checks `current` at each step, so claude at depth 20)
+    const tree: Record<number, ProcInfo> = {};
+    for (let i = 100; i < 120; i++) tree[i] = { ppid: i + 1, commBasename: 'bash' };
+    tree[120] = { ppid: 1, commBasename: 'claude' };
+    const lookup = makeProcLookup(tree);
+
+    // Default maxDepth = 12 — should NOT reach claude (which is at depth 20)
+    expect(findClaudeAncestorPid(100, lookup)).toBeNull();
+    // Generous maxDepth — should find it
+    expect(findClaudeAncestorPid(100, lookup, 25)).toBe(120);
+  });
+
+  it('does not loop forever on a cyclic process tree', () => {
+    // Pathological: 100 → 200 → 100 (cycle). Should return null without hanging.
+    const lookup = makeProcLookup({
+      100: { ppid: 200, commBasename: 'bash' },
+      200: { ppid: 100, commBasename: 'bash' },
+    });
+    expect(findClaudeAncestorPid(100, lookup)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// commBasenameOf — basename normalization for ps -o comm= outputs
+// ---------------------------------------------------------------------------
+
+describe('commBasenameOf', () => {
+  it('strips a unix path prefix', () => {
+    expect(commBasenameOf('/opt/homebrew/bin/claude')).toBe('claude');
+  });
+
+  it('strips a windows path prefix and `.exe` suffix', () => {
+    expect(commBasenameOf('C:\\Users\\me\\AppData\\Local\\claude.exe')).toBe('claude');
+  });
+
+  it('strips `.exe` case-insensitively', () => {
+    expect(commBasenameOf('claude.EXE')).toBe('claude');
+  });
+
+  it('returns the input unchanged when already a basename', () => {
+    expect(commBasenameOf('claude')).toBe('claude');
+    expect(commBasenameOf('bash')).toBe('bash');
+  });
+
+  it('trims leading/trailing whitespace', () => {
+    expect(commBasenameOf('  /usr/bin/claude  ')).toBe('claude');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveSessionToken integration: walk-up depth limit
+// ---------------------------------------------------------------------------
+
+describe('resolveSessionToken — walk-up depth limit integration', () => {
+  it('falls through to ppid/cache when claude exists deeper than walk-up maxDepth', async () => {
+    // Build a chain longer than the default maxDepth (12) with claude at the
+    // end. The walk-up returns null before reaching claude, so resolution
+    // should fall through to the ppid path and persist that token to cache.
+    const tmpDir = await mkdtemp(join(tmpdir(), 'onebrain-si-test-depth-'));
+    try {
+      const originalEnv = { ...process.env };
+      const originalPpid = process.ppid;
+      try {
+        process.env['WT_SESSION'] = undefined;
+        process.env['TMUX_PANE'] = undefined;
+        process.env['TERM_SESSION_ID'] = undefined;
+        setPpid(50000);
+
+        const tree: Record<number, ProcInfo> = {};
+        for (let i = 50000; i < 50050; i++) {
+          tree[i] = { ppid: i + 1, commBasename: 'bash' };
+        }
+        tree[50050] = { ppid: 1, commBasename: 'claude' };
+        const lookup = makeProcLookup(tree);
+
+        const token = await resolveSessionToken(tmpDir, lookup);
+        // Walk-up bottomed out at depth 12 without finding claude → null →
+        // fall through to step 6 (ppid).
+        expect(token).toBe('50000');
+      } finally {
+        process.env = originalEnv;
+        restorePpid(originalPpid);
+      }
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
   });
 });
 
@@ -253,19 +485,19 @@ describe('runSessionInit', () => {
   });
 
   it('returns block decision when vault.yml is missing', async () => {
-    const result = await runSessionInit(tmpDir, tmpDir);
+    const result = await runSessionInit(tmpDir, tmpDir, noClaudeAncestor);
     expect(result).toEqual({ decision: 'block', reason: 'onebrain-init-required' });
   });
 
   it('returns block decision when vault.yml is malformed YAML', async () => {
     await writeFile(join(tmpDir, 'vault.yml'), MALFORMED_YAML, 'utf8');
-    const result = await runSessionInit(tmpDir, tmpDir);
+    const result = await runSessionInit(tmpDir, tmpDir, noClaudeAncestor);
     expect(result).toEqual({ decision: 'block', reason: 'onebrain-init-required' });
   });
 
   it('returns normal payload when vault.yml is present and valid', async () => {
     await writeFile(join(tmpDir, 'vault.yml'), VALID_VAULT_YML, 'utf8');
-    const result = await runSessionInit(tmpDir, tmpDir);
+    const result = await runSessionInit(tmpDir, tmpDir, noClaudeAncestor);
     expect(result).toHaveProperty('datetime');
     expect(result).toHaveProperty('session_token');
     expect(result).toHaveProperty('qmd_unembedded', 0);
@@ -278,13 +510,19 @@ describe('runSessionInit', () => {
   it('uses PPID as session_token', async () => {
     await writeFile(join(tmpDir, 'vault.yml'), VALID_VAULT_YML, 'utf8');
     setPpid(42001);
-    const result = (await runSessionInit(tmpDir, tmpDir)) as Record<string, unknown>;
+    const result = (await runSessionInit(tmpDir, tmpDir, noClaudeAncestor)) as Record<
+      string,
+      unknown
+    >;
     expect(result['session_token']).toBe('42001');
   });
 
   it('qmd_unembedded is 0 when qmd is not in PATH / errors', async () => {
     await writeFile(join(tmpDir, 'vault.yml'), VALID_VAULT_YML, 'utf8');
-    const result = (await runSessionInit(tmpDir, tmpDir)) as Record<string, unknown>;
+    const result = (await runSessionInit(tmpDir, tmpDir, noClaudeAncestor)) as Record<
+      string,
+      unknown
+    >;
     // qmd is not expected to be installed in test env
     expect(result['qmd_unembedded']).toBe(0);
   });
@@ -293,7 +531,10 @@ describe('runSessionInit', () => {
   it('normal payload output shape matches snapshot', async () => {
     await writeFile(join(tmpDir, 'vault.yml'), VALID_VAULT_YML, 'utf8');
     setPpid(55555);
-    const result = (await runSessionInit(tmpDir, tmpDir)) as Record<string, unknown>;
+    const result = (await runSessionInit(tmpDir, tmpDir, noClaudeAncestor)) as Record<
+      string,
+      unknown
+    >;
 
     // Lock the exact field names of the SessionInitPayload shape.
     // The values are dynamic (datetime, session_token vary), so we assert structure only.
@@ -306,7 +547,7 @@ describe('runSessionInit', () => {
   it('cleanStaleStateFile — no state file → resolves normally with payload', async () => {
     await writeFile(join(tmpDir, 'vault.yml'), VALID_VAULT_YML, 'utf8');
     // No state file exists in tmpDir
-    const result = await runSessionInit(tmpDir, tmpDir);
+    const result = await runSessionInit(tmpDir, tmpDir, noClaudeAncestor);
     expect(result).toHaveProperty('datetime');
     expect(result).toHaveProperty('session_token');
   });
@@ -317,7 +558,7 @@ describe('runSessionInit', () => {
     const stateFile = join(tmpDir, 'onebrain-77777.state');
     await writeFile(stateFile, '1:0:00', 'utf8');
     // Fresh file should NOT be deleted
-    await runSessionInit(tmpDir, tmpDir);
+    await runSessionInit(tmpDir, tmpDir, noClaudeAncestor);
     // File should still exist (mtime is fresh, after process start)
     const s = await stat(stateFile);
     expect(s).toBeDefined();
@@ -330,7 +571,7 @@ describe('runSessionInit', () => {
     // Set mtime to epoch (far in the past) — definitely before process start
     await utimes(stateFile, 0, 0);
     // Run session init — stale file should be cleaned up
-    await runSessionInit(tmpDir, tmpDir);
+    await runSessionInit(tmpDir, tmpDir, noClaudeAncestor);
     // File should be gone
     await expect(stat(stateFile)).rejects.toThrow();
   });
@@ -357,7 +598,7 @@ describe('runSessionInit', () => {
     });
 
     try {
-      const result = await runSessionInit(tmpDir, tmpDir);
+      const result = await runSessionInit(tmpDir, tmpDir, noClaudeAncestor);
       expect(result).toHaveProperty('datetime');
     } finally {
       bunFileSpy.mockRestore();
@@ -366,7 +607,10 @@ describe('runSessionInit', () => {
 
   it('unicode: datetime field in normal payload contains · separators that survive JSON.parse', async () => {
     await writeFile(join(tmpDir, 'vault.yml'), VALID_VAULT_YML, 'utf8');
-    const result = (await runSessionInit(tmpDir, tmpDir)) as Record<string, unknown>;
+    const result = (await runSessionInit(tmpDir, tmpDir, noClaudeAncestor)) as Record<
+      string,
+      unknown
+    >;
     const datetime = result['datetime'] as string;
 
     // The field must contain the middle-dot separator used in the greeting format
@@ -380,7 +624,7 @@ describe('runSessionInit', () => {
 
   it('unicode: full JSON payload is valid UTF-8 — encode → decode is lossless', async () => {
     await writeFile(join(tmpDir, 'vault.yml'), VALID_VAULT_YML, 'utf8');
-    const result = await runSessionInit(tmpDir, tmpDir);
+    const result = await runSessionInit(tmpDir, tmpDir, noClaudeAncestor);
     const json = JSON.stringify(result);
 
     const encoded = new TextEncoder().encode(json);
@@ -422,7 +666,10 @@ describe('runSessionInit', () => {
     });
 
     try {
-      const result = (await runSessionInit(tmpDir, tmpDir)) as Record<string, unknown>;
+      const result = (await runSessionInit(tmpDir, tmpDir, noClaudeAncestor)) as Record<
+        string,
+        unknown
+      >;
       expect(result['qmd_unembedded']).toBe(5);
     } finally {
       spawnSpy.mockRestore();

--- a/src/commands/internal/session-init.ts
+++ b/src/commands/internal/session-init.ts
@@ -64,6 +64,134 @@ export function formatDatetime(date: Date): string {
 }
 
 // ---------------------------------------------------------------------------
+// findClaudeAncestorPid
+// ---------------------------------------------------------------------------
+
+/**
+ * Result of looking up a process: parent PID + command basename
+ * (path-stripped and `.exe`-trimmed; ready for direct equality comparison).
+ */
+export type ProcInfo = { readonly ppid: number; readonly commBasename: string };
+
+/**
+ * A function that returns ProcInfo for a given PID, or null if lookup fails.
+ * Injectable so tests can simulate process trees without touching real PIDs.
+ */
+export type ProcLookup = (pid: number) => ProcInfo | null;
+
+/**
+ * Compute the basename of a `comm` value as `ps -o comm=` returns it
+ * (which may be a full path on Linux/macOS and may end in `.exe` on Windows).
+ * Exported for testing the basename normalization contract.
+ */
+export function commBasenameOf(raw: string): string {
+  return raw
+    .trim()
+    .replace(/^.*[/\\]/, '')
+    .replace(/\.exe$/i, '');
+}
+
+/**
+ * Default ProcLookup implementation backed by `ps -o ppid=,comm= -p <pid>`.
+ *
+ * Returns null silently on Windows (no `ps`) — the only *expected* "no lookup"
+ * case. On Unix, when `ps` is reachable but returns an unexpected exit code,
+ * empty output, or unparseable output, we still return null but emit a one-line
+ * warning to stderr first. Without that warning, an unparseable-output regression
+ * (e.g. a busybox `ps` variant emitting a header) silently falls back to the
+ * day-scoped cache — which is exactly the cross-session collision bug this
+ * walk-up was added to prevent.
+ */
+const defaultProcLookup: ProcLookup = (pid: number): ProcInfo | null => {
+  if (process.platform === 'win32') return null;
+  let result: ReturnType<typeof Bun.spawnSync>;
+  try {
+    result = Bun.spawnSync(['ps', '-o', 'ppid=,comm=', '-p', String(pid)], {
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException | undefined)?.code;
+    // ENOENT on Unix would be very unusual (ps almost always exists); other
+    // codes (EACCES from sandboxing, EMFILE/ENOMEM at spawn) are signals the
+    // user should see, not silent fallbacks.
+    process.stderr.write(`onebrain: ps spawn failed for pid ${pid} (${code ?? 'unknown'})\n`);
+    return null;
+  }
+  if (!result.success) {
+    process.stderr.write(`onebrain: ps -p ${pid} exited ${result.exitCode}\n`);
+    return null;
+  }
+  const out = new TextDecoder().decode(result.stdout).trim();
+  if (!out) {
+    process.stderr.write(`onebrain: ps -p ${pid} returned empty output\n`);
+    return null;
+  }
+  // Expected single-line format: "<ppid> <comm-or-path>".
+  // We want exactly one data line; if multiple lines arrived (header leak
+  // from a non-standard ps), bail loudly.
+  if (out.includes('\n')) {
+    process.stderr.write(
+      `onebrain: ps -p ${pid} returned multi-line output: ${out.replace(/\n/g, ' | ').slice(0, 120)}\n`,
+    );
+    return null;
+  }
+  const match = out.match(/^\s*(\d+)\s+(.+)$/);
+  if (!match) {
+    process.stderr.write(`onebrain: ps -p ${pid} unparseable: ${out.slice(0, 120)}\n`);
+    return null;
+  }
+  const ppid = Number(match[1]);
+  if (Number.isNaN(ppid)) return null;
+  return { ppid, commBasename: commBasenameOf(match[2] ?? '') };
+};
+
+/**
+ * Walk up the process tree from `startPid` looking for a process whose
+ * `commBasename` is `claude`. Returns its PID, or null if not found.
+ *
+ * Capped at 12 hops — empirically deeper than any shell→multiplexer→claude
+ * chain seen in practice, shallow enough that a corrupted process table
+ * terminates in milliseconds.
+ *
+ * Why: `process.ppid` here is the ephemeral `bash -c` wrapper Claude Code
+ * spawns to run the CLI, not the long-lived `claude` process. The wrapper PID
+ * changes between every CLI invocation in the same Claude session, so using
+ * it as a token would produce a different identity per call. Walking up to
+ * the nearest `claude` ancestor yields one stable PID for the lifetime of the
+ * Claude session — the identity we actually want for namespacing checkpoint
+ * files across session-init, stop-hook, and orphan-scan calls (all of which
+ * share this resolver via `resolveSessionToken`).
+ */
+export function findClaudeAncestorPid(
+  startPid: number,
+  lookup: ProcLookup = defaultProcLookup,
+  maxDepth = 12,
+): number | null {
+  let current = startPid;
+  for (let i = 0; i < maxDepth; i++) {
+    if (current <= 1) return null;
+    const info = lookup(current);
+    if (!info) return null;
+    if (info.commBasename === 'claude') return current;
+    if (info.ppid <= 1) {
+      // Walked cleanly to init without finding claude — distinct from a
+      // lookup failure (which already wrote its own warning). Surfacing this
+      // makes the day-cache fallback below visible instead of silent.
+      process.stderr.write(
+        `onebrain: walk-up reached init from pid ${startPid} without finding claude (last comm=${info.commBasename})\n`,
+      );
+      return null;
+    }
+    current = info.ppid;
+  }
+  process.stderr.write(
+    `onebrain: walk-up exhausted ${maxDepth} hops from pid ${startPid} without finding claude\n`,
+  );
+  return null;
+}
+
+// ---------------------------------------------------------------------------
 // resolveSessionToken
 // ---------------------------------------------------------------------------
 
@@ -72,18 +200,32 @@ export function formatDatetime(date: Date): string {
  * 1. WT_SESSION env var (Windows Terminal — strip non-alphanumeric, first 8 chars)
  * 2. TMUX_PANE env var (tmux — stable per-pane, e.g. "%3" → "3")
  * 3. TERM_SESSION_ID env var (macOS Terminal.app — stable per-tab UUID)
- * 4. Day-scoped cache file: $tmpDir/onebrain-day-YYYYMMDD.token (if valid cached token exists)
- * 5. process.ppid if > 1 — resolve, write to cache, return
- * 6. PowerShell parent PID (Windows fallback) — resolve, write to cache, return
- * 7. Random fallback — generate, write to cache, return
+ * 4. Walk up the process tree to find a `claude` ancestor PID (Unix) — stable
+ *    per Claude session, returned without touching the cache
+ * 5. Day-scoped cache file: $tmpDir/onebrain-day-YYYYMMDD.token (if a valid
+ *    cached token exists) — legacy stabilizer with cross-session collision risk
+ * 6. process.ppid if > 1 — write to cache, return
+ * 7. PowerShell parent PID (Windows fallback) — write to cache, return
+ * 8. Random 5-digit fallback — write to cache, return
  *
- * Env-var sources (1–3) are preferred over ppid because both session-init and
- * the stop hook run as children of separate bash processes (different ppid values),
+ * Env-var sources (1–3) are preferred because both session-init and the stop
+ * hook run as children of separate bash wrappers (different ppid values),
  * while env vars are inherited from the shared terminal session ancestor.
- * Cache (step 4) is checked before ppid so that re-runs within the same day always
- * return the same token even if ppid varies between invocations.
+ *
+ * Walk-up (4) covers terminals that set none of those env vars (e.g. Obsidian's
+ * terminal plugin on macOS). Without it, every Claude session on the same
+ * machine and day shared one cached token because the cache key only encoded
+ * the date — that's the bug this resolver path was added to fix.
+ *
+ * Steps 6–8 are last-resort fallbacks when both the env vars and walk-up fail.
+ * Step 6 reuses the unstable wrapper ppid because *some* identity (with the
+ * cache stabilizing repeated calls) is better than none; users in this branch
+ * accept the day-cache collision risk by virtue of having no better signal.
  */
-export async function resolveSessionToken(tmpDir: string = osTmpdir()): Promise<string> {
+export async function resolveSessionToken(
+  tmpDir: string = osTmpdir(),
+  procLookup: ProcLookup = defaultProcLookup,
+): Promise<string> {
   // 1. WT_SESSION (Windows Terminal)
   const wtSession = process.env['WT_SESSION'];
   if (wtSession) {
@@ -105,7 +247,21 @@ export async function resolveSessionToken(tmpDir: string = osTmpdir()): Promise<
     if (stripped.length > 0) return stripped;
   }
 
-  // 4. Day-scoped cache — check before ppid so re-runs return the same token
+  // 4. Walk up the process tree to find a `claude` ancestor PID.
+  //    On success, return without touching the cache: walk-up is deterministic
+  //    per Claude session, so caching adds collision risk without benefit.
+  const startPpid = process.ppid;
+  if (startPpid !== undefined && startPpid > 1) {
+    const claudePid = findClaudeAncestorPid(startPpid, procLookup);
+    if (claudePid !== null && claudePid > 1) {
+      return String(claudePid);
+    }
+  }
+
+  // 5. Day-scoped cache — used only when steps 1–4 above all fail. This is
+  //    the legacy stabilizer for environments where neither env vars nor the
+  //    walk-up can identify a session ancestor; it carries a known collision
+  //    risk (one cached token per day, shared across all callers in $TMPDIR).
   const today = new Date();
   const yyyymmdd = [
     today.getFullYear(),
@@ -121,7 +277,7 @@ export async function resolveSessionToken(tmpDir: string = osTmpdir()): Promise<
     if (!Number.isNaN(n) && n > 1) return cached;
   }
 
-  // 5. PPID — resolve, write to cache, return
+  // 6. PPID — resolve, write to cache, return
   const ppid = process.ppid;
   if (ppid !== undefined && ppid > 1) {
     const token = String(ppid);
@@ -129,7 +285,7 @@ export async function resolveSessionToken(tmpDir: string = osTmpdir()): Promise<
     return token;
   }
 
-  // 6. PowerShell fallback (Windows only) — resolve, write to cache, return
+  // 7. PowerShell fallback (Windows only) — resolve, write to cache, return
   try {
     const ps = Bun.spawn(
       [
@@ -166,7 +322,7 @@ export async function resolveSessionToken(tmpDir: string = osTmpdir()): Promise<
     // Not on Windows or powershell.exe not available — fall through
   }
 
-  // 7. Generate and cache a random 5-digit token (10000–99999)
+  // 8. Generate and cache a random 5-digit token (10000–99999)
   const token = String(Math.floor(Math.random() * 90000) + 10000);
   await Bun.write(cacheFile, token);
   return token;
@@ -194,12 +350,27 @@ async function cleanStaleStateFile(token: string, tmpDir: string): Promise<void>
     if (mtimeMs < processStartMs) {
       try {
         await unlink(stateFile);
-      } catch {
-        // Already deleted or never existed — non-fatal
+      } catch (err) {
+        const code = (err as NodeJS.ErrnoException | undefined)?.code;
+        // ENOENT = lost a delete race with a concurrent caller; silent.
+        // EACCES/EPERM = $TMPDIR permissions broken (e.g. file owned by root
+        // after a prior `sudo onebrain`) — surface so the user can chmod or
+        // remove the file before checkpoint writes start failing too.
+        if (code !== 'ENOENT') {
+          process.stderr.write(
+            `onebrain: cannot remove stale state file ${stateFile} (${code ?? 'unknown'})\n`,
+          );
+        }
       }
     }
-  } catch {
-    // Non-fatal — stale cleanup is best-effort
+  } catch (err) {
+    // stat()/exists() races on the file we just observed are non-fatal, but
+    // anything other than ENOENT is worth seeing — it would mask the same
+    // permissions class as the unlink branch above.
+    const code = (err as NodeJS.ErrnoException | undefined)?.code;
+    if (code && code !== 'ENOENT') {
+      process.stderr.write(`onebrain: cleanStaleStateFile failed (${code})\n`);
+    }
   }
 }
 
@@ -259,6 +430,7 @@ async function queryQmdUnembedded(): Promise<number> {
 export async function runSessionInit(
   vaultRoot: string,
   tmpDir: string = osTmpdir(),
+  procLookup: ProcLookup = defaultProcLookup,
 ): Promise<SessionInitResult> {
   // Validate vault.yml — block if missing or malformed
   try {
@@ -268,7 +440,7 @@ export async function runSessionInit(
   }
 
   // Resolve session token and clean up stale state
-  const sessionToken = await resolveSessionToken(tmpDir);
+  const sessionToken = await resolveSessionToken(tmpDir, procLookup);
   await cleanStaleStateFile(sessionToken, tmpDir);
 
   // Format datetime


### PR DESCRIPTION
## Summary

- On macOS + Obsidian terminal plugin, every Claude session got the **same** `session_token` because none of `WT_SESSION` / `TMUX_PANE` / `TERM_SESSION_ID` are set. Resolution fell through to a day-scoped cache file (`$TMPDIR/onebrain-day-YYYYMMDD.token`) keyed only by date — so all sessions on the same day shared it.
- Root cause: `process.ppid` of `session-init` is the ephemeral `bash -c` wrapper Claude Code spawns, not the long-lived `claude` process. The cache was added to stabilize this, but stabilizing only by date causes cross-session collisions.
- Fix: walk up the process tree from `process.ppid` until we find a process whose `commBasename` is `claude`. That PID is stable for the lifetime of the Claude session and is shared by every caller of `resolveSessionToken` (session-init, `onebrain checkpoint stop`, orphan-scan).

## Changes

- New: `findClaudeAncestorPid` (bounded walk, 12 hops) + `commBasenameOf` helper + injectable `ProcLookup` seam.
- New step 4 in `resolveSessionToken` priority order — runs after env vars, before the day-cache. Cache is now last-resort with the documented collision risk.
- All silent failure paths in `defaultProcLookup` (ps unexpected exit, empty/multi-line/unparseable output, spawn exception) write a one-line warning to stderr before returning null. The win32 short-circuit at the top stays silent (expected case).
- `findClaudeAncestorPid` writes a stderr warning when the walk reaches init or exhausts maxDepth without finding claude — distinguishes a clean miss from a lookup failure.
- `cleanStaleStateFile` narrowed: ENOENT silent (race), other errno codes surfaced.
- Renamed `ProcInfo.comm` → `ProcInfo.commBasename`; normalization performed once at the lookup boundary.

## Verification

- 47 tests pass (43 existing, 4 new — `commBasenameOf`, walk-up integration, depth-limit fallthrough, plus updated `findClaudeAncestorPid` tree tests).
- Typecheck clean. Biome clean.
- Smoke-tested the rebuilt binary on this Mac + Obsidian terminal: token now matches the live `claude` PID instead of the stale cache.

Before:
```
$ onebrain session-init
{"datetime":"...","session_token":"28106",...}   # cached, shared by every session
```

After:
```
$ onebrain session-init
{"datetime":"...","session_token":"14463",...}   # claude PID, distinct per session
```

## Test plan

- [x] `bun test src/commands/internal/session-init.test.ts` — 47 pass / 0 fail
- [x] `bun test` (full suite) — 282 pass / 0 fail
- [x] `bun run typecheck` clean
- [x] `bunx biome check` clean
- [x] Manual smoke test on Obsidian terminal plugin (macOS) — token = claude PID
- [x] Manual smoke test with `TMUX_PANE` and `TERM_SESSION_ID` set — env vars still win over walk-up
- [x] 3 review rounds (code-reviewer × 2, silent-failure-hunter, type-design-analyzer, comment-analyzer)