### PR TITLE
fix: Windows + iCloud Drive reliability — mkdir EEXIST + tar drive-letter (#126)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-latest_version: 2.1.14
+latest_version: 2.1.15
 released: 2026-05-06
 ---
 
@@ -12,6 +12,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 > For plugin changes (skills, agents, hooks, INSTRUCTIONS), see [PLUGIN-CHANGELOG.md](PLUGIN-CHANGELOG.md).
 
 ## [Unreleased]
+
+## v2.1.15 — fix(vault-sync, register-hooks): Windows + iCloud reliability
+
+- fix(vault-sync): set `TAR_OPTIONS=--force-local` on win32 so MSYS/Git Bash GNU tar stops parsing `C:\…` vault paths as `host:path` and the extraction completes (#126)
+- fix(vault-sync, register-hooks, init): swallow EEXIST from `mkdir({ recursive: true })` when the path is already a directory — covers the iCloud-Drive-on-Windows quirk where `mkdir` throws despite the recursive flag; non-EEXIST errors and EEXIST-on-a-file still propagate (#126)
+- new(lib): `mkdirIdempotent` helper in `@onebrain/core` — single shared EEXIST-tolerant `mkdir` used by all CLI write paths, replacing four ad-hoc `mkdir({ recursive: true })` call sites
+- test: 4 new cases for `mkdirIdempotent` (fresh dir, idempotent, EEXIST-on-file rethrow, EACCES rethrow) and 4 for `buildTarSpawnEnv` (darwin/linux passthrough, win32 sets `--force-local`, win32 overrides user-set `TAR_OPTIONS`)
 
 ## v2.1.14 — fix(register-hooks): migrate legacy `qmd update -c …` PostToolUse entries
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onebrain-ai/cli",
-  "version": "2.1.14",
+  "version": "2.1.15",
   "description": "CLI for OneBrain — personal AI OS for Obsidian with persistent memory, 24+ skills, and Claude Code integration",
   "keywords": [
     "onebrain",

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -474,14 +474,14 @@ function getFix(r: DoctorResult): Fix | null {
     const missingStr = r.hint.replace('Missing: ', '');
     return {
       fn: async (vaultDir) => {
-        const { mkdir } = await import('node:fs/promises');
+        const { mkdirIdempotent } = await import('../lib/index.js');
         const { join } = await import('node:path');
         const missing = missingStr
           .split(', ')
           .map((f) => f.trim())
           .filter(Boolean);
         for (const folder of missing) {
-          await mkdir(join(vaultDir, folder), { recursive: true });
+          await mkdirIdempotent(join(vaultDir, folder));
         }
       },
       description: `Create missing folders: ${missingStr}`,

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -16,11 +16,12 @@
  * Exit code: 0 on success, 1 on failure.
  */
 
-import { mkdir, readFile, readdir, rename, stat, writeFile } from 'node:fs/promises';
+import { readFile, readdir, rename, stat, writeFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 import pc from 'picocolors';
 import { stringify as stringifyYaml } from 'yaml';
+import { mkdirIdempotent } from '../lib/index.js';
 import { printBanner, resolveBinaryVersion } from './internal/cli-banner.js';
 import {
   askYesNo,
@@ -126,7 +127,7 @@ async function createFolders(vaultDir: string): Promise<number> {
   for (const rel of allPaths) {
     const full = join(vaultDir, rel);
     if (!(await pathExists(full))) {
-      await mkdir(full, { recursive: true });
+      await mkdirIdempotent(full);
       created++;
     }
   }
@@ -295,7 +296,7 @@ async function registerPlugin(
   // Write atomically
   const tmpPath = `${installedPluginsPath}.tmp`;
   try {
-    await mkdir(dirname(installedPluginsPath), { recursive: true });
+    await mkdirIdempotent(dirname(installedPluginsPath));
     await writeFile(tmpPath, JSON.stringify(data, null, 4), 'utf8');
     await rename(tmpPath, installedPluginsPath);
   } catch (err) {
@@ -414,7 +415,7 @@ async function installObsidianPlugins(
     }
 
     // Download assets
-    await mkdir(pluginDir, { recursive: true });
+    await mkdirIdempotent(pluginDir);
     let pluginFailed = false;
 
     for (const assetName of ['main.js', 'manifest.json', 'styles.css'] as const) {

--- a/src/commands/internal/register-hooks.ts
+++ b/src/commands/internal/register-hooks.ts
@@ -9,12 +9,12 @@
  * Non-TTY: plain text prefixed with "register-hooks:"
  */
 
-import { mkdir, readFile, rename, writeFile } from 'node:fs/promises';
+import { readFile, rename, writeFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { spinner } from '@clack/prompts';
 import pc from 'picocolors';
-import { loadVaultConfig } from '../../lib/index.js';
+import { loadVaultConfig, mkdirIdempotent } from '../../lib/index.js';
 import { detectHarness } from './harness.js';
 
 // ---------------------------------------------------------------------------
@@ -89,7 +89,7 @@ async function readSettings(settingsPath: string): Promise<SettingsJson> {
 }
 
 async function writeSettings(settingsPath: string, settings: SettingsJson): Promise<void> {
-  await mkdir(dirname(settingsPath), { recursive: true });
+  await mkdirIdempotent(dirname(settingsPath));
   const tmpPath = `${settingsPath}.tmp`;
   await writeFile(tmpPath, JSON.stringify(settings, null, 4), 'utf8');
   await rename(tmpPath, settingsPath);

--- a/src/commands/internal/vault-sync.test.ts
+++ b/src/commands/internal/vault-sync.test.ts
@@ -13,7 +13,7 @@ import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises'
 import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { runVaultSync } from './vault-sync.js';
+import { buildTarSpawnOverrides, runVaultSync } from './vault-sync.js';
 
 // ---------------------------------------------------------------------------
 // Suite-level guard: real ~/.claude/plugins/installed_plugins.json must NOT
@@ -896,5 +896,35 @@ describe('runVaultSync', () => {
     // Sibling refreshed to tarball version.
     expect(entries[1].installPath).toBe(join(vaultDir, '.claude/plugins/onebrain'));
     expect(entries[1].version).toBe('1.11.0');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildTarSpawnOverrides — Windows MSYS tar drive-letter workaround (#126)
+// ---------------------------------------------------------------------------
+
+describe('buildTarSpawnOverrides', () => {
+  it('returns {} on macOS so spread leaves Bun.spawn options unchanged', () => {
+    expect(buildTarSpawnOverrides('darwin', { PATH: '/usr/bin' })).toEqual({});
+  });
+
+  it('returns {} on Linux', () => {
+    expect(buildTarSpawnOverrides('linux', { PATH: '/usr/bin' })).toEqual({});
+  });
+
+  it('on win32, sets env.TAR_OPTIONS=--force-local while preserving the parent env', () => {
+    const parent = { PATH: 'C:\\Windows', FOO: 'bar' };
+    const overrides = buildTarSpawnOverrides('win32', parent);
+    expect(overrides.env?.['TAR_OPTIONS']).toBe('--force-local');
+    expect(overrides.env?.['PATH']).toBe('C:\\Windows');
+    expect(overrides.env?.['FOO']).toBe('bar');
+  });
+
+  it('on win32, overrides any pre-existing TAR_OPTIONS so user-set flags do not break extraction', () => {
+    // We intentionally override TAR_OPTIONS rather than appending — the user
+    // path may have flags incompatible with the inner-loop tar invocation
+    // (e.g. `--verbose` would change exit semantics). Document via test.
+    const overrides = buildTarSpawnOverrides('win32', { TAR_OPTIONS: '--verbose' });
+    expect(overrides.env?.['TAR_OPTIONS']).toBe('--force-local');
   });
 });

--- a/src/commands/internal/vault-sync.ts
+++ b/src/commands/internal/vault-sync.ts
@@ -17,13 +17,13 @@
  * Non-TTY: plain text prefixed with "vault-sync:"
  */
 
-import { mkdir, mkdtemp, readFile, readdir, rm, stat, unlink, writeFile } from 'node:fs/promises';
+import { mkdtemp, readFile, readdir, rm, stat, unlink, writeFile } from 'node:fs/promises';
 import { homedir, tmpdir } from 'node:os';
 import { dirname, join, sep as pathSep, relative, resolve as resolvePath } from 'node:path';
 import { intro, outro, spinner } from '@clack/prompts';
 import pc from 'picocolors';
 import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
-import { atomicWrite } from '../../lib/index.js';
+import { atomicWrite, mkdirIdempotent } from '../../lib/index.js';
 import { makeStepFn } from './cli-ui.js';
 import { detectHarness } from './harness.js';
 
@@ -113,22 +113,50 @@ async function downloadTarball(
 }
 
 /**
- * Extract a .tar.gz buffer to destDir using the `tar` CLI.
- * Returns the path of the top-level extracted directory.
+ * Build the spawn-option overrides for the `tar` extraction subprocess.
+ *
+ * On Windows MSYS/Git Bash, GNU tar parses any path containing a colon as
+ * `host:path` and tries to ssh to host `C` (or whichever drive letter), which
+ * blows up `vault-sync` for any vault under a Windows drive root. Setting
+ * `TAR_OPTIONS=--force-local` tells GNU tar to treat colons as part of the
+ * local path. BSD tar on macOS ignores the env var entirely, so we only set
+ * it on win32 to avoid surprises on platforms where the workaround is a no-op.
+ *
+ * Returns `{}` outside win32 (caller spreads → spawn inherits parent env), or
+ * `{ env: { ... } }` on win32 with `TAR_OPTIONS=--force-local` overlaid on the
+ * parent env. The shape lets callers use `Bun.spawn(args, { ...other, ...buildTarSpawnOverrides() })`
+ * without needing a conditional spread. Exported for testing.
+ */
+export function buildTarSpawnOverrides(
+  platform: NodeJS.Platform = process.platform,
+  parentEnv: NodeJS.ProcessEnv = process.env,
+): { env?: NodeJS.ProcessEnv } {
+  if (platform !== 'win32') return {};
+  return { env: { ...parentEnv, TAR_OPTIONS: '--force-local' } };
+}
+
+/**
+ * Extract a .tar.gz buffer to destDir using the `tar` CLI. Returns the path of
+ * the top-level extracted directory. See `buildTarSpawnOverrides` for the win32 quirk.
  */
 async function extractTarball(tarball: ArrayBuffer, destDir: string): Promise<string> {
   const tarPath = join(destDir, 'bundle.tar.gz');
   await writeFile(tarPath, Buffer.from(tarball));
 
-  // Spawn tar to extract
+  // Spawn tar to extract — only override env on win32 (see buildTarSpawnOverrides).
+  const tarOverrides = buildTarSpawnOverrides();
   const proc = Bun.spawn(['tar', '-xzf', tarPath, '-C', destDir], {
     stdout: 'pipe',
     stderr: 'pipe',
+    ...tarOverrides,
   });
   const exitCode = await proc.exited;
   if (exitCode !== 0) {
     const errText = await new Response(proc.stderr).text();
-    throw new Error(`tar extraction failed (exit ${exitCode}): ${errText.trim()}`);
+    // Surface the win32 env override in the error so a tar failure on Windows
+    // is self-documenting in user-submitted logs (see #126).
+    const envHint = tarOverrides.env ? ', TAR_OPTIONS=--force-local' : '';
+    throw new Error(`tar extraction failed (exit ${exitCode}${envHint}): ${errText.trim()}`);
   }
 
   // Delete the tarball file now we've extracted
@@ -187,7 +215,7 @@ async function syncPluginFiles(
   const sourcePlugin = join(extractedDir, '.claude', 'plugins', 'onebrain');
   const destPlugin = join(vaultRoot, '.claude', 'plugins', 'onebrain');
 
-  await mkdir(destPlugin, { recursive: true });
+  await mkdirIdempotent(destPlugin);
 
   // Collect source files (relative to sourcePlugin)
   const sourceFiles = await listFilesRecursive(sourcePlugin);
@@ -210,7 +238,7 @@ async function syncPluginFiles(
   for (const srcPath of sourceFiles) {
     const rel = relative(sourcePlugin, srcPath);
     const destPath = join(destPlugin, rel);
-    await mkdir(dirname(destPath), { recursive: true });
+    await mkdirIdempotent(dirname(destPath));
     const content = await readFile(srcPath);
     await writeFile(destPath, content);
     filesAdded++;
@@ -759,7 +787,7 @@ export async function runVaultSync(
         for (const srcPath of obsidianFiles) {
           const rel = relative(sourceObsidian, srcPath);
           const destPath = join(destObsidian, rel);
-          await mkdir(dirname(destPath), { recursive: true });
+          await mkdirIdempotent(dirname(destPath));
           const content = await readFile(srcPath);
           await writeFile(destPath, content);
         }

--- a/src/lib/fs-mkdir-safe.test.ts
+++ b/src/lib/fs-mkdir-safe.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { chmod, mkdir, mkdtemp, rm, stat, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { mkdirIdempotent } from './fs-mkdir-safe.js';
+
+describe('mkdirIdempotent', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'ob-mkdir-test-'));
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('creates a fresh directory', async () => {
+    const target = join(tmpDir, 'a', 'b', 'c');
+    await mkdirIdempotent(target);
+    const s = await stat(target);
+    expect(s.isDirectory()).toBe(true);
+  });
+
+  it('is idempotent on a directory that already exists (no error thrown)', async () => {
+    const target = join(tmpDir, 'a');
+    await mkdir(target, { recursive: true });
+    // Standard Node mkdir({recursive:true}) doesn't throw here either, but this
+    // pins the contract: regardless of platform, calling twice must succeed.
+    await mkdirIdempotent(target);
+    await mkdirIdempotent(target);
+    const s = await stat(target);
+    expect(s.isDirectory()).toBe(true);
+  });
+
+  it('rethrows EEXIST when the existing entry is a regular file', async () => {
+    const target = join(tmpDir, 'collision');
+    await writeFile(target, 'not a directory', 'utf8');
+
+    let caught: NodeJS.ErrnoException | undefined;
+    try {
+      await mkdirIdempotent(target);
+    } catch (err) {
+      caught = err as NodeJS.ErrnoException;
+    }
+    expect(caught).toBeDefined();
+    expect(caught?.code).toBe('EEXIST');
+  });
+
+  it('rethrows non-EEXIST errors unchanged (EACCES)', async () => {
+    // Drop write permission on a parent so the inner mkdir hits EACCES, not
+    // EEXIST. Confirms the wrapper's EEXIST-only swallow rule — everything
+    // else propagates verbatim. Skipped on win32 (chmod is a no-op).
+    if (process.platform === 'win32') return;
+
+    const lockedParent = join(tmpDir, 'locked');
+    await mkdir(lockedParent);
+    await chmod(lockedParent, 0o500);
+    try {
+      let caught: NodeJS.ErrnoException | undefined;
+      try {
+        await mkdirIdempotent(join(lockedParent, 'child'));
+      } catch (err) {
+        caught = err as NodeJS.ErrnoException;
+      }
+      expect(caught).toBeDefined();
+      expect(caught?.code).toBe('EACCES');
+    } finally {
+      await chmod(lockedParent, 0o700);
+    }
+  });
+});

--- a/src/lib/fs-mkdir-safe.ts
+++ b/src/lib/fs-mkdir-safe.ts
@@ -1,0 +1,50 @@
+// fs-mkdir-safe — `mkdir({ recursive: true })` that tolerates iCloud Drive on Windows
+//
+// Standard Node `fs/promises` `mkdir(path, { recursive: true })` is documented as
+// idempotent: if the directory already exists, it returns silently. This contract
+// breaks on Windows when the path lives inside iCloud Drive — the CSC (Client-Side
+// Caching) layer occasionally reports a path as both "does not exist yet" (to the
+// pre-mkdir stat) and "already exists" (when `mkdir` actually runs), throwing
+// EEXIST despite the `recursive: true` flag. See issue #126.
+//
+// Reproducing this on macOS or Linux is essentially impossible without simulating
+// the iCloud filesystem; the wrapper exists to keep production callers from
+// crashing on a transient state mismatch they cannot prevent.
+
+import type { Stats } from 'node:fs';
+import { mkdir, stat } from 'node:fs/promises';
+
+/**
+ * `mkdir(path, { recursive: true })` that swallows EEXIST when the existing
+ * filesystem entry is already a directory.
+ *
+ * - On any error other than EEXIST → rethrows.
+ * - On EEXIST → calls `stat` to confirm the path is a directory; if it's a
+ *   regular file, the original EEXIST is rethrown so callers don't silently
+ *   trample a file with directory semantics.
+ */
+export async function mkdirIdempotent(path: string): Promise<void> {
+  try {
+    await mkdir(path, { recursive: true });
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException | undefined)?.code;
+    if (code !== 'EEXIST') throw err;
+    // EEXIST with recursive:true is the iCloud-on-Windows quirk — confirm the
+    // post-condition is met (path is a directory) before swallowing.
+    let info: Stats;
+    try {
+      info = await stat(path);
+    } catch (statErr) {
+      // The stat error is usually more actionable than the original EEXIST:
+      // - EACCES on the parent directory points at a permissions problem
+      //   the user needs to see.
+      // - ENOENT means the path was removed between mkdir and stat (a race);
+      //   the original EEXIST is misleading because the path now doesn't exist.
+      // In both cases we want the stat error to win, falling back to the
+      // original mkdir error only if stat itself reported nothing useful.
+      const statCode = (statErr as NodeJS.ErrnoException | undefined)?.code;
+      throw statCode ? statErr : err;
+    }
+    if (!info.isDirectory()) throw err;
+  }
+}

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -23,3 +23,5 @@ export {
 } from './validator.js';
 
 export { atomicWrite } from './fs-atomic.js';
+
+export { mkdirIdempotent } from './fs-mkdir-safe.js';


### PR DESCRIPTION
Closes #126 (platform-agnostic structural fixes — Bug 1 + Bug 2; the slash-mixing observation was already a non-issue because all OneBrain write paths use \`path.join\`).

## Summary

Two distinct Windows-only failures that compose during \`/update\`:

### Bug 1 — \`mkdir({ recursive: true })\` throws EEXIST on iCloud Drive

The iCloud CSC layer on Windows occasionally reports a path as both "doesn't exist" (to the pre-mkdir \`stat\`) and "already exists" (to \`mkdir\` itself), throwing EEXIST despite the \`recursive: true\` flag. \`vault-sync\`, \`register-hooks\`, \`init\`, and \`/doctor --fix\` all crash on this.

**Fix:** new \`mkdirIdempotent\` helper in \`@onebrain/core\`. Swallows EEXIST when the path is a directory; rethrows otherwise. On EEXIST + \`stat\` failure, surfaces the more actionable error (EACCES on parent, ENOENT race) instead of the stale EEXIST.

Five call sites switched: \`writeSettings\`, \`vault-sync\` syncPlugin (×2) + Obsidian sync, \`init\` ensureFolders / installed-plugins / Obsidian-asset-dir, \`/doctor\` create-missing-folders auto-fix.

### Bug 2 — \`tar -xzf\` fails with \`Cannot connect to C:\`

GNU tar in MSYS/Git Bash parses any path containing a colon as \`host:path\` and tries to ssh.

**Fix:** new \`buildTarSpawnOverrides\` helper sets \`TAR_OPTIONS=--force-local\` on win32 only (BSD tar on macOS ignores the env var, so the workaround is a no-op there — set it conditionally to avoid surprises). The extraction error message now embeds \`TAR_OPTIONS=--force-local\` when the override was applied, so user-submitted Windows logs are self-documenting.

## Test plan

- [x] \`bun test\` — 306 pass / 0 fail (8 new: 4 for mkdirIdempotent, 4 for buildTarSpawnOverrides)
- [x] \`bun run typecheck\` clean
- [x] \`bunx biome check\` clean on changed files
- [x] 3 review rounds (code-reviewer × 3, silent-failure-hunter × 2, type-design-analyzer × 2) — all returned "ship it" by round 3

Mac-untestable for the actual Windows symptoms; structural correctness is verified by mocking the platform value and by confirming behavior is identical on platforms where the workarounds are no-ops.

## Out of scope (deferred)

- Issues #128 / #129 / #130 are skill / shell-script Windows compat issues, not CLI source — separate tracks.