### PR TITLE
test(cli-banner): smoke tests for static-banner exit paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-latest_version: 2.1.15
+latest_version: 2.1.16
 released: 2026-05-06
 ---
 
@@ -12,6 +12,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 > For plugin changes (skills, agents, hooks, INSTRUCTIONS), see [PLUGIN-CHANGELOG.md](PLUGIN-CHANGELOG.md).
 
 ## [Unreleased]
+
+## v2.1.16 — test(cli-banner): smoke tests for static-banner exit paths
+
+- test(cli-banner): assert `printBanner()` resolves under 250ms in both non-TTY and TTY-without-truecolor modes — guards both early-return branches against regressions where animation accidentally runs in CI/piped/16-color contexts
 
 ## v2.1.15 — fix(vault-sync, register-hooks): Windows + iCloud reliability
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onebrain-ai/cli",
-  "version": "2.1.15",
+  "version": "2.1.16",
   "description": "CLI for OneBrain — personal AI OS for Obsidian with persistent memory, 24+ skills, and Claude Code integration",
   "keywords": [
     "onebrain",

--- a/src/commands/internal/cli-banner.test.ts
+++ b/src/commands/internal/cli-banner.test.ts
@@ -109,6 +109,19 @@ describe('printBanner — non-TTY (piped/CI) static path', () => {
     const unique = new Set(matches);
     expect(unique.size).toBeGreaterThan(5);
   });
+
+  it('exit path resolves promptly without hanging on animation timers', async () => {
+    // Animated path runs ≥3 × SENTENCE_HOLD_MS plus intro and lock-shimmer
+    // delays — easily >1s. Static exit path has no awaits and must return
+    // well under that. A regression where isInteractiveStdout() wrongly
+    // reports true (or the early return is removed) would make this hang.
+    // 250ms threshold leaves ~4× headroom over the regression signal while
+    // tolerating cold-CI variance.
+    const start = performance.now();
+    await expect(printBanner()).resolves.toBeUndefined();
+    const elapsed = performance.now() - start;
+    expect(elapsed).toBeLessThan(250);
+  });
 });
 
 describe('printBanner — TTY without truecolor (16-color static fallback)', () => {
@@ -149,6 +162,16 @@ describe('printBanner — TTY without truecolor (16-color static fallback)', () 
     const all = spy.chunks.join('');
     expect(all).not.toContain('\x1b[?25l');
     expect(all).not.toContain('\x1b[?25h');
+  });
+
+  it('exit path resolves promptly without hanging on animation timers', async () => {
+    // Symmetric to the non-TTY suite's exit-path guard. Both `!isInteractiveStdout()`
+    // and `!supportsRgb()` independently route to the static path; this asserts the
+    // !supportsRgb() branch (isTTY=true, no COLORTERM) also bails out fast.
+    const start = performance.now();
+    await expect(printBanner()).resolves.toBeUndefined();
+    const elapsed = performance.now() - start;
+    expect(elapsed).toBeLessThan(250);
   });
 });
 


### PR DESCRIPTION
## Summary

- Adds smoke tests for both static-banner exit paths in `printBanner()` — non-TTY (piped/CI) and TTY-without-truecolor (16-color) — asserting the function resolves under 250ms.
- Animated path runs >1s via `SENTENCE_HOLD_MS` + `lockShimmer` cycles; the early-return path has no awaits and must bail out fast. Existing tests verified output shape only — these tests guard the timing/control-flow contract.
- Closes the Reviewer 3 nit (non-blocking) from prior cli-banner work.

## Why two tests?

Both `!isInteractiveStdout()` and `!supportsRgb()` independently route to `printStaticBanner()`. A regression on either gate would not be caught by a test that only exercises one. Symmetric assertions in both describe blocks close that gap.

## Test plan

- [x] `bun test src/commands/internal/cli-banner.test.ts` — 19/19 pass
- [x] `bun test` (full suite) — 308/308 pass
- [x] `bun run typecheck` — clean
- [x] `bunx biome check` — clean
- [x] 3-round parallel review (logic / conventions / test coverage) — consensus fixes applied: added 16-color branch test + bumped threshold 100ms → 250ms for cold-CI variance

## Version

CLI patch bump: 2.1.15 → 2.1.16. Plugin track untouched.