### PR TITLE
fix: Windows skill + script compat — PowerShell / cmd / native Python (#128, #129, #130)

### DIFF
--- a/.claude/plugins/onebrain/.claude-plugin/plugin.json
+++ b/.claude/plugins/onebrain/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "onebrain",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "description": "OneBrain — Where human and AI thinking become one. A powerful thinking partner powered by AI synergy.",
   "author": {
     "name": "OneBrain Contributors"

--- a/.claude/plugins/onebrain/INSTRUCTIONS.md
+++ b/.claude/plugins/onebrain/INSTRUCTIONS.md
@@ -227,7 +227,7 @@ On weekends: lighter, less task-focused tone. **No-repeat rule:** don't ask abou
 - Read `[agent_folder]/MEMORY-INDEX.md` → load memory file index for lazy-loading
 - Load `memory/` files matching active project keywords from MEMORY-INDEX.md Topics column (`status: active` or `needs-review` only). Also match user's first message once it arrives.
 - Glob `[inbox_folder]/*.md` → count files as `inbox_count`
-- Run via Bash: `LC_ALL=en_US.UTF-8 grep -r "- \[ \] .*📅 [0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}" "[projects_folder]/" "[inbox_folder]/"` → keep only tasks where date ≤ today; group overdue first, then due today
+- Run the Grep tool **twice** — once with `path: "[projects_folder]"` and once with `path: "[inbox_folder]"`, both with the pattern `- \[ \] .*📅 [0-9]{4}-[0-9]{2}-[0-9]{2}` and `output_mode: "content"`. Combine the two result sets. (Grep handles UTF-8 correctly on every platform; the previous Bash shell-out relied on `LC_ALL=en_US.UTF-8` and GNU grep BRE semantics, both Bash-only.) Keep only tasks where date ≤ today; group overdue first, then due today
 - Run `onebrain orphan-scan "[logs_folder]" "[session_token]"` (from vault root) → parse JSON output; read `orphan_count` field. JSON shape: `{"orphan_count":N}`. If the command fails or is unavailable, fall back to: Glob `[logs_folder]/**/*-checkpoint-*.md`, discard files whose date has a non-auto-saved session log, then count distinct session tokens among remaining files.
 
 **Step 4 — Send startup status (after Step 3 completes):**

--- a/.claude/plugins/onebrain/skills/doctor/SKILL.md
+++ b/.claude/plugins/onebrain/skills/doctor/SKILL.md
@@ -81,11 +81,12 @@ Run all applicable checks based on flags (default: all). Collect findings before
 - Verify `name`, `version`, `description` fields exist and are non-empty
 
 **Plugin install path:**
-- Read `~/.claude/plugins/installed_plugins.json`
+- Read `$HOME/.claude/plugins/installed_plugins.json` (Unix) or `$env:USERPROFILE/.claude/plugins/installed_plugins.json` (Windows PowerShell). Do not pass an unexpanded `~` to file-reading tools — they will not expand it.
 - Find the entry where key starts with `onebrain@` and `scope == "project"` and `projectPath` matches the current vault
 - If not found: 🟡 "onebrain not found in installed_plugins.json — run /onboarding or /plugin to install"
-- If `installPath` is inside `~/.claude/plugins/cache/` (use `Path(installPath).relative_to(Path.home() / '.claude/plugins/cache')` or check if the path string contains `/.claude/plugins/cache/` — do not use simple `startswith` on unexpanded tilde): 🔴 "Plugin loading from user cache — run /doctor --fix to pin to vault"
-- If `installPath` is the vault plugin directory (ends with `.claude/plugins/onebrain`): ✅ "Plugin: vault-level"
+- Before any path comparison, normalize `installPath` separators with `installPath.replaceAll('\\', '/')` — Windows paths can mix backslashes and forward slashes, and substring matches against `'/.claude/plugins/cache/'` will silently fail otherwise.
+- If the normalized `installPath` contains `/.claude/plugins/cache/`: 🔴 "Plugin loading from user cache — run /doctor --fix to pin to vault"
+- If the normalized `installPath` ends with `.claude/plugins/onebrain`: ✅ "Plugin: vault-level"
 
 **INSTRUCTIONS.md:**
 - Check file exists at `.claude/plugins/onebrain/INSTRUCTIONS.md`
@@ -195,4 +196,4 @@ If `--fix` was run: also update `stats.last_doctor_fix: YYYY-MM-DD`.
 
 - **`--fix` is not transactional.** If Pass C is interrupted (user says "stop", or a file write fails), previously edited files are already changed but later files are not. Report each fixed file immediately as it completes so the user has a clear record of what was and was not changed if something interrupts.
 
-- **vault.yml with Windows line endings (CRLF).** If edited on Windows, YAML values may have a trailing `\r`. If a folder path existence check fails unexpectedly, strip trailing whitespace from vault.yml values before using them in file path operations.
+- **vault.yml with Windows line endings (CRLF).** If edited on Windows, YAML values may have a trailing `\r`. **Always** strip trailing whitespace from any vault.yml-derived path string (e.g. `value.replace(/\s+$/, '')` or equivalent) before passing it to file-existence checks, Glob, or Read — otherwise a folder named `00-inbox\r` will silently fail to match the on-disk `00-inbox/`. Apply this in Step 2 (folder existence) and any other step that reads a path out of vault.yml.

--- a/.claude/plugins/onebrain/skills/doctor/references/autofix-procedures.md
+++ b/.claude/plugins/onebrain/skills/doctor/references/autofix-procedures.md
@@ -9,9 +9,9 @@ Invoked by `/doctor --fix` flag only. Each pass confirms with the user before wr
 Fixes: Plugin `installPath` pointing to user cache instead of vault directory.
 Applies when: /doctor Config check shows 🔴 "Plugin loading from user cache"
 
-Run from vault root (pins to vault and clears cache in one step):
-```bash
-onebrain vault-sync "$PWD"
+Run from vault root (pins to vault and clears cache in one step). The CLI defaults the vault path to the current working directory; passing explicit `"$PWD"` is Bash-only and breaks on PowerShell/cmd:
+```
+onebrain vault-sync
 ```
 
 After running: Tell the user: "Start a new Claude Code session — the plugin will now load from the vault directory."

--- a/.claude/plugins/onebrain/skills/help/SKILL.md
+++ b/.claude/plugins/onebrain/skills/help/SKILL.md
@@ -11,10 +11,10 @@ When this skill is invoked, present all available OneBrain commands to the user.
 
 1. Determine install location: use Glob to check if `.claude/plugins/onebrain/.claude-plugin/plugin.json` exists relative to the vault root
    - If it exists → this is a **project plugin**
-   - If it does not exist → this is a **global plugin** (installed at `~/.claude/plugins/`)
+   - If it does not exist → this is a **global plugin** (installed at `$HOME/.claude/plugins/` on Unix or `$env:USERPROFILE/.claude/plugins/` on Windows PowerShell)
 2. Read the version from the correct path:
    - If project plugin: read from `.claude/plugins/onebrain/.claude-plugin/plugin.json`
-   - If global plugin: use Glob on `~/.claude/plugins/cache/onebrain/onebrain/*/.claude-plugin/plugin.json` to find all cached versions. If multiple matches are returned, use the one with the highest version number (compare the version directory name as semver). If no matches are found, skip the version display.
+   - If global plugin: use Glob on `$HOME/.claude/plugins/cache/onebrain/onebrain/*/.claude-plugin/plugin.json` (Unix) or `$env:USERPROFILE/.claude/plugins/cache/onebrain/onebrain/*/.claude-plugin/plugin.json` (Windows PowerShell) to find all cached versions. The Glob tool does not expand `~`, so use the env var that resolves to the user's home directory. If multiple matches are returned, use the one with the highest version number (compare the version directory name as semver). If no matches are found, skip the version display.
 3. Display as the first line of your response:
    - If project plugin: OneBrain v{version} (project plugin)
    - If global plugin: OneBrain v{version} (global plugin)

--- a/.claude/plugins/onebrain/skills/import/SKILL.md
+++ b/.claude/plugins/onebrain/skills/import/SKILL.md
@@ -197,10 +197,14 @@ When a stub note is created (extraction tool unavailable, extraction failed, emp
 If the Read tool, markitdown, or any extraction step returns an error or empty output: do NOT create a note. Return an error. Do NOT delete the inbox file.
 
 **4. File validation before processing.**
-Check file size with `ls -la "[filepath]"`. If 0 bytes: create a stub note ("File is empty : no content to extract."), do NOT delete inbox file, return.
+Check file size in bytes via Node (already required by the OneBrain CLI, so reliably on PATH). Pass the path via `process.argv` so Windows backslashes are not interpreted as escape sequences inside a string literal. The `catch` arm logs the errno code to stderr (visible in tool output) so EACCES / ENOTDIR / EISDIR / ENOENT are not collapsed into a single misleading "empty file" stub:
+```
+node -e "try { console.log(require('fs').statSync(process.argv[1]).size) } catch (e) { console.error(e.code || e.message); console.log(-1) }" -- "[filepath]"
+```
+If the output is `0`, create a stub note ("File is empty : no content to extract."), do NOT delete inbox file, return. If the output is `-1` (stat threw — read the stderr line for the errno code), the file is unreadable; create a stub note that names the actual error, and do not delete.
 
 **5. `--attach` directory creation.**
-Before every `cp`, run `mkdir -p` for the target directory. If `cp` fails: skip the embed, report the failure, do NOT delete inbox file, stop.
+Before every copy, ensure the target directory exists. Prefer Node (`node -e "require('fs').mkdirSync(process.argv[1], { recursive: true })" -- "<dir>"`) — it is portable across Bash/PowerShell/cmd. Native shell forms also work when the active shell is known (`mkdir -p` Bash, `New-Item -ItemType Directory -Force` PowerShell, `mkdir` cmd); **do not** call `mkdir -p` from PowerShell — its `mkdir` alias would create a literal directory named `-p`. If the subsequent copy fails: skip the embed, report the failure, do NOT delete inbox file, stop.
 
 **6. Filename collision.**
 Before writing a note, check if the target path already exists. If it does: append ` (Imported YYYY-MM-DD)` to the filename and note the rename in the summary.

--- a/.claude/plugins/onebrain/skills/import/references/image-handler.md
+++ b/.claude/plugins/onebrain/skills/import/references/image-handler.md
@@ -31,13 +31,17 @@ Note Template: see `note-template.md`.
 
 ## --attach behavior (all image types including SVG)
 
-- Run: `mkdir -p "[vault-root]/[attachments_folder]/images/"`
-- Run: `cp "[filepath]" "[vault-root]/[attachments_folder]/images/[filename]"`
-- If `cp` fails: skip embed, report failure, do NOT delete inbox file, stop
+- Ensure the directory `[vault-root]/[attachments_folder]/images/` exists. Most reliable across shells is Node (already on PATH because the CLI requires it):
+  ```
+  node -e "require('fs').mkdirSync(process.argv[1], { recursive: true })" -- "[vault-root]/[attachments_folder]/images/"
+  ```
+  Native shell forms also work if the active shell is known: `mkdir -p <dir>` on Bash, `New-Item -ItemType Directory -Force <dir>` on PowerShell, `mkdir <dir>` on cmd. **Do not** call `mkdir -p` from PowerShell — its `mkdir` function alias treats `-p` as a positional child name and creates a directory literally named `-p`.
+- Copy `[filepath]` to `[vault-root]/[attachments_folder]/images/[filename]`. Use `cp` on Bash, `Copy-Item` on PowerShell, `copy` on cmd.
+- If the copy fails: skip embed, report failure, do NOT delete inbox file, stop
 - Add `![[filename]]` embed above the Summary section in the note
 
 ## Cleanup
 
-Only after note creation succeeded AND (if `--attach` was set) `cp` succeeded. If `cp` failed, the handler already stopped; do not reach this step. If the file was inside the inbox folder: `rm "[filepath]"`. If delete fails, report as partial success.
+Only after note creation succeeded AND (if `--attach` was set) the copy succeeded. If the copy failed, the handler already stopped; do not reach this step. If the file was inside the inbox folder: remove `[filepath]` (`rm` on Bash, `Remove-Item` on PowerShell, `del` on cmd). If delete fails, report as partial success.
 
 **Return:** Note path, or error with reason.

--- a/.claude/plugins/onebrain/skills/import/references/markitdown-setup.md
+++ b/.claude/plugins/onebrain/skills/import/references/markitdown-setup.md
@@ -9,45 +9,44 @@ command -v markitdown
 ```
 
 Exit 0 → markitdown is installed. Proceed with the handler.
-Non-zero or command not found → run OS detection below before attempting install.
+Non-zero or command not found → proceed to Python check (no OS gate; markitdown installs and runs on macOS, Linux, WSL, and native Windows).
 
-## 2. OS Detection
+## 2. Python Check
 
-Run `uname`:
-- `Darwin` → proceed to Python check
-- `Linux` AND `uname -r` contains `microsoft` or `WSL` (WSL) → treat as Linux, proceed to Python check
-- `Linux` AND `uname -r` does NOT contain `microsoft` or `WSL` (native Linux) → proceed to Python check
-- Windows non-WSL: `$OS` equals `Windows_NT` AND uname fails or returns `MINGW`/`CYGWIN` →
-  create stub note:
-  > ⚠ Windows detected (non-WSL). /import requires WSL. Run this in a WSL terminal and retry.
-  Stop. Do NOT delete the inbox file.
-- `uname` not found: proceed to Python check (assume POSIX-compatible environment).
-
-## 3. Python Check
+Try in order — first one that succeeds wins:
 
 ```bash
-python3 --version
+python3 --version    # macOS / Linux / WSL
+python --version     # Windows default Python launcher (also works on Linux when symlinked)
+py -3 --version      # Windows Python launcher (always available since Python 3.6)
 ```
 
-Not found → create stub note:
+All three fail → create stub note:
 > ⚠ Python 3 is not installed. Install Python first:
 > - macOS: `brew install python3`
 > - Linux/WSL: `sudo apt install python3`
+> - Windows: install from https://www.python.org/downloads/ or the Microsoft Store
 >
 > Then run: `pipx install markitdown` and re-import this file.
 
 Stop. Do NOT delete the inbox file.
 
-## 4. Install
+Remember which command succeeded — use the matching `pipx`/`pip` form below.
 
-Try in order:
+## 3. Install
+
+Try `pipx` first (preferred — isolated environment):
+
 ```bash
-pipx install markitdown   # preferred (isolated environment)
+pipx install markitdown
 ```
-If `pipx` is not found:
+
+If `pipx` is not on PATH, fall back to `pip` matched to whichever Python detector succeeded above:
+
 ```bash
-pip3 install markitdown   # macOS/Linux/WSL
-pip install markitdown    # fallback if pip3 not in PATH
+pip3 install markitdown         # if `python3` succeeded
+pip install markitdown          # if `python` succeeded
+py -3 -m pip install markitdown # if `py -3` succeeded (Windows)
 ```
 
 Install succeeded → retry the handler from the beginning (markitdown is now available).

--- a/.claude/plugins/onebrain/skills/import/references/pdf-handler.md
+++ b/.claude/plugins/onebrain/skills/import/references/pdf-handler.md
@@ -27,13 +27,17 @@ Note Template: see `note-template.md`.
    - Key Points: bullet list of 3-7 main points from the document
 
 5. If `--attach` flag is set:
-   - Run: `mkdir -p "[vault-root]/[attachments_folder]/pdf/"`
-   - Run: `cp "[filepath]" "[vault-root]/[attachments_folder]/pdf/[filename]"`
-   - If `cp` fails: skip embed, report failure, do NOT delete inbox file, stop
+   - Ensure the directory `[vault-root]/[attachments_folder]/pdf/` exists. Prefer Node (portable across Bash/PowerShell/cmd):
+     ```
+     node -e "require('fs').mkdirSync(process.argv[1], { recursive: true })" -- "[vault-root]/[attachments_folder]/pdf/"
+     ```
+     Native shell forms also work if the active shell is known: `mkdir -p <dir>` on Bash, `New-Item -ItemType Directory -Force <dir>` on PowerShell, `mkdir <dir>` on cmd. **Do not** call `mkdir -p` from PowerShell.
+   - Copy `[filepath]` to `[vault-root]/[attachments_folder]/pdf/[filename]` (`cp` on Bash, `Copy-Item` on PowerShell, `copy` on cmd).
+   - If the copy fails: skip embed, report failure, do NOT delete inbox file, stop
    - Add `![[filename]]` embed to the note body (above the Summary section)
 
 6. Cleanup : only if step 4 (note creation) succeeded:
-   - If the file was inside the inbox folder: `rm "[filepath]"`
+   - If the file was inside the inbox folder: remove `[filepath]` (`rm` on Bash, `Remove-Item` on PowerShell, `del` on cmd)
    - If the file was an explicit path outside the inbox: do NOT delete it
    - If delete fails: report as partial success (note created, manual delete needed)
 

--- a/.claude/plugins/onebrain/skills/import/references/video-handler.md
+++ b/.claude/plugins/onebrain/skills/import/references/video-handler.md
@@ -6,7 +6,11 @@ Note Template: see `note-template.md`.
 
 1. Collect metadata:
    - Filename (without extension) → use as note title
-   - File size: `ls -lh "[filepath]"` via Bash : if the command fails, record size as "unknown"
+   - File size in bytes — call Node (already required by the OneBrain CLI, so reliably on PATH). Pass the path via `process.argv` so Windows backslashes are not interpreted as escape sequences inside a string literal. The `catch` arm logs the errno code to stderr (visible in tool output) so the agent can surface a real cause when the stat fails:
+     ```
+     node -e "try { console.log(require('fs').statSync(process.argv[1]).size) } catch (e) { console.error(e.code || e.message); console.log('unknown') }" -- "[filepath]"
+     ```
+     If stdout is `unknown`, record size as "unknown" and proceed (the stderr line tells the agent which errno fired, in case it's actionable).
    - File extension (format type: MP4, MOV, WebM, MKV)
 
 2. Choose output subfolder (suggest `media` or `video`; confirm with user in single-file mode, auto-select in batch mode). Create note using `note-template.md`:
@@ -15,11 +19,15 @@ Note Template: see `note-template.md`.
    - Key Points: left blank : add context about this video manually
 
 3. `--attach` behavior:
-   - Run: `mkdir -p "[vault-root]/[attachments_folder]/video/"`
-   - Run: `cp "[filepath]" "[vault-root]/[attachments_folder]/video/[filename]"`
-   - If `cp` fails: skip embed, report failure, do NOT delete inbox file, stop
+   - Ensure the directory `[vault-root]/[attachments_folder]/video/` exists. Prefer Node (portable across Bash/PowerShell/cmd):
+     ```
+     node -e "require('fs').mkdirSync(process.argv[1], { recursive: true })" -- "[vault-root]/[attachments_folder]/video/"
+     ```
+     Native shell forms also work if the active shell is known: `mkdir -p <dir>` on Bash, `New-Item -ItemType Directory -Force <dir>` on PowerShell, `mkdir <dir>` on cmd. **Do not** call `mkdir -p` from PowerShell.
+   - Copy `[filepath]` to `[vault-root]/[attachments_folder]/video/[filename]` (`cp` on Bash, `Copy-Item` on PowerShell, `copy` on cmd).
+   - If the copy fails: skip embed, report failure, do NOT delete inbox file, stop
    - Add `![[filename]]` embed above the Summary section
 
-4. Cleanup : only after note creation succeeded AND (if `--attach` was set) `cp` succeeded. If `cp` failed, the handler already stopped; do not reach this step. If the file was inside the inbox folder: `rm "[filepath]"`. If delete fails, report as partial success.
+4. Cleanup : only after note creation succeeded AND (if `--attach` was set) the copy succeeded. If the copy failed, the handler already stopped; do not reach this step. If the file was inside the inbox folder: remove `[filepath]` (`rm` on Bash, `Remove-Item` on PowerShell, `del` on cmd). If delete fails, report as partial success.
 
 5. Return: note path.

--- a/.claude/plugins/onebrain/skills/learn/SKILL.md
+++ b/.claude/plugins/onebrain/skills/learn/SKILL.md
@@ -124,11 +124,11 @@ Run minimum 3 independent review rounds before merging any PR.
 **How to apply:** After implementation is complete, dispatch 3 review sub-agents before running `gh pr create`.
 ```
 
-**Input:** "remember that the OneBrain source repo is at ~/projects/onebrain"
+**Input:** "remember that the OneBrain source repo is at $HOME/projects/onebrain"
 
 **Good output (context memory file — minimal one-liner body):**
 ```
-OneBrain source repo is at ~/projects/onebrain.
+OneBrain source repo is at $HOME/projects/onebrain (use `$env:USERPROFILE` on Windows PowerShell).
 ```
 
 (Simple factual memories do not need **Why:** / **How to apply:** structure — use it only when the rule needs reasoning to be applied correctly in edge cases.)

--- a/.claude/plugins/onebrain/skills/moc/SKILL.md
+++ b/.claude/plugins/onebrain/skills/moc/SKILL.md
@@ -182,9 +182,13 @@ PINNED_CONTENT
 
 ## Step 5: Open in Obsidian and confirm
 
+The shipped helper detects platform and emits the right URI (cygpath, percent-encoding, etc.). On macOS/Linux/MSYS just run it via Bash:
+
 ```bash
 bash ".claude/plugins/onebrain/startup/scripts/open-in-obsidian.sh" "MOC.md"
 ```
+
+In a PowerShell-only environment where `bash` is not on PATH, the helper still runs because Git for Windows / WSL ships `bash.exe` on PATH alongside Obsidian on Windows; if it genuinely is not present, skip the open step (the file is already saved) rather than constructing a URI by hand — manual URI assembly is exactly the pattern the helper exists to replace.
 
 Then say:
 🗺️ MOC.md updated.

--- a/.claude/plugins/onebrain/skills/onboarding/SKILL.md
+++ b/.claude/plugins/onebrain/skills/onboarding/SKILL.md
@@ -275,9 +275,9 @@ Before any user interaction, copy plugin files from the global cache into the va
 
 **1. Locate the cache directory:**
 
-Check both paths : both may exist depending on when the plugin was installed:
-- `~/.claude/plugins/cache/onebrain/onebrain/` : installs after marketplace rename
-- `~/.claude/plugins/cache/onebrain-local/onebrain/` : legacy installs before rename
+Check both paths : both may exist depending on when the plugin was installed. The Glob tool does not expand `~`, so resolve the user's home with `$HOME` (Unix / Bash / MSYS) or `$env:USERPROFILE` (Windows PowerShell) before globbing:
+- `$HOME/.claude/plugins/cache/onebrain/onebrain/` : installs after marketplace rename
+- `$HOME/.claude/plugins/cache/onebrain-local/onebrain/` : legacy installs before rename
 
 Collect all version subdirectories from both paths into a single combined list. If neither path exists or neither contains any version subdirectories, tell the user:
 > OneBrain plugin cache not found. Run `/plugin install onebrain@onebrain` to install it, then try `/onboarding` again.
@@ -324,10 +324,10 @@ From this point, the project-level copy takes priority over the global cache.
 
 **Pin to vault (run after Step 0 file copy):**
 
-Run from vault root:
+Run from vault root (the CLI defaults the vault path to the current working directory; explicit `"$PWD"` is Bash-only and breaks on PowerShell/cmd):
 
-```bash
-onebrain vault-sync "$PWD"
+```
+onebrain vault-sync
 ```
 
 This pins the plugin to the vault directory and clears the plugin cache in one step. Tell the user: "Start a new Claude Code session — the plugin will now load from the vault directory."

--- a/.claude/plugins/onebrain/skills/qmd/SKILL.md
+++ b/.claude/plugins/onebrain/skills/qmd/SKILL.md
@@ -62,8 +62,17 @@ After installation, verify with `which qmd` (macOS/Linux) or `where qmd` (Window
 
 ### Step 4: Generate collection name
 
-1. Get vault root directory name: `basename "$CLAUDE_PROJECT_DIR"`
-2. Generate a 6-character random hex string: try `openssl rand -hex 3` first; if that fails, try `python3 -c "import secrets; print(secrets.token_hex(3))"`. If both fail, tell the user "Could not generate a unique collection name. Please run `/qmd setup` again." and stop.
+`node` is reliably on PATH because the OneBrain CLI requires it — calling `node -e "…"` works without per-platform branching from Bash, PowerShell, and Git Bash. (Native cmd.exe needs care: `%VAR%` is still expanded inside double quotes, so a vault path containing a literal `%` will be substituted away. If the active shell is cmd, run the command through `bash -c` or PowerShell instead.)
+
+1. Get vault root directory name (replaces `basename`, which is not available on Windows):
+   ```
+   node -e "console.log(require('path').basename(process.cwd()))"
+   ```
+2. Generate a 6-character random hex string (replaces `openssl rand -hex 3` and `python3 -c …secrets.token_hex…`, neither of which is on default Windows PATH):
+   ```
+   node -e "console.log(require('crypto').randomBytes(3).toString('hex'))"
+   ```
+   If `node` itself cannot be invoked (rare — would mean the CLI is not actually installed), tell the user "Could not generate a unique collection name. Please run `/qmd setup` again." and stop.
 3. Collection name = `<vault-dirname>-<hex>` (e.g., `onebrain-a3f2c1`)
 
 ### Step 5: Create the qmd collection
@@ -142,7 +151,7 @@ Read vault.yml. If `qmd_collection` key is missing:
 
 Stop.
 
-Check `which qmd`. If not found:
+Check that `qmd` is on PATH (`which qmd` on Bash, `where qmd` on cmd, `Get-Command qmd` on PowerShell). If not found:
 > qmd is not installed. Run `/qmd setup` to install and configure it.
 
 Stop.
@@ -188,7 +197,7 @@ Read vault.yml for `qmd_collection`. If missing:
 
 Stop.
 
-Check `which qmd`. If not found:
+Check that `qmd` is on PATH (`which qmd` on Bash, `where qmd` on cmd, `Get-Command qmd` on PowerShell). If not found:
 🔴 qmd binary not found — run /qmd setup to reinstall.
 
 Stop.
@@ -215,7 +224,7 @@ Read vault.yml for `qmd_collection`. If missing:
 
 Stop.
 
-Check `which qmd`. If not found:
+Check that `qmd` is on PATH (`which qmd` on Bash, `where qmd` on cmd, `Get-Command qmd` on PowerShell). If not found:
 > qmd is not installed. Run `/qmd setup` to install and configure it.
 
 Stop.

--- a/.claude/plugins/onebrain/skills/reading-notes/SKILL.md
+++ b/.claude/plugins/onebrain/skills/reading-notes/SKILL.md
@@ -64,7 +64,7 @@ From the raw input, extract:
 
 ## Step 5: Create the Note
 
-File: `[resources_folder]/[subfolder]/[Book Title] : Notes.md` (subfolder confirmed in Step 4)
+File: `[resources_folder]/[subfolder]/[Book Title] - Notes.md` (subfolder confirmed in Step 4)
 
 ```markdown
 ---
@@ -141,7 +141,7 @@ After writing, dispatch the **Tag Suggester** agent (`agents/tag-suggester.md`) 
 📚 Reading Notes — {Title}
 ──────────────────────────────────────────────────────────────
 Author: {Author}
-Saved to `[resources_folder]/[subfolder]/[Title] : Notes.md`
+Saved to `[resources_folder]/[subfolder]/[Title] - Notes.md`
 
 → Add to a reading list in a project note?
 → Run /connect to find related vault notes.
@@ -153,4 +153,3 @@ Saved to `[resources_folder]/[subfolder]/[Title] : Notes.md`
 
 - **Input option (b) — describing from memory — is the hardest path.** Users often conflate the author's ideas with their own take. Ask separate questions: "What was the book's main argument?" and "What did YOU conclude or take away?" to separate source material from personal synthesis.
 
-- **Filename colon on Windows.** The file template uses `[Book Title] : Notes.md` with a colon, which is invalid on Windows filesystems. If vault is on Windows or synced via a Windows-incompatible path, replace ` : ` with ` - ` in the filename.

--- a/.claude/plugins/onebrain/skills/reorganize/SKILL.md
+++ b/.claude/plugins/onebrain/skills/reorganize/SKILL.md
@@ -138,8 +138,8 @@ Wait for response. Apply any requested adjustments before proceeding.
 
 For each approved move:
 
-1. Create the subfolder if it doesn't exist (use `mkdir -p [target_folder]/[subfolder]`)
-2. Move the file: `mv "[source_path]" "[target_path]"`
+1. Ensure the target subfolder exists (`[target_folder]/[subfolder]`). Most portable: `node -e "require('fs').mkdirSync(process.argv[1], { recursive: true })" -- "[target_folder]/[subfolder]"`. Native shell forms also work: `mkdir -p` (Bash), `New-Item -ItemType Directory -Force` (PowerShell — **never** `mkdir -p` here), `mkdir` (cmd). Existing-directory errors are non-fatal.
+2. Move the file from `[source_path]` to `[target_path]`. Use `mv` on Bash, `Move-Item` on PowerShell, `move` on cmd.
 3. Confirm each move silently; report errors immediately
 
 Process notes by folder (all knowledge, then resources, then areas, then projects, then logs, then archive).

--- a/.claude/plugins/onebrain/skills/tasks/SKILL.md
+++ b/.claude/plugins/onebrain/skills/tasks/SKILL.md
@@ -141,9 +141,13 @@ Do not proceed to Step 3 if the write failed.
 
 ## Step 3: Open in Obsidian and confirm
 
+The shipped helper detects platform and emits the right URI (cygpath, percent-encoding, etc.). On macOS/Linux/MSYS just run it via Bash:
+
 ```bash
 bash ".claude/plugins/onebrain/startup/scripts/open-in-obsidian.sh" "TASKS.md"
 ```
+
+In a PowerShell-only environment where `bash` is not on PATH, the helper still runs because Git for Windows / WSL ships `bash.exe` on PATH alongside Obsidian on Windows; if it genuinely is not present, skip the open step (the file is already saved) rather than constructing a URI by hand — manual URI assembly is exactly the pattern the helper exists to replace.
 
 Then say:
 📋 TASKS.md updated.

--- a/.claude/plugins/onebrain/skills/update/SKILL.md
+++ b/.claude/plugins/onebrain/skills/update/SKILL.md
@@ -53,7 +53,22 @@ After confirming the vault update (step 7 above), also check if the installed `o
 2. Fetch latest from npm: `npm view @onebrain-ai/cli version 2>/dev/null` → parse version string. If npm unavailable or fetch fails → skip.
 3. If installed = latest → skip (no output needed).
 4. If newer version available:
-   a. Detect available package managers: `which bun 2>/dev/null` and `which npm 2>/dev/null`
+   a. Detect available package managers. Use the form matching the active shell — PowerShell 5.1 (Win10/Server 2019 default) does not parse `||` as a control operator, so do not chain `which || where` in a single command:
+      - **Bash / zsh / Git Bash:**
+        ```bash
+        which bun 2>/dev/null
+        which npm 2>/dev/null
+        ```
+      - **PowerShell:** `Get-Command` always exits 0 — interpret presence by whether the command emitted a `CommandInfo` line (non-empty stdout) rather than by exit code:
+        ```powershell
+        Get-Command bun -ErrorAction SilentlyContinue
+        Get-Command npm -ErrorAction SilentlyContinue
+        ```
+      - **cmd:**
+        ```
+        where bun 2>nul
+        where npm 2>nul
+        ```
    b. AskUserQuestion: "Update onebrain CLI from v{installed} to v{latest}?"
       - Both bun and npm available: options `npm / bun / skip` (npm as default)
       - Only bun: options `bun / skip`
@@ -87,7 +102,7 @@ Steps:
    a. Pre-migration backup: copy `[agent_folder]/MEMORY.md` → `[archive_folder]/05-agent/MEMORY-YYYY-MM-DD.md`
       and `[agent_folder]/context/` → `[archive_folder]/05-agent/context.YYYY-MM-DD/` (if context/ exists)
    b. Sync remaining files — run these two sub-steps in parallel, then clean cache after both complete:
-      - **Full vault sync:** run `onebrain vault-sync "$PWD" --branch {branch}`. Downloads the full GitHub tarball, syncs plugin folder (with stale file cleanup), copies README.md/CONTRIBUTING.md/CHANGELOG.md/PLUGIN-CHANGELOG.md to vault root (overwrite), merges CLAUDE.md/GEMINI.md/AGENTS.md (vault is primary; injects new repo `@` imports only), pins plugin to vault, and clears plugin cache.
+      - **Full vault sync:** run `onebrain vault-sync --branch {branch}` (the CLI defaults the vault root to the current working directory; explicit `"$PWD"` was Bash-only and broke on PowerShell/cmd). Downloads the full GitHub tarball, syncs plugin folder (with stale file cleanup), copies README.md/CONTRIBUTING.md/CHANGELOG.md/PLUGIN-CHANGELOG.md to vault root (overwrite), merges CLAUDE.md/GEMINI.md/AGENTS.md (vault is primary; injects new repo `@` imports only), pins plugin to vault, and clears plugin cache.
       - **Settings merge:** WebFetch `https://raw.githubusercontent.com/onebrain-ai/onebrain/{branch}/.claude/settings.json`, then merge into `[vault]/.claude/settings.json`. Merge strategy (never overwrite, always additive): `permissions.allow` → union; `enabledPlugins` → merge keys (skip any `onebrain@*` key whose marketplace points to a `directory` source — repo-dev-only, not valid in vault context); `extraKnownMarketplaces` → skip (repo-dev-only config, not valid in vault context); `hooks` → skip (handled by migration Step 6).
    c. Once all step 3b sub-steps are complete, load `[vault]/.claude/plugins/onebrain/skills/update/references/migration-steps.md` and run all 8 migration steps
    d. Bump `plugin.json` version to `{new}` (last — completion signal; do not bump early)

--- a/.claude/plugins/onebrain/startup/scripts/open-in-obsidian.sh
+++ b/.claude/plugins/onebrain/startup/scripts/open-in-obsidian.sh
@@ -8,9 +8,52 @@
 # Example: bash "...open-in-obsidian.sh" "TASKS.md"
 
 [ -z "$1" ] && exit 1
-vault_path=$(cd "${CLAUDE_PROJECT_DIR:-.}" && pwd)
-uri="obsidian://open?path=${vault_path}/${1}"
-case "$(uname -s 2>/dev/null)" in
+
+uname_s="$(uname -s 2>/dev/null)"
+
+# On MINGW/CYGWIN/MSYS, `pwd` returns a POSIX path like `/c/Users/...` which
+# Windows Obsidian rejects. `cygpath -m` returns the mixed form `C:/Users/...`,
+# which the Obsidian URI handler accepts. See issue #130.
+case "$uname_s" in
+  MINGW*|CYGWIN*|MSYS*)
+    if command -v cygpath >/dev/null 2>&1; then
+      vault_path=$(cygpath -m "${CLAUDE_PROJECT_DIR:-.}")
+    else
+      vault_path=$(cd "${CLAUDE_PROJECT_DIR:-.}" && pwd)
+    fi
+    ;;
+  *)
+    vault_path=$(cd "${CLAUDE_PROJECT_DIR:-.}" && pwd)
+    ;;
+esac
+
+# URL-encode via Node — handles UTF-8 (CJK / accented vault names) correctly.
+# A bash byte-loop encoder would either drop continuation bytes (UTF-8 locale)
+# or sign-extend them to 16-hex (C locale); see #130 round-1 review. Node is
+# guaranteed present because OneBrain's CLI requires it.
+_node_encode() {
+  node -e 'process.stdout.write(encodeURIComponent(process.argv[1]))' -- "$1" 2>/dev/null
+}
+
+encoded_vault="$(_node_encode "$vault_path")"
+encoded_file="$(_node_encode "$1")"
+
+# If Node is missing, abort loudly. Falling back to a raw, un-encoded URI
+# would silently truncate the vault path at the first `&`/`?`/`#`/space and
+# launch Obsidian against the wrong vault — exactly the silent-failure mode
+# the encoder exists to prevent (#130).
+if [ -z "$encoded_vault" ] || [ -z "$encoded_file" ]; then
+  printf 'open-in-obsidian: node required for URI encoding; aborting launch\n' >&2
+  exit 1
+fi
+
+# encodeURIComponent escapes the path separators (`/` → `%2F`); Obsidian's URI
+# handler decodes them back. The vault path and the file path are joined with
+# a literal `/` between the two encoded segments — Obsidian then sees a
+# correctly-formed `path=` value after URL decoding.
+uri="obsidian://open?path=${encoded_vault}%2F${encoded_file}"
+
+case "$uname_s" in
   Darwin)             open "$uri" 2>/dev/null || true ;;
   Linux)              xdg-open "$uri" 2>/dev/null || true ;;
   CYGWIN*|MINGW*|MSYS*) cmd.exe /c start "" "$uri" 2>/dev/null || true ;;

--- a/PLUGIN-CHANGELOG.md
+++ b/PLUGIN-CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-latest_version: 2.2.4
+latest_version: 2.2.5
 released: 2026-05-06
 ---
 
@@ -12,6 +12,19 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 > For CLI binary changes, see [CHANGELOG.md](CHANGELOG.md).
 
 ## [Unreleased]
+
+## v2.2.5 — fix: Windows skill + script compat (PowerShell / cmd / native Python)
+
+Audit pass over every skill snippet that assumed Bash / Unix-only tooling. Closes #128, #129, #130.
+
+- fix(open-in-obsidian.sh): use `cygpath -m` on MINGW/CYGWIN/MSYS to emit `C:/...` paths Obsidian accepts; percent-encode the URI so spaces and `#`/`&`/`?` in vault paths or filenames no longer truncate the launch (#130)
+- fix(reading-notes): default filename template uses ` - ` instead of ` : ` so notes save on NTFS without truncation; gotcha note removed (#130)
+- fix(import/markitdown-setup): drop the WSL-only gate on Windows; detect `python3` / `python` / `py -3` (and matching `pip` / `py -3 -m pip`) so native Windows installs can install markitdown (#128)
+- fix(qmd setup): replace `openssl rand -hex 3` / `python3 -c …` with `node -e "…randomBytes(3)…"`; `basename` swapped for a Node one-liner — Node is portable and already required by the CLI (#128)
+- fix(skills): cross-platform shell guidance — `which X || where X` for package detection; describe outcome (mkdir / mv / cp / rm / ls) so the model picks the shell-native form on PowerShell/cmd; drop `"$PWD"` from `onebrain vault-sync` (CLI defaults to cwd) (#129)
+- fix(INSTRUCTIONS startup): replace `LC_ALL=en_US.UTF-8 grep -r …` with the Grep tool — UTF-8 handling is platform-correct and PowerShell can dispatch it (#129)
+- fix(doctor SKILL): always strip trailing whitespace from vault.yml-derived paths (CRLF on Windows); normalize `installPath` separators before substring checks against the cache dir (#129)
+- fix(skills/help, /onboarding, /learn): use `$HOME` / `$env:USERPROFILE` instead of the literal `~` for Glob/Read calls — the Glob tool does not expand tildes (#129)
 
 ## v2.2.4 — feat(update): backfill vault-side config drift after migration
 


### PR DESCRIPTION
Closes #128, #129, #130.

Audit pass over every skill snippet that assumed Bash / Unix-only tooling, plus two shipped artifacts (\`open-in-obsidian.sh\` and the \`reading-notes\` filename template) that produced output Windows itself refuses to accept. Plugin-only PR — CLI source unchanged.

## #130 — shipped artifacts

- \`open-in-obsidian.sh\`: use \`cygpath -m\` on MINGW/CYGWIN/MSYS so Windows Obsidian receives \`C:/Users/...\` instead of \`/c/Users/...\`; URL-encode the URI through Node so spaces and \`#\`/\`&\`/\`?\` no longer truncate the launch (and UTF-8/CJK paths encode correctly — a bash byte-loop would either drop continuation bytes or sign-extend to 16-hex). When Node is missing, abort loudly (\`exit 1\`) rather than fall back to the un-encoded form, which would silently launch the wrong vault.
- \`reading-notes\`: default filename uses \` - \` instead of \` : \` so notes save on NTFS without truncation. Old "swap on Windows" gotcha removed.

## #128 — native Windows Python

- \`markitdown-setup\`: drop the WSL-only gate; detect \`python3\` / \`python\` / \`py -3\` and the matching pip variant.
- \`qmd setup\`: replace \`openssl rand -hex 3\` and \`python3 secrets.token_hex\` with \`node -e "…randomBytes(3)…"\`, and \`basename\` with a Node one-liner. Node is on PATH because the OneBrain CLI requires it.

## #129 — cross-shell skill prose

- \`update\`: split \`which X || where X\` into separate Bash / PowerShell (\`Get-Command -ErrorAction SilentlyContinue\`) / cmd snippets — PS 5.1 does not parse \`||\` and treats \`2>/dev/null\` as a redirect to literal file \`/dev/null\`.
- import + reorganize: primary mkdir form is now \`node -e "…mkdirSync(…,{recursive:true})…"\`. Explicit "do NOT \`mkdir -p\` from PowerShell" — its alias creates a literal \`-p\` directory.
- file-size checks: \`node -e "try { …statSync(process.argv[1]).size… } catch(e){ console.error(e.code); console.log(-1) }" -- "[filepath]"\`. Pass via \`process.argv\` so Windows backslashes do not become escape sequences. Catch logs errno so EACCES vs ENOTDIR vs ENOENT do not collapse into a single misleading "empty file" stub.
- INSTRUCTIONS startup: replace \`LC_ALL=en_US.UTF-8 grep -r …\` with two Grep tool calls.
- doctor SKILL: directive to strip trailing whitespace from vault.yml-derived paths (CRLF on Windows). Normalize \`installPath\` separators before cache-substring match.
- help / onboarding / learn / doctor: replace literal \`~\` with \`\$HOME\` / \`\$env:USERPROFILE\` (Glob tool does not expand tildes).
- tasks / moc: drop the broken inline \`pwsh\` fallback — manual URI assembly is what the shipped helper exists to replace.
- qmd: document the cmd.exe \`%VAR%\` expansion gotcha (paths containing \`%\` must be invoked via \`bash -c\` or PowerShell, not native cmd).

## Verification

- 306 tests pass / 0 fail
- \`bun run typecheck\` clean
- \`bash -n open-in-obsidian.sh\` syntax OK
- Local smoke test of the new Node encoder against a Thai vault path verified correct UTF-8 output (no byte-loop corruption)
- 3 review rounds (code-reviewer × 3, silent-failure-hunter × 2, comment-analyzer)

## Out of scope (deferred)

- vault.yml CRLF strip in \`loadVaultConfig\` / \`session-init\` — should be a CLI fix so every consumer sees clean values without each skill re-stripping. Tracked as a follow-up.