### PR TITLE
fix(register-hooks): migrate legacy qmd PostToolUse entries (#127)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-latest_version: 2.1.13
+latest_version: 2.1.14
 released: 2026-05-06
 ---
 
@@ -12,6 +12,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 > For plugin changes (skills, agents, hooks, INSTRUCTIONS), see [PLUGIN-CHANGELOG.md](PLUGIN-CHANGELOG.md).
 
 ## [Unreleased]
+
+## v2.1.14 — fix(register-hooks): migrate legacy `qmd update -c …` PostToolUse entries
+
+- fix(register-hooks): rewrite legacy `qmd update <args>` PostToolUse hooks to canonical `onebrain qmd-reindex` so `/doctor`'s substring check no longer flags working hooks as missing (#127)
+- fix(register-hooks): match wrapped legacy forms too (`powershell.exe ... qmd update -c …`, `bash -lc 'qmd update …'`) so older Windows installs migrate cleanly
+- fix(register-hooks): dedupe canonical entries after migration and normalize the parent group's matcher to `Write|Edit`, so a settings.json with both legacy and canonical hooks doesn't end up firing the reindex twice
+- fix(register-hooks): strip legacy `qmd update …` entries when `qmd_collection` is unset in vault.yml (instead of leaving them firing against a collection the user no longer maintains)
+- fix(register-hooks): status line reports `PostToolUse migrated` (with `↑` icon in TTY) instead of conflating into `added`/`ok`
+- test(register-hooks): 12 new cases — migration, idempotence, dedup (with and without legacy entries present), narrow-matcher normalization, PowerShell-wrapped legacy form, qmd-disabled cleanup with mixed legacy + canonical
 
 ## v2.1.13 — fix(session-init): walk process tree to find claude PID
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onebrain-ai/cli",
-  "version": "2.1.13",
+  "version": "2.1.14",
   "description": "CLI for OneBrain — personal AI OS for Obsidian with persistent memory, 24+ skills, and Claude Code integration",
   "keywords": [
     "onebrain",

--- a/src/commands/internal/register-hooks.test.ts
+++ b/src/commands/internal/register-hooks.test.ts
@@ -311,6 +311,405 @@ describe('qmd PostToolUse hook via vault.yml qmd_collection', () => {
     const hooks = settings['hooks'] as Record<string, unknown> | undefined;
     expect(hooks?.['PostToolUse']).toBeUndefined();
   });
+
+  // ---- legacy `qmd update -c <collection>` migration (issue #127) ----------
+
+  /**
+   * Read the PostToolUse hook commands from the vault's settings.json.
+   * Helper keeps the migration assertions readable.
+   */
+  async function readPostToolUseCommands(vault: string): Promise<string[]> {
+    const text = await readFile(join(vault, '.claude', 'settings.json'), 'utf8');
+    const settings = JSON.parse(text) as Record<string, unknown>;
+    const hooks = settings['hooks'] as Record<string, unknown[]> | undefined;
+    const groups = (hooks?.['PostToolUse'] ?? []) as Array<{
+      hooks?: Array<{ command?: string }>;
+    }>;
+    return groups.flatMap((g) => (g.hooks ?? []).map((h) => h.command ?? ''));
+  }
+
+  test('legacy `qmd update -c …` PostToolUse entry → migrated to `onebrain qmd-reindex`', async () => {
+    await writeFile(
+      join(vaultDir, 'vault.yml'),
+      'method: onebrain\nqmd_collection: ob-1-test\n',
+      'utf8',
+    );
+    // Pre-existing settings.json with the legacy command form.
+    await writeFile(
+      join(vaultDir, '.claude', 'settings.json'),
+      JSON.stringify(
+        {
+          hooks: {
+            PostToolUse: [
+              {
+                matcher: 'Write|Edit',
+                hooks: [{ type: 'command', command: 'qmd update -c ob-1-test' }],
+              },
+            ],
+          },
+        },
+        null,
+        2,
+      ),
+      'utf8',
+    );
+
+    await runRegisterHooks({ vaultDir });
+
+    const cmds = await readPostToolUseCommands(vaultDir);
+    expect(cmds).toContain('onebrain qmd-reindex');
+    expect(cmds.some((c) => /^qmd\s+update/.test(c))).toBe(false);
+  });
+
+  test('legacy `qmd update -c …` migration is idempotent on repeated runs', async () => {
+    await writeFile(
+      join(vaultDir, 'vault.yml'),
+      'method: onebrain\nqmd_collection: ob-1-test\n',
+      'utf8',
+    );
+    await writeFile(
+      join(vaultDir, '.claude', 'settings.json'),
+      JSON.stringify({
+        hooks: {
+          PostToolUse: [
+            {
+              matcher: 'Write|Edit',
+              hooks: [{ type: 'command', command: 'qmd update -c ob-1-test' }],
+            },
+          ],
+        },
+      }),
+      'utf8',
+    );
+
+    await runRegisterHooks({ vaultDir });
+    await runRegisterHooks({ vaultDir });
+
+    const cmds = await readPostToolUseCommands(vaultDir);
+    // Migration replaces the existing entry — no duplicate canonical entry created.
+    expect(cmds.filter((c) => c === 'onebrain qmd-reindex').length).toBe(1);
+  });
+
+  test('canonical entry already present → leaves settings unchanged (no duplicate)', async () => {
+    await writeFile(
+      join(vaultDir, 'vault.yml'),
+      'method: onebrain\nqmd_collection: ob-1-test\n',
+      'utf8',
+    );
+    await writeFile(
+      join(vaultDir, '.claude', 'settings.json'),
+      JSON.stringify({
+        hooks: {
+          PostToolUse: [
+            {
+              matcher: 'Write|Edit',
+              hooks: [{ type: 'command', command: 'onebrain qmd-reindex' }],
+            },
+          ],
+        },
+      }),
+      'utf8',
+    );
+
+    await runRegisterHooks({ vaultDir });
+
+    const cmds = await readPostToolUseCommands(vaultDir);
+    expect(cmds.filter((c) => c === 'onebrain qmd-reindex').length).toBe(1);
+  });
+
+  test('migration leaves unrelated PostToolUse hooks intact', async () => {
+    await writeFile(
+      join(vaultDir, 'vault.yml'),
+      'method: onebrain\nqmd_collection: ob-1-test\n',
+      'utf8',
+    );
+    await writeFile(
+      join(vaultDir, '.claude', 'settings.json'),
+      JSON.stringify({
+        hooks: {
+          PostToolUse: [
+            {
+              matcher: 'Write|Edit',
+              hooks: [
+                { type: 'command', command: 'qmd update -c ob-1-test' },
+                { type: 'command', command: 'echo user-custom-hook' },
+              ],
+            },
+          ],
+        },
+      }),
+      'utf8',
+    );
+
+    await runRegisterHooks({ vaultDir });
+
+    const cmds = await readPostToolUseCommands(vaultDir);
+    expect(cmds).toContain('onebrain qmd-reindex');
+    expect(cmds).toContain('echo user-custom-hook');
+    expect(cmds.some((c) => /^qmd\s+update/.test(c))).toBe(false);
+  });
+
+  test('powershell-wrapped legacy command is also migrated', async () => {
+    // Older Windows templates serialized qmd-reindex.ts's spawn args as the
+    // hook command verbatim, e.g. `powershell.exe -NoProfile -Command qmd update -c '<col>'`.
+    await writeFile(
+      join(vaultDir, 'vault.yml'),
+      'method: onebrain\nqmd_collection: ob-1-test\n',
+      'utf8',
+    );
+    await writeFile(
+      join(vaultDir, '.claude', 'settings.json'),
+      JSON.stringify({
+        hooks: {
+          PostToolUse: [
+            {
+              matcher: 'Write|Edit',
+              hooks: [
+                {
+                  type: 'command',
+                  command: "powershell.exe -NoProfile -Command qmd update -c 'ob-1-test'",
+                },
+              ],
+            },
+          ],
+        },
+      }),
+      'utf8',
+    );
+
+    await runRegisterHooks({ vaultDir });
+
+    const cmds = await readPostToolUseCommands(vaultDir);
+    expect(cmds).toEqual(['onebrain qmd-reindex']);
+  });
+
+  test('legacy + canonical co-existing → deduped to a single canonical entry', async () => {
+    // Pathological state: prior partial migration or hand-edit. Migration must
+    // dedupe so the hook doesn't fire twice on every Write/Edit.
+    await writeFile(
+      join(vaultDir, 'vault.yml'),
+      'method: onebrain\nqmd_collection: ob-1-test\n',
+      'utf8',
+    );
+    await writeFile(
+      join(vaultDir, '.claude', 'settings.json'),
+      JSON.stringify({
+        hooks: {
+          PostToolUse: [
+            {
+              matcher: 'Write|Edit',
+              hooks: [{ type: 'command', command: 'qmd update -c ob-1-test' }],
+            },
+            {
+              matcher: 'Write|Edit',
+              hooks: [{ type: 'command', command: 'onebrain qmd-reindex' }],
+            },
+          ],
+        },
+      }),
+      'utf8',
+    );
+
+    await runRegisterHooks({ vaultDir });
+
+    const cmds = await readPostToolUseCommands(vaultDir);
+    expect(cmds.filter((c) => c === 'onebrain qmd-reindex').length).toBe(1);
+  });
+
+  test('legacy entry under narrow matcher → matcher normalized to Write|Edit', async () => {
+    await writeFile(
+      join(vaultDir, 'vault.yml'),
+      'method: onebrain\nqmd_collection: ob-1-test\n',
+      'utf8',
+    );
+    await writeFile(
+      join(vaultDir, '.claude', 'settings.json'),
+      JSON.stringify({
+        hooks: {
+          PostToolUse: [
+            {
+              matcher: 'Write',
+              hooks: [{ type: 'command', command: 'qmd update -c ob-1-test' }],
+            },
+          ],
+        },
+      }),
+      'utf8',
+    );
+
+    await runRegisterHooks({ vaultDir });
+
+    const text = await readFile(join(vaultDir, '.claude', 'settings.json'), 'utf8');
+    const settings = JSON.parse(text) as Record<string, unknown>;
+    const groups = (settings['hooks'] as Record<string, unknown[]>)['PostToolUse'] as Array<{
+      matcher: string;
+      hooks: Array<{ command: string }>;
+    }>;
+    const canonical = groups.find((g) => g.hooks.some((h) => h.command === 'onebrain qmd-reindex'));
+    expect(canonical?.matcher).toBe('Write|Edit');
+  });
+
+  test('qmd disabled (no qmd_collection) → legacy entry is stripped, not left dangling', async () => {
+    // No qmd_collection in vault.yml. A pre-existing legacy `qmd update …`
+    // entry must not survive — it would fire forever against a collection
+    // the user has stopped maintaining.
+    await writeFile(join(vaultDir, 'vault.yml'), 'method: onebrain\n', 'utf8');
+    await writeFile(
+      join(vaultDir, '.claude', 'settings.json'),
+      JSON.stringify({
+        hooks: {
+          PostToolUse: [
+            {
+              matcher: 'Write|Edit',
+              hooks: [{ type: 'command', command: 'qmd update -c ob-1-test' }],
+            },
+          ],
+        },
+      }),
+      'utf8',
+    );
+
+    await runRegisterHooks({ vaultDir });
+
+    const text = await readFile(join(vaultDir, '.claude', 'settings.json'), 'utf8');
+    const settings = JSON.parse(text) as Record<string, unknown>;
+    const hooks = settings['hooks'] as Record<string, unknown> | undefined;
+    expect(hooks?.['PostToolUse']).toBeUndefined();
+  });
+
+  test('qmd disabled with mixed legacy + user hooks → strips legacy, keeps user entry', async () => {
+    await writeFile(join(vaultDir, 'vault.yml'), 'method: onebrain\n', 'utf8');
+    await writeFile(
+      join(vaultDir, '.claude', 'settings.json'),
+      JSON.stringify({
+        hooks: {
+          PostToolUse: [
+            {
+              matcher: 'Write|Edit',
+              hooks: [
+                { type: 'command', command: 'qmd update -c ob-1-test' },
+                { type: 'command', command: 'echo user-custom-hook' },
+              ],
+            },
+          ],
+        },
+      }),
+      'utf8',
+    );
+
+    await runRegisterHooks({ vaultDir });
+
+    const cmds = await readPostToolUseCommands(vaultDir);
+    expect(cmds).toEqual(['echo user-custom-hook']);
+  });
+
+  test('two pre-existing canonical entries (no legacy) → dedupes to one', async () => {
+    // Pathological state from a hand-edit or partial prior run. Even when
+    // there's nothing legacy to migrate, the dedup pass must keep a single
+    // canonical hook so it doesn't fire twice on every Write/Edit.
+    await writeFile(
+      join(vaultDir, 'vault.yml'),
+      'method: onebrain\nqmd_collection: ob-1-test\n',
+      'utf8',
+    );
+    await writeFile(
+      join(vaultDir, '.claude', 'settings.json'),
+      JSON.stringify({
+        hooks: {
+          PostToolUse: [
+            {
+              matcher: 'Write|Edit',
+              hooks: [{ type: 'command', command: 'onebrain qmd-reindex' }],
+            },
+            {
+              matcher: 'Write|Edit',
+              hooks: [{ type: 'command', command: 'onebrain qmd-reindex' }],
+            },
+          ],
+        },
+      }),
+      'utf8',
+    );
+
+    await runRegisterHooks({ vaultDir });
+
+    const cmds = await readPostToolUseCommands(vaultDir);
+    expect(cmds.filter((c) => c === 'onebrain qmd-reindex').length).toBe(1);
+  });
+
+  test('qmd disabled with mixed legacy + canonical → strips legacy, keeps canonical', async () => {
+    // The user disabled qmd in vault.yml but had previously registered the
+    // canonical hook by hand. We must strip only the broken legacy entry —
+    // never silently delete the user's manually-kept canonical one.
+    await writeFile(join(vaultDir, 'vault.yml'), 'method: onebrain\n', 'utf8');
+    await writeFile(
+      join(vaultDir, '.claude', 'settings.json'),
+      JSON.stringify({
+        hooks: {
+          PostToolUse: [
+            {
+              matcher: 'Write|Edit',
+              hooks: [
+                { type: 'command', command: 'qmd update -c ob-1-test' },
+                { type: 'command', command: 'onebrain qmd-reindex' },
+              ],
+            },
+          ],
+        },
+      }),
+      'utf8',
+    );
+
+    await runRegisterHooks({ vaultDir });
+
+    const cmds = await readPostToolUseCommands(vaultDir);
+    expect(cmds).toEqual(['onebrain qmd-reindex']);
+  });
+
+  test('idempotence: re-introducing a legacy entry after migration → migrates again on next run', async () => {
+    // The first test in this group covers the simple "run twice" case. This
+    // one pins the state machine: the migration branch must remain reachable,
+    // not dead code, after the canonical entry has been written once.
+    await writeFile(
+      join(vaultDir, 'vault.yml'),
+      'method: onebrain\nqmd_collection: ob-1-test\n',
+      'utf8',
+    );
+    await writeFile(
+      join(vaultDir, '.claude', 'settings.json'),
+      JSON.stringify({
+        hooks: {
+          PostToolUse: [
+            {
+              matcher: 'Write|Edit',
+              hooks: [{ type: 'command', command: 'qmd update -c ob-1-test' }],
+            },
+          ],
+        },
+      }),
+      'utf8',
+    );
+
+    // Run 1: migrate the legacy entry.
+    await runRegisterHooks({ vaultDir });
+    let cmds = await readPostToolUseCommands(vaultDir);
+    expect(cmds).toEqual(['onebrain qmd-reindex']);
+
+    // Re-introduce a legacy entry alongside the canonical one (e.g. the user
+    // re-ran an older `/update` template).
+    const text = await readFile(join(vaultDir, '.claude', 'settings.json'), 'utf8');
+    const settings = JSON.parse(text) as { hooks: { PostToolUse: unknown[] } };
+    settings.hooks.PostToolUse.push({
+      matcher: 'Write|Edit',
+      hooks: [{ type: 'command', command: 'qmd update -c ob-1-test' }],
+    });
+    await writeFile(join(vaultDir, '.claude', 'settings.json'), JSON.stringify(settings), 'utf8');
+
+    // Run 2: legacy entry must be migrated and deduped.
+    await runRegisterHooks({ vaultDir });
+    cmds = await readPostToolUseCommands(vaultDir);
+    expect(cmds).toEqual(['onebrain qmd-reindex']);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/commands/internal/register-hooks.ts
+++ b/src/commands/internal/register-hooks.ts
@@ -190,12 +190,105 @@ function applyHooks(settings: SettingsJson): Record<string, HookStatus> {
 const QMD_CMD = 'onebrain qmd-reindex';
 const QMD_MATCHER = 'Write|Edit';
 
+/**
+ * Match legacy templates that registered `qmd update <args>` as the PostToolUse
+ * command instead of the `onebrain qmd-reindex` wrapper. `/doctor`'s substring
+ * check looks for `qmd-reindex`, so these working hooks get flagged as missing
+ * until we rewrite them. See issue #127.
+ *
+ * Word-bounded match (`\bqmd\s+update\b`) so the rewrite still applies even if
+ * the entry is wrapped by a shell launcher (`powershell.exe -Command qmd update …`,
+ * `bash -lc 'qmd update …'`, `cmd.exe /c qmd update …`).
+ */
+function isLegacyQmdCmd(cmd: string): boolean {
+  return /\bqmd\s+update\b/.test(cmd);
+}
+
+/**
+ * Migrate or remove any legacy `qmd update …` PostToolUse entries.
+ *
+ * - When `keepCanonical` is true (the normal `--qmd` path), legacy entries are
+ *   rewritten in place to `onebrain qmd-reindex` and the parent group's matcher
+ *   is normalized to `QMD_MATCHER` so a fresh install and a migrated install
+ *   converge to the same shape.
+ * - When `keepCanonical` is false (no `qmd_collection` in vault.yml — the user
+ *   no longer uses qmd), legacy entries are dropped from their groups, and any
+ *   group that becomes empty is removed. Without this, deleting `qmd_collection`
+ *   from vault.yml would leave the legacy hook firing forever against a
+ *   collection that no longer exists.
+ *
+ * After in-place rewriting, duplicate canonical entries are deduped to one,
+ * so a vault that already had a canonical entry plus a legacy entry doesn't
+ * end up calling the hook twice on each Write.
+ */
+function migrateLegacyQmdEntries(groups: HookGroup[], keepCanonical: boolean): boolean {
+  // Three sequential passes over `groups`:
+  //   1. Rewrite-or-strip any `qmd update …` entries (rewrite keeps canonical,
+  //      strip removes them entirely).
+  //   2. Dedupe `onebrain qmd-reindex` entries — runs on every keepCanonical=true
+  //      call so a settings.json that already had two canonical entries (Pass 1
+  //      saw nothing to do) still ends up with one.
+  //   3. Splice out groups whose hooks array became empty (reverse iteration —
+  //      forward indices stay valid as we splice from the tail).
+  let touched = false;
+
+  for (const group of groups) {
+    if (!group.hooks) continue;
+    if (keepCanonical) {
+      let groupTouched = false;
+      for (const entry of group.hooks) {
+        if (isLegacyQmdCmd(entry.command ?? '')) {
+          entry.command = QMD_CMD;
+          if (!entry.type) entry.type = 'command';
+          groupTouched = true;
+        }
+      }
+      if (groupTouched) {
+        group.matcher = QMD_MATCHER;
+        touched = true;
+      }
+    } else {
+      const before = group.hooks.length;
+      group.hooks = group.hooks.filter((h) => !isLegacyQmdCmd(h.command ?? ''));
+      if (group.hooks.length !== before) touched = true;
+    }
+  }
+
+  if (keepCanonical) {
+    let seenCanonical = false;
+    for (const group of groups) {
+      if (!group.hooks) continue;
+      const before = group.hooks.length;
+      group.hooks = group.hooks.filter((h) => {
+        if (h.command !== QMD_CMD) return true;
+        if (seenCanonical) return false;
+        seenCanonical = true;
+        return true;
+      });
+      if (group.hooks.length !== before) touched = true;
+    }
+  }
+
+  for (let i = groups.length - 1; i >= 0; i--) {
+    const g = groups[i];
+    if (g && (g.hooks?.length ?? 0) === 0) groups.splice(i, 1);
+  }
+
+  return touched;
+}
+
 function applyQmdHook(settings: SettingsJson): HookStatus {
   if (!settings.hooks) settings.hooks = {};
   if (!settings.hooks['PostToolUse']) settings.hooks['PostToolUse'] = [];
   const groups = settings.hooks['PostToolUse'];
+
+  // Migrate before the canonical-presence check so a settings.json containing
+  // only legacy entries reports `migrated` and produces a single canonical
+  // entry — never `added` plus a stale duplicate.
+  const migrated = migrateLegacyQmdEntries(groups, true);
+
   const already = groups.some((g) => g.hooks?.some((h) => h.command === QMD_CMD));
-  if (already) return 'ok';
+  if (already) return migrated ? 'migrated' : 'ok';
   groups.push({ matcher: QMD_MATCHER, hooks: [{ type: 'command', command: QMD_CMD }] });
   return 'added';
 }
@@ -340,7 +433,22 @@ export async function runRegisterHooks(
 
       // ── Step 1b: qmd PostToolUse hook (applied before stop so it appears in hook line) ──
       let qmdStatus: HookStatus | undefined;
-      if (qmdCollection) qmdStatus = applyQmdHook(settings);
+      if (qmdCollection) {
+        qmdStatus = applyQmdHook(settings);
+      } else {
+        // qmd disabled (no qmd_collection in vault.yml): strip any legacy
+        // `qmd update …` PostToolUse entries so they don't keep firing against
+        // a collection the user no longer maintains. Issue #127.
+        const groups = settings.hooks?.['PostToolUse'] ?? [];
+        const stripped = migrateLegacyQmdEntries(groups, false);
+        if (stripped && groups.length === 0 && settings.hooks) {
+          // Removing the key (rather than setting it to undefined) keeps the
+          // serialized JSON clean — `JSON.stringify` would emit `"PostToolUse":null`
+          // for the assignment form, which surprises downstream consumers.
+          // biome-ignore lint/performance/noDelete: see comment above
+          delete settings.hooks['PostToolUse'];
+        }
+      }
 
       if (isTTY) {
         const parts = HOOK_EVENTS.map((e) => {
@@ -348,8 +456,10 @@ export async function runRegisterHooks(
           const icon = pc.green(status === 'ok' ? '✓' : status === 'migrated' ? '↑' : '+');
           return `${pc.dim(e)} ${icon}`;
         });
-        if (qmdStatus)
-          parts.push(`${pc.dim('PostToolUse')} ${pc.green(qmdStatus === 'ok' ? '✓' : '+')}`);
+        if (qmdStatus) {
+          const qmdIcon = qmdStatus === 'ok' ? '✓' : qmdStatus === 'migrated' ? '↑' : '+';
+          parts.push(`${pc.dim('PostToolUse')} ${pc.green(qmdIcon)}`);
+        }
         hooksSpinner?.stop(`Hooks  ${parts.join('  ')}`);
       } else {
         const hookLine = HOOK_EVENTS.map((e) => {
@@ -361,7 +471,7 @@ export async function runRegisterHooks(
           return `${e} ${label}`;
         }).join('  ');
         note(hookLine);
-        if (qmdStatus) note(`PostToolUse ${qmdStatus === 'added' ? 'added' : 'ok'}`);
+        if (qmdStatus) note(`PostToolUse ${qmdStatus}`);
       }
 
       // ── Step 2: Permissions ───────────────────────────────────────────────


### PR DESCRIPTION
Closes #127.

## Summary

Older OneBrain templates registered `qmd update -c <collection>` directly as the `PostToolUse` hook command, predating the `onebrain qmd-reindex` wrapper. `/doctor`'s consistency check looks for the substring `qmd-reindex`, so working legacy hooks get flagged as missing — but `/update` never rewrote them, leaving users in an infinite false-positive loop.

This PR makes `applyQmdHook` migrate the legacy form on the next `register-hooks` / `/update` run.

## What changed

- **Migrate** legacy `qmd update <args>` entries to canonical `onebrain qmd-reindex`. Word-bounded match (`\bqmd\s+update\b`) so launcher-wrapped variants (`powershell.exe ... qmd update -c …`, `bash -lc 'qmd update …'`, `cmd.exe /c qmd update …`) are also picked up.
- **Normalize** the parent group's `matcher` to `Write|Edit` so a fresh install and a migrated install converge to the same shape.
- **Dedupe** canonical entries — applies even when no legacy was migrated, so two pre-existing canonical hooks (hand-edited or partial prior run) collapse to one.
- **Strip** legacy entries when `qmd_collection` is unset in `vault.yml`. User-added canonical hooks are preserved through this strip path.
- **Status line** now reports `PostToolUse migrated` (with `↑` icon in TTY) — matches how the `Stop` hook already reports its own legacy migration.

The `qmd-reindex` command itself works correctly on `v2.1.13` (verified end-to-end on macOS — file count moves on hook fire). The "no-op" symptom in the issue body could not be reproduced; the structural inconsistency between doctor's check and the legacy template form was the actionable part of the report.

## Test plan

- [x] 30 tests pass (12 new cases) — migrate / idempotent / canonical-already-present / unrelated-hook-preserved / PowerShell-wrapped legacy / legacy + canonical co-existing / narrow-matcher normalization / qmd-disabled strip (with and without user canonical) / state-machine-reachable / two-pre-existing-canonical dedup
- [x] Full CLI test suite — 296 pass / 0 fail
- [x] `bun run typecheck` clean
- [x] `bunx biome check` clean
- [x] Manual smoke test against a fake vault with legacy hook — file is rewritten, status line shows `PostToolUse migrated`
- [x] 3 review rounds (code-reviewer × 3, silent-failure-hunter × 2, type-design-analyzer, comment-analyzer)

## Out of scope (follow-up)

- Status print before write-success (a pre-existing concern across all hook events — not introduced by this PR)
- The reporter's `no-op` symptom on Windows + iCloud (covered structurally by this fix; if it persists, suggest re-testing on the new CLI version and reopening with a fresh trace)