### PR TITLE
refactor(diagrams): gradient-fill memory + harness; port dark variants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@ Thumbs.db
 # ── Internal tooling ──────────────────────────────────────────────────────────
 .superpowers/
 docs/superpowers/
+# Local diagram preview harness (one-off audit tool, not for repo)
+preview.html
 
 # ── Node / Bun ────────────────────────────────────────────────────────────────
 node_modules/

--- a/assets/diagrams/bidir-flow-dark.svg
+++ b/assets/diagrams/bidir-flow-dark.svg
@@ -3,34 +3,30 @@
   <desc id="desc">Two circles connected by curved arrows. Human (left, cyan) sends preferences, decisions, and corrections to Agent (right, pink). Agent returns captures, links, and synthesis. Each interaction sharpens both.</desc>
 
   <style>
-    .text-strong { fill: #ffffff; }
-    .text-soft   { fill: rgba(255,255,255,0.78); }
-    .text-fade   { fill: rgba(255,255,255,0.50); }
-    .text-mute   { fill: rgba(255,255,255,0.35); }
-    .frame-corner { stroke: rgba(255,255,255,0.22); }
-    .grid-line    { stroke: rgba(255,255,255,0.06); }
-    .divider      { stroke: rgba(255,255,255,0.10); }
+    .text-strong { fill: #0a0a14; }
+    .text-soft   { fill: rgba(10,10,20,0.82); }
+    .text-fade   { fill: rgba(10,10,20,0.55); }
+    .text-mute   { fill: rgba(10,10,20,0.38); }
+    .frame-corner { stroke: rgba(10,10,20,0.40); }
+    .grid-line    { stroke: rgba(10,10,20,0.07); }
+    .divider      { stroke: rgba(10,10,20,0.18); }
 
     .arc-down   { animation: arc-pulse 5s linear infinite; }
     .arc-up     { animation: arc-pulse 5s linear infinite; animation-delay: 2.5s; }
     @keyframes arc-pulse {
-      0%, 35%, 100% { opacity: 0.5; }
+      0%, 35%, 100% { opacity: 0.55; }
       8%            { opacity: 1; }
     }
 
-    .core-h { animation: core-h-breathe 6s ease-in-out infinite; transform-origin: 0 0; }
-    .core-a { animation: core-a-breathe 6s ease-in-out infinite; animation-delay: 3s; transform-origin: 0 0; }
-    @keyframes core-h-breathe {
-      0%, 100% { stroke-width: 1.5; stroke-opacity: 0.65; }
-      50%      { stroke-width: 2.5; stroke-opacity: 1.0; }
-    }
-    @keyframes core-a-breathe {
-      0%, 100% { stroke-width: 1.5; stroke-opacity: 0.65; }
-      50%      { stroke-width: 2.5; stroke-opacity: 1.0; }
+    .core-h { animation: core-breathe 6s ease-in-out infinite; transform-origin: center; transform-box: fill-box; }
+    .core-a { animation: core-breathe 6s ease-in-out infinite; animation-delay: 3s; transform-origin: center; transform-box: fill-box; }
+    @keyframes core-breathe {
+      0%, 100% { transform: scale(1); }
+      50%      { transform: scale(1.04); }
     }
 
     @media (prefers-reduced-motion: reduce) {
-      .arc-down, .arc-up, .core-h, .core-a { animation: none; opacity: 0.7; }
+      .arc-down, .arc-up, .core-h, .core-a { animation: none; opacity: 1; }
     }
   </style>
 
@@ -39,33 +35,89 @@
       <path d="M 40 0 L 0 0 0 40" fill="none" class="grid-line" stroke-width="0.5"/>
     </pattern>
     <marker id="ah-pink" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
-      <path d="M 0 0 L 10 5 L 0 10 z" fill="#ff2d92"/>
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#dc1c89"/>
     </marker>
     <marker id="ah-cyan" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
-      <path d="M 0 0 L 10 5 L 0 10 z" fill="#00f3ff"/>
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#00a3bc"/>
     </marker>
+    <radialGradient id="g-human-fill" cx="0.32" cy="0.32" r="0.85">
+      <stop offset="0%"   stop-color="#00b8d4" stop-opacity="1"/>
+      <stop offset="100%" stop-color="#00a3bc" stop-opacity="1"/>
+    </radialGradient>
+    <radialGradient id="g-agent-fill" cx="0.32" cy="0.32" r="0.85">
+      <stop offset="0%"   stop-color="#ed3da0" stop-opacity="1"/>
+      <stop offset="100%" stop-color="#dc1c89" stop-opacity="1"/>
+    </radialGradient>
   </defs>
 
+  <!-- HUMAN core (left) -->
   <g transform="translate(180,158)">
-    <circle class="core-h" cx="0" cy="0" r="48" fill="rgba(2,2,4,0.92)" stroke="#00f3ff"/>
-    <text x="0" y="-2" text-anchor="middle" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="20" letter-spacing="0.06em" class="text-strong">HUMAN</text>
-    <text x="0" y="16" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-size="9" letter-spacing="0.32em" fill="#00f3ff">YOU</text>
+    <circle class="core-h" cx="0" cy="0" r="48" fill="url(#g-human-fill)"/>
+    <text x="0" y="-2" text-anchor="middle" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="20" letter-spacing="0.06em" fill="#ffffff">HUMAN</text>
+    <text x="0" y="16" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-size="9" letter-spacing="0.32em" fill="rgba(255,255,255,0.85)">YOU</text>
   </g>
 
+  <!-- AGENT core (right) -->
   <g transform="translate(540,158)">
-    <circle class="core-a" cx="0" cy="0" r="48" fill="rgba(2,2,4,0.92)" stroke="#ff2d92"/>
-    <text x="0" y="-2" text-anchor="middle" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="20" letter-spacing="0.06em" class="text-strong">AGENT</text>
-    <text x="0" y="16" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-size="9" letter-spacing="0.32em" fill="#ff2d92">ONEBRAIN</text>
+    <circle class="core-a" cx="0" cy="0" r="48" fill="url(#g-agent-fill)"/>
+    <text x="0" y="-2" text-anchor="middle" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="20" letter-spacing="0.06em" fill="#ffffff">AGENT</text>
+    <text x="0" y="16" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-size="9" letter-spacing="0.32em" fill="rgba(255,255,255,0.85)">ONEBRAIN</text>
   </g>
 
+  <!-- Top arc: HUMAN → AGENT -->
   <g class="arc-down">
-    <path d="M 224 130 Q 360 70 496 130" fill="none" stroke="#ff2d92" stroke-width="1.4" marker-end="url(#ah-pink)"/>
-    <text x="360" y="78" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-size="10" letter-spacing="0.25em" class="text-soft">PREFERENCES · DECISIONS · CORRECTIONS</text>
+    <path d="M 224 130 Q 360 70 496 130" fill="none" stroke="#dc1c89" stroke-width="1.6" marker-end="url(#ah-pink)"/>
+    <text x="360" y="78" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-size="10" font-weight="600" letter-spacing="0.25em" fill="#dc1c89">PREFERENCES · DECISIONS · CORRECTIONS</text>
   </g>
 
+  <!-- Bottom arc: AGENT → HUMAN -->
   <g class="arc-up">
-    <path d="M 496 186 Q 360 246 224 186" fill="none" stroke="#00f3ff" stroke-width="1.4" marker-end="url(#ah-cyan)"/>
-    <text x="360" y="244" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-size="10" letter-spacing="0.25em" class="text-soft">CAPTURES · LINKS · SYNTHESIS</text>
+    <path d="M 496 186 Q 360 246 224 186" fill="none" stroke="#00a3bc" stroke-width="1.6" marker-end="url(#ah-cyan)"/>
+    <text x="360" y="244" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-size="10" font-weight="600" letter-spacing="0.25em" fill="#00a3bc">CAPTURES · LINKS · SYNTHESIS</text>
+  </g>
+
+  <!-- Motion layer: particles + arrival rings, all on dur=3.6s cycle.
+       keyTimes 0.92 = particle reaches node, 0.95 = ring peak (sync). -->
+  <g class="motion-layer">
+    <!-- Top arc particles (HUMAN → AGENT) -->
+    <circle r="4" fill="#dc1c89" opacity="0">
+      <animateMotion dur="3.6s" repeatCount="indefinite" path="M 224 130 Q 360 70 496 130"/>
+      <animate attributeName="opacity" values="0;1;1;0;0" keyTimes="0;0.05;0.9;0.95;1" dur="3.6s" repeatCount="indefinite"/>
+    </circle>
+    <circle r="4" fill="#dc1c89" opacity="0">
+      <animateMotion dur="3.6s" begin="1.8s" repeatCount="indefinite" path="M 224 130 Q 360 70 496 130"/>
+      <animate attributeName="opacity" values="0;1;1;0;0" keyTimes="0;0.05;0.9;0.95;1" dur="3.6s" begin="1.8s" repeatCount="indefinite"/>
+    </circle>
+    <!-- Ring on AGENT — fires at particle 1 arrival -->
+    <circle cx="540" cy="158" r="48" fill="none" stroke="#dc1c89" stroke-width="2" opacity="0">
+      <animate attributeName="r" values="48;48;70;70" keyTimes="0;0.92;0.99;1" dur="3.6s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0;0.9;0;0" keyTimes="0;0.92;0.95;0.99;1" dur="3.6s" repeatCount="indefinite"/>
+    </circle>
+    <!-- Ring on AGENT — fires at particle 2 arrival -->
+    <circle cx="540" cy="158" r="48" fill="none" stroke="#dc1c89" stroke-width="2" opacity="0">
+      <animate attributeName="r" values="48;48;70;70" keyTimes="0;0.92;0.99;1" dur="3.6s" begin="1.8s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0;0.9;0;0" keyTimes="0;0.92;0.95;0.99;1" dur="3.6s" begin="1.8s" repeatCount="indefinite"/>
+    </circle>
+
+    <!-- Bottom arc particles (AGENT → HUMAN) -->
+    <circle r="4" fill="#00a3bc" opacity="0">
+      <animateMotion dur="3.6s" begin="0.9s" repeatCount="indefinite" path="M 496 186 Q 360 246 224 186"/>
+      <animate attributeName="opacity" values="0;1;1;0;0" keyTimes="0;0.05;0.9;0.95;1" dur="3.6s" begin="0.9s" repeatCount="indefinite"/>
+    </circle>
+    <circle r="4" fill="#00a3bc" opacity="0">
+      <animateMotion dur="3.6s" begin="2.7s" repeatCount="indefinite" path="M 496 186 Q 360 246 224 186"/>
+      <animate attributeName="opacity" values="0;1;1;0;0" keyTimes="0;0.05;0.9;0.95;1" dur="3.6s" begin="2.7s" repeatCount="indefinite"/>
+    </circle>
+    <!-- Ring on HUMAN — fires at particle 3 arrival -->
+    <circle cx="180" cy="158" r="48" fill="none" stroke="#00a3bc" stroke-width="2" opacity="0">
+      <animate attributeName="r" values="48;48;70;70" keyTimes="0;0.92;0.99;1" dur="3.6s" begin="0.9s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0;0.9;0;0" keyTimes="0;0.92;0.95;0.99;1" dur="3.6s" begin="0.9s" repeatCount="indefinite"/>
+    </circle>
+    <!-- Ring on HUMAN — fires at particle 4 arrival -->
+    <circle cx="180" cy="158" r="48" fill="none" stroke="#00a3bc" stroke-width="2" opacity="0">
+      <animate attributeName="r" values="48;48;70;70" keyTimes="0;0.92;0.99;1" dur="3.6s" begin="2.7s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0;0.9;0;0" keyTimes="0;0.92;0.95;0.99;1" dur="3.6s" begin="2.7s" repeatCount="indefinite"/>
+    </circle>
   </g>
 
 </svg>

--- a/assets/diagrams/bidir-flow-light.svg
+++ b/assets/diagrams/bidir-flow-light.svg
@@ -18,19 +18,15 @@
       8%            { opacity: 1; }
     }
 
-    .core-h { animation: core-h-breathe 6s ease-in-out infinite; transform-origin: 0 0; }
-    .core-a { animation: core-a-breathe 6s ease-in-out infinite; animation-delay: 3s; transform-origin: 0 0; }
-    @keyframes core-h-breathe {
-      0%, 100% { stroke-width: 1.5; stroke-opacity: 0.7; }
-      50%      { stroke-width: 2.5; stroke-opacity: 1.0; }
-    }
-    @keyframes core-a-breathe {
-      0%, 100% { stroke-width: 1.5; stroke-opacity: 0.7; }
-      50%      { stroke-width: 2.5; stroke-opacity: 1.0; }
+    .core-h { animation: core-breathe 6s ease-in-out infinite; transform-origin: center; transform-box: fill-box; }
+    .core-a { animation: core-breathe 6s ease-in-out infinite; animation-delay: 3s; transform-origin: center; transform-box: fill-box; }
+    @keyframes core-breathe {
+      0%, 100% { transform: scale(1); }
+      50%      { transform: scale(1.04); }
     }
 
     @media (prefers-reduced-motion: reduce) {
-      .arc-down, .arc-up, .core-h, .core-a { animation: none; opacity: 0.7; }
+      .arc-down, .arc-up, .core-h, .core-a { animation: none; opacity: 1; }
     }
   </style>
 
@@ -39,37 +35,89 @@
       <path d="M 40 0 L 0 0 0 40" fill="none" class="grid-line" stroke-width="0.5"/>
     </pattern>
     <marker id="ah-pink" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
-      <path d="M 0 0 L 10 5 L 0 10 z" fill="#c91075"/>
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#dc1c89"/>
     </marker>
     <marker id="ah-cyan" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
-      <path d="M 0 0 L 10 5 L 0 10 z" fill="#00788c"/>
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#00a3bc"/>
     </marker>
+    <radialGradient id="g-human-fill" cx="0.32" cy="0.32" r="0.85">
+      <stop offset="0%"   stop-color="#00b8d4" stop-opacity="1"/>
+      <stop offset="100%" stop-color="#00a3bc" stop-opacity="1"/>
+    </radialGradient>
+    <radialGradient id="g-agent-fill" cx="0.32" cy="0.32" r="0.85">
+      <stop offset="0%"   stop-color="#ed3da0" stop-opacity="1"/>
+      <stop offset="100%" stop-color="#dc1c89" stop-opacity="1"/>
+    </radialGradient>
   </defs>
 
   <!-- HUMAN core (left) -->
   <g transform="translate(180,158)">
-    <circle class="core-h" cx="0" cy="0" r="48" fill="#ffffff" stroke="#00788c"/>
-    <text x="0" y="-2" text-anchor="middle" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="20" letter-spacing="0.06em" class="text-strong">HUMAN</text>
-    <text x="0" y="16" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-size="9" letter-spacing="0.32em" fill="#00788c">YOU</text>
+    <circle class="core-h" cx="0" cy="0" r="48" fill="url(#g-human-fill)"/>
+    <text x="0" y="-2" text-anchor="middle" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="20" letter-spacing="0.06em" fill="#ffffff">HUMAN</text>
+    <text x="0" y="16" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-size="9" letter-spacing="0.32em" fill="rgba(255,255,255,0.85)">YOU</text>
   </g>
 
   <!-- AGENT core (right) -->
   <g transform="translate(540,158)">
-    <circle class="core-a" cx="0" cy="0" r="48" fill="#ffffff" stroke="#c91075"/>
-    <text x="0" y="-2" text-anchor="middle" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="20" letter-spacing="0.06em" class="text-strong">AGENT</text>
-    <text x="0" y="16" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-size="9" letter-spacing="0.32em" fill="#c91075">ONEBRAIN</text>
+    <circle class="core-a" cx="0" cy="0" r="48" fill="url(#g-agent-fill)"/>
+    <text x="0" y="-2" text-anchor="middle" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="20" letter-spacing="0.06em" fill="#ffffff">AGENT</text>
+    <text x="0" y="16" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-size="9" letter-spacing="0.32em" fill="rgba(255,255,255,0.85)">ONEBRAIN</text>
   </g>
 
   <!-- Top arc: HUMAN → AGENT -->
   <g class="arc-down">
-    <path d="M 224 130 Q 360 70 496 130" fill="none" stroke="#c91075" stroke-width="1.4" marker-end="url(#ah-pink)"/>
-    <text x="360" y="78" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-size="10" letter-spacing="0.25em" class="text-soft">PREFERENCES · DECISIONS · CORRECTIONS</text>
+    <path d="M 224 130 Q 360 70 496 130" fill="none" stroke="#dc1c89" stroke-width="1.6" marker-end="url(#ah-pink)"/>
+    <text x="360" y="78" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-size="10" font-weight="600" letter-spacing="0.25em" fill="#dc1c89">PREFERENCES · DECISIONS · CORRECTIONS</text>
   </g>
 
   <!-- Bottom arc: AGENT → HUMAN -->
   <g class="arc-up">
-    <path d="M 496 186 Q 360 246 224 186" fill="none" stroke="#00788c" stroke-width="1.4" marker-end="url(#ah-cyan)"/>
-    <text x="360" y="244" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-size="10" letter-spacing="0.25em" class="text-soft">CAPTURES · LINKS · SYNTHESIS</text>
+    <path d="M 496 186 Q 360 246 224 186" fill="none" stroke="#00a3bc" stroke-width="1.6" marker-end="url(#ah-cyan)"/>
+    <text x="360" y="244" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-size="10" font-weight="600" letter-spacing="0.25em" fill="#00a3bc">CAPTURES · LINKS · SYNTHESIS</text>
+  </g>
+
+  <!-- Motion layer: particles + arrival rings, all on dur=3.6s cycle.
+       keyTimes 0.92 = particle reaches node, 0.95 = ring peak (sync). -->
+  <g class="motion-layer">
+    <!-- Top arc particles (HUMAN → AGENT) -->
+    <circle r="4" fill="#dc1c89" opacity="0">
+      <animateMotion dur="3.6s" repeatCount="indefinite" path="M 224 130 Q 360 70 496 130"/>
+      <animate attributeName="opacity" values="0;1;1;0;0" keyTimes="0;0.05;0.9;0.95;1" dur="3.6s" repeatCount="indefinite"/>
+    </circle>
+    <circle r="4" fill="#dc1c89" opacity="0">
+      <animateMotion dur="3.6s" begin="1.8s" repeatCount="indefinite" path="M 224 130 Q 360 70 496 130"/>
+      <animate attributeName="opacity" values="0;1;1;0;0" keyTimes="0;0.05;0.9;0.95;1" dur="3.6s" begin="1.8s" repeatCount="indefinite"/>
+    </circle>
+    <!-- Ring on AGENT — fires at particle 1 arrival -->
+    <circle cx="540" cy="158" r="48" fill="none" stroke="#dc1c89" stroke-width="2" opacity="0">
+      <animate attributeName="r" values="48;48;70;70" keyTimes="0;0.92;0.99;1" dur="3.6s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0;0.9;0;0" keyTimes="0;0.92;0.95;0.99;1" dur="3.6s" repeatCount="indefinite"/>
+    </circle>
+    <!-- Ring on AGENT — fires at particle 2 arrival -->
+    <circle cx="540" cy="158" r="48" fill="none" stroke="#dc1c89" stroke-width="2" opacity="0">
+      <animate attributeName="r" values="48;48;70;70" keyTimes="0;0.92;0.99;1" dur="3.6s" begin="1.8s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0;0.9;0;0" keyTimes="0;0.92;0.95;0.99;1" dur="3.6s" begin="1.8s" repeatCount="indefinite"/>
+    </circle>
+
+    <!-- Bottom arc particles (AGENT → HUMAN) -->
+    <circle r="4" fill="#00a3bc" opacity="0">
+      <animateMotion dur="3.6s" begin="0.9s" repeatCount="indefinite" path="M 496 186 Q 360 246 224 186"/>
+      <animate attributeName="opacity" values="0;1;1;0;0" keyTimes="0;0.05;0.9;0.95;1" dur="3.6s" begin="0.9s" repeatCount="indefinite"/>
+    </circle>
+    <circle r="4" fill="#00a3bc" opacity="0">
+      <animateMotion dur="3.6s" begin="2.7s" repeatCount="indefinite" path="M 496 186 Q 360 246 224 186"/>
+      <animate attributeName="opacity" values="0;1;1;0;0" keyTimes="0;0.05;0.9;0.95;1" dur="3.6s" begin="2.7s" repeatCount="indefinite"/>
+    </circle>
+    <!-- Ring on HUMAN — fires at particle 3 arrival -->
+    <circle cx="180" cy="158" r="48" fill="none" stroke="#00a3bc" stroke-width="2" opacity="0">
+      <animate attributeName="r" values="48;48;70;70" keyTimes="0;0.92;0.99;1" dur="3.6s" begin="0.9s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0;0.9;0;0" keyTimes="0;0.92;0.95;0.99;1" dur="3.6s" begin="0.9s" repeatCount="indefinite"/>
+    </circle>
+    <!-- Ring on HUMAN — fires at particle 4 arrival -->
+    <circle cx="180" cy="158" r="48" fill="none" stroke="#00a3bc" stroke-width="2" opacity="0">
+      <animate attributeName="r" values="48;48;70;70" keyTimes="0;0.92;0.99;1" dur="3.6s" begin="2.7s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0;0.9;0;0" keyTimes="0;0.92;0.95;0.99;1" dur="3.6s" begin="2.7s" repeatCount="indefinite"/>
+    </circle>
   </g>
 
 </svg>

--- a/assets/diagrams/coevo-loop-dark.svg
+++ b/assets/diagrams/coevo-loop-dark.svg
@@ -3,80 +3,131 @@
   <desc id="desc">Three nodes arranged in a triangle: 01 CAPTURE at top, 02 EVOLVE at bottom-right, 03 WRAPUP at bottom-left. Curved arrows flow clockwise between them, visualizing the recurring co-evolution loop.</desc>
 
   <style>
-    .text-strong { fill: #ffffff; }
-    .text-soft   { fill: rgba(255,255,255,0.78); }
-    .text-fade   { fill: rgba(255,255,255,0.50); }
-    .text-mute   { fill: rgba(255,255,255,0.35); }
-
     .leg { animation: leg-pulse 4.5s linear infinite; }
     .leg-2 { animation-delay: 1.5s; }
     .leg-3 { animation-delay: 3s; }
     @keyframes leg-pulse {
-      0%, 33%, 100% { opacity: 0.5; }
+      0%, 33%, 100% { opacity: 0.6; }
       10%           { opacity: 1; }
     }
 
-    .ring-orbit { animation: ring-orbit-spin 90s linear infinite; transform-origin: 0 0; }
-    @keyframes ring-orbit-spin { to { transform: rotate(360deg); } }
+    .core-1 { animation: core-breathe 6s ease-in-out infinite; transform-origin: center; transform-box: fill-box; }
+    .core-2 { animation: core-breathe 6s ease-in-out infinite; animation-delay: 2s; transform-origin: center; transform-box: fill-box; }
+    .core-3 { animation: core-breathe 6s ease-in-out infinite; animation-delay: 4s; transform-origin: center; transform-box: fill-box; }
+    @keyframes core-breathe {
+      0%, 100% { transform: scale(1); }
+      50%      { transform: scale(1.04); }
+    }
 
     @media (prefers-reduced-motion: reduce) {
-      .leg, .ring-orbit { animation: none; opacity: 0.5; }
+      .leg, .core-1, .core-2, .core-3 { animation: none; opacity: 1; }
     }
   </style>
 
   <defs>
     <marker id="ah-1" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
-      <path d="M 0 0 L 10 5 L 0 10 z" fill="#ff2d92"/>
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#dc1c89"/>
     </marker>
     <marker id="ah-2" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
-      <path d="M 0 0 L 10 5 L 0 10 z" fill="#bc13fe"/>
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#9234e8"/>
     </marker>
     <marker id="ah-3" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
-      <path d="M 0 0 L 10 5 L 0 10 z" fill="#00f3ff"/>
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#00a3bc"/>
     </marker>
+    <radialGradient id="g-capture-fill" cx="0.32" cy="0.32" r="0.85">
+      <stop offset="0%"   stop-color="#ed3da0" stop-opacity="1"/>
+      <stop offset="100%" stop-color="#dc1c89" stop-opacity="1"/>
+    </radialGradient>
+    <radialGradient id="g-evolve-fill" cx="0.32" cy="0.32" r="0.85">
+      <stop offset="0%"   stop-color="#a855f7" stop-opacity="1"/>
+      <stop offset="100%" stop-color="#9234e8" stop-opacity="1"/>
+    </radialGradient>
+    <radialGradient id="g-wrapup-fill" cx="0.32" cy="0.32" r="0.85">
+      <stop offset="0%"   stop-color="#00b8d4" stop-opacity="1"/>
+      <stop offset="100%" stop-color="#00a3bc" stop-opacity="1"/>
+    </radialGradient>
   </defs>
 
-  <circle class="ring-orbit" cx="0" cy="0" r="180" fill="none" stroke="rgba(255,255,255,0.14)" stroke-width="1" stroke-dasharray="3 5"/>
 
+  <!-- Legs: straight lines from edge to edge of each circle, pointing
+       directly at the destination's center so the arrow vector is radial. -->
+  <!-- 01→02 leg (top → bottom-right) -->
   <g class="leg">
-    <path d="M 27 -83.2 Q 82.2 -47.5 85.6 18.2" fill="none" stroke="#ff2d92" stroke-width="1.6" marker-end="url(#ah-1)"/>
+    <path id="leg-1" d="M 27 -83.2 L 85.6 18.2" fill="none" stroke="#dc1c89" stroke-width="1.6" marker-end="url(#ah-1)"/>
   </g>
+
+  <!-- 02→03 leg (bottom-right → bottom-left) -->
   <g class="leg leg-2">
-    <path d="M 58.6 65 Q 0 110 -58.6 65" fill="none" stroke="#bc13fe" stroke-width="1.6" marker-end="url(#ah-2)"/>
+    <path id="leg-2" d="M 58.6 65 L -58.6 65" fill="none" stroke="#9234e8" stroke-width="1.6" marker-end="url(#ah-2)"/>
   </g>
+
+  <!-- 03→01 leg (bottom-left → top) -->
   <g class="leg leg-3">
-    <path d="M -85.6 18.2 Q -82.2 -47.5 -27 -83.2" fill="none" stroke="#00f3ff" stroke-width="1.6" marker-end="url(#ah-3)"/>
+    <path id="leg-3" d="M -85.6 18.2 L -27 -83.2" fill="none" stroke="#00a3bc" stroke-width="1.6" marker-end="url(#ah-3)"/>
   </g>
 
-  <!-- Node 01 — CAPTURE (top): single-line name + short cmd inside the
-       circle. The 01→02 arrow exits the bottom of this circle, so an
-       outside-bottom cmd label would collide with the arrow path —
-       hence cmd stays inside, abbreviated to one command. The README
-       prose carries the full triple. -->
+  <!-- Node 01 — CAPTURE (top) -->
   <g transform="translate(0,-130)">
-    <circle cx="0" cy="0" r="54" fill="rgba(2,2,4,0.92)" stroke="#ff2d92" stroke-width="1.5"/>
-    <text x="0" y="-12" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-size="11" font-weight="700" fill="#ff2d92" letter-spacing="0.18em">01</text>
-    <text x="0" y="6" text-anchor="middle" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="14" letter-spacing="0.05em" class="text-strong">CAPTURE</text>
-    <text x="0" y="22" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-size="8" letter-spacing="0.28em" fill="#ff2d92">/braindump</text>
+    <circle class="core-1" cx="0" cy="0" r="54" fill="url(#g-capture-fill)"/>
+    <text x="0" y="-12" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-size="11" font-weight="700" fill="rgba(255,255,255,0.85)" letter-spacing="0.18em">01</text>
+    <text x="0" y="6" text-anchor="middle" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="14" letter-spacing="0.05em" fill="#ffffff">CAPTURE</text>
+    <text x="0" y="22" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-size="8" letter-spacing="0.28em" fill="rgba(255,255,255,0.85)">/braindump</text>
   </g>
 
-  <!-- Node 02 — EVOLVE (bottom-right): cmd outside below the circle.
-       The 02→03 arrow's apex sits at y=110 (well above the cmd at
-       abs y=141), so no overlap. -->
+  <!-- Node 02 — EVOLVE (bottom-right) -->
   <g transform="translate(112.6,65)">
-    <circle cx="0" cy="0" r="54" fill="rgba(2,2,4,0.92)" stroke="#bc13fe" stroke-width="1.5"/>
-    <text x="0" y="-12" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-size="11" font-weight="700" fill="#bc13fe" letter-spacing="0.18em">02</text>
-    <text x="0" y="6" text-anchor="middle" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="14" letter-spacing="0.05em" class="text-strong">EVOLVE</text>
-    <text x="0" y="68" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-size="8" letter-spacing="0.28em" fill="#bc13fe">/distill · /learn</text>
+    <circle class="core-2" cx="0" cy="0" r="54" fill="url(#g-evolve-fill)"/>
+    <text x="0" y="-12" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-size="11" font-weight="700" fill="rgba(255,255,255,0.85)" letter-spacing="0.18em">02</text>
+    <text x="0" y="6" text-anchor="middle" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="14" letter-spacing="0.05em" fill="#ffffff">EVOLVE</text>
+    <text x="0" y="68" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-size="8" font-weight="600" letter-spacing="0.28em" fill="#9234e8">/distill · /learn</text>
   </g>
 
-  <!-- Node 03 — WRAPUP (bottom-left): cmd outside below the circle.
-       Mirror of node 02 — no arrow path crosses this cmd region. -->
+  <!-- Node 03 — WRAPUP (bottom-left) -->
   <g transform="translate(-112.6,65)">
-    <circle cx="0" cy="0" r="54" fill="rgba(2,2,4,0.92)" stroke="#00f3ff" stroke-width="1.5"/>
-    <text x="0" y="-12" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-size="11" font-weight="700" fill="#00f3ff" letter-spacing="0.18em">03</text>
-    <text x="0" y="6" text-anchor="middle" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="14" letter-spacing="0.05em" class="text-strong">WRAPUP</text>
-    <text x="0" y="68" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-size="8" letter-spacing="0.28em" fill="#00f3ff">/wrapup · /recap</text>
+    <circle class="core-3" cx="0" cy="0" r="54" fill="url(#g-wrapup-fill)"/>
+    <text x="0" y="-12" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-size="11" font-weight="700" fill="rgba(255,255,255,0.85)" letter-spacing="0.18em">03</text>
+    <text x="0" y="6" text-anchor="middle" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="14" letter-spacing="0.05em" fill="#ffffff">WRAPUP</text>
+    <text x="0" y="68" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-size="8" font-weight="600" letter-spacing="0.28em" fill="#00a3bc">/wrapup · /recap</text>
+  </g>
+
+  <!-- Motion layer: particles flow clockwise around the triangle.
+       Each particle's cycle = 5.4s, traversing its leg in the first 1.8s
+       (keyTimes 0→0.333) then resting (invisible). Begin offsets stagger
+       the legs by 1.8s so exactly one particle is in flight at a time.
+       Ring on the destination node bursts at the moment of arrival. -->
+  <g class="motion-layer">
+    <!-- Leg 1: CAPTURE → EVOLVE -->
+    <circle r="3.5" fill="#dc1c89" opacity="0">
+      <animateMotion dur="5.4s" calcMode="linear" keyPoints="0;1;1" keyTimes="0;0.333;1" repeatCount="indefinite" path="M 27 -83.2 L 85.6 18.2"/>
+      <animate attributeName="opacity" values="0;1;1;0;0" keyTimes="0;0.02;0.31;0.333;1" dur="5.4s" repeatCount="indefinite"/>
+    </circle>
+    <!-- Ring on EVOLVE (purple) — bursts at t=0.333 -->
+    <circle cx="112.6" cy="65" r="54" fill="none" stroke="#9234e8" stroke-width="2" opacity="0">
+      <animate attributeName="r" values="54;54;76;76" keyTimes="0;0.333;0.40;1" dur="5.4s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0;0.9;0;0" keyTimes="0;0.333;0.36;0.40;1" dur="5.4s" repeatCount="indefinite"/>
+    </circle>
+
+    <!-- Leg 2: EVOLVE → WRAPUP -->
+    <circle r="3.5" fill="#9234e8" opacity="0">
+      <animateMotion dur="5.4s" begin="1.8s" calcMode="linear" keyPoints="0;1;1" keyTimes="0;0.333;1" repeatCount="indefinite" path="M 58.6 65 L -58.6 65"/>
+      <animate attributeName="opacity" values="0;1;1;0;0" keyTimes="0;0.02;0.31;0.333;1" dur="5.4s" begin="1.8s" repeatCount="indefinite"/>
+    </circle>
+    <!-- Ring on WRAPUP (teal) — bursts at t=0.333 of leg-2's cycle -->
+    <circle cx="-112.6" cy="65" r="54" fill="none" stroke="#00a3bc" stroke-width="2" opacity="0">
+      <animate attributeName="r" values="54;54;76;76" keyTimes="0;0.333;0.40;1" dur="5.4s" begin="1.8s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0;0.9;0;0" keyTimes="0;0.333;0.36;0.40;1" dur="5.4s" begin="1.8s" repeatCount="indefinite"/>
+    </circle>
+
+    <!-- Leg 3: WRAPUP → CAPTURE -->
+    <circle r="3.5" fill="#00a3bc" opacity="0">
+      <animateMotion dur="5.4s" begin="3.6s" calcMode="linear" keyPoints="0;1;1" keyTimes="0;0.333;1" repeatCount="indefinite" path="M -85.6 18.2 L -27 -83.2"/>
+      <animate attributeName="opacity" values="0;1;1;0;0" keyTimes="0;0.02;0.31;0.333;1" dur="5.4s" begin="3.6s" repeatCount="indefinite"/>
+    </circle>
+    <!-- Ring on CAPTURE (pink) — bursts at t=0.333 of leg-3's cycle -->
+    <circle cx="0" cy="-130" r="54" fill="none" stroke="#dc1c89" stroke-width="2" opacity="0">
+      <animate attributeName="r" values="54;54;76;76" keyTimes="0;0.333;0.40;1" dur="5.4s" begin="3.6s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0;0.9;0;0" keyTimes="0;0.333;0.36;0.40;1" dur="5.4s" begin="3.6s" repeatCount="indefinite"/>
+    </circle>
   </g>
 
 </svg>

--- a/assets/diagrams/coevo-loop-light.svg
+++ b/assets/diagrams/coevo-loop-light.svg
@@ -3,86 +3,131 @@
   <desc id="desc">Three nodes arranged in a triangle: 01 CAPTURE at top, 02 EVOLVE at bottom-right, 03 WRAPUP at bottom-left. Curved arrows flow clockwise between them, visualizing the recurring co-evolution loop.</desc>
 
   <style>
-    .text-strong { fill: #0a0a14; }
-    .text-soft   { fill: rgba(10,10,20,0.82); }
-    .text-fade   { fill: rgba(10,10,20,0.55); }
-    .text-mute   { fill: rgba(10,10,20,0.40); }
-
     .leg { animation: leg-pulse 4.5s linear infinite; }
     .leg-2 { animation-delay: 1.5s; }
     .leg-3 { animation-delay: 3s; }
     @keyframes leg-pulse {
-      0%, 33%, 100% { opacity: 0.55; }
+      0%, 33%, 100% { opacity: 0.6; }
       10%           { opacity: 1; }
     }
 
-    .ring-orbit { animation: ring-orbit-spin 90s linear infinite; transform-origin: 0 0; }
-    @keyframes ring-orbit-spin { to { transform: rotate(360deg); } }
+    .core-1 { animation: core-breathe 6s ease-in-out infinite; transform-origin: center; transform-box: fill-box; }
+    .core-2 { animation: core-breathe 6s ease-in-out infinite; animation-delay: 2s; transform-origin: center; transform-box: fill-box; }
+    .core-3 { animation: core-breathe 6s ease-in-out infinite; animation-delay: 4s; transform-origin: center; transform-box: fill-box; }
+    @keyframes core-breathe {
+      0%, 100% { transform: scale(1); }
+      50%      { transform: scale(1.04); }
+    }
 
     @media (prefers-reduced-motion: reduce) {
-      .leg, .ring-orbit { animation: none; opacity: 0.55; }
+      .leg, .core-1, .core-2, .core-3 { animation: none; opacity: 1; }
     }
   </style>
 
   <defs>
     <marker id="ah-1" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
-      <path d="M 0 0 L 10 5 L 0 10 z" fill="#c91075"/>
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#dc1c89"/>
     </marker>
     <marker id="ah-2" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
-      <path d="M 0 0 L 10 5 L 0 10 z" fill="#7c1ade"/>
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#9234e8"/>
     </marker>
     <marker id="ah-3" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
-      <path d="M 0 0 L 10 5 L 0 10 z" fill="#00788c"/>
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#00a3bc"/>
     </marker>
+    <radialGradient id="g-capture-fill" cx="0.32" cy="0.32" r="0.85">
+      <stop offset="0%"   stop-color="#ed3da0" stop-opacity="1"/>
+      <stop offset="100%" stop-color="#dc1c89" stop-opacity="1"/>
+    </radialGradient>
+    <radialGradient id="g-evolve-fill" cx="0.32" cy="0.32" r="0.85">
+      <stop offset="0%"   stop-color="#a855f7" stop-opacity="1"/>
+      <stop offset="100%" stop-color="#9234e8" stop-opacity="1"/>
+    </radialGradient>
+    <radialGradient id="g-wrapup-fill" cx="0.32" cy="0.32" r="0.85">
+      <stop offset="0%"   stop-color="#00b8d4" stop-opacity="1"/>
+      <stop offset="100%" stop-color="#00a3bc" stop-opacity="1"/>
+    </radialGradient>
   </defs>
 
-  <!-- Outer guide ring -->
-  <circle class="ring-orbit" cx="0" cy="0" r="180" fill="none" stroke="rgba(10,10,20,0.18)" stroke-width="1" stroke-dasharray="3 5"/>
 
+  <!-- Legs: straight lines from edge to edge of each circle, pointing
+       directly at the destination's center so the arrow vector is radial. -->
   <!-- 01→02 leg (top → bottom-right) -->
   <g class="leg">
-    <path d="M 27 -83.2 Q 82.2 -47.5 85.6 18.2" fill="none" stroke="#c91075" stroke-width="1.6" marker-end="url(#ah-1)"/>
+    <path id="leg-1" d="M 27 -83.2 L 85.6 18.2" fill="none" stroke="#dc1c89" stroke-width="1.6" marker-end="url(#ah-1)"/>
   </g>
 
   <!-- 02→03 leg (bottom-right → bottom-left) -->
   <g class="leg leg-2">
-    <path d="M 58.6 65 Q 0 110 -58.6 65" fill="none" stroke="#7c1ade" stroke-width="1.6" marker-end="url(#ah-2)"/>
+    <path id="leg-2" d="M 58.6 65 L -58.6 65" fill="none" stroke="#9234e8" stroke-width="1.6" marker-end="url(#ah-2)"/>
   </g>
 
   <!-- 03→01 leg (bottom-left → top) -->
   <g class="leg leg-3">
-    <path d="M -85.6 18.2 Q -82.2 -47.5 -27 -83.2" fill="none" stroke="#00788c" stroke-width="1.6" marker-end="url(#ah-3)"/>
+    <path id="leg-3" d="M -85.6 18.2 L -27 -83.2" fill="none" stroke="#00a3bc" stroke-width="1.6" marker-end="url(#ah-3)"/>
   </g>
 
-  <!-- Node 01 — CAPTURE (top): single-line name + short cmd inside the
-       circle. The 01→02 arrow exits the bottom of this circle, so an
-       outside-bottom cmd label would collide with the arrow path —
-       hence cmd stays inside, abbreviated to one command. The README
-       prose carries the full triple. -->
+  <!-- Node 01 — CAPTURE (top) -->
   <g transform="translate(0,-130)">
-    <circle cx="0" cy="0" r="54" fill="#ffffff" stroke="#c91075" stroke-width="1.5"/>
-    <text x="0" y="-12" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-size="11" font-weight="700" fill="#c91075" letter-spacing="0.18em">01</text>
-    <text x="0" y="6" text-anchor="middle" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="14" letter-spacing="0.05em" class="text-strong">CAPTURE</text>
-    <text x="0" y="22" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-size="8" letter-spacing="0.28em" fill="#c91075">/braindump</text>
+    <circle class="core-1" cx="0" cy="0" r="54" fill="url(#g-capture-fill)"/>
+    <text x="0" y="-12" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-size="11" font-weight="700" fill="rgba(255,255,255,0.85)" letter-spacing="0.18em">01</text>
+    <text x="0" y="6" text-anchor="middle" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="14" letter-spacing="0.05em" fill="#ffffff">CAPTURE</text>
+    <text x="0" y="22" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-size="8" letter-spacing="0.28em" fill="rgba(255,255,255,0.85)">/braindump</text>
   </g>
 
-  <!-- Node 02 — EVOLVE (bottom-right): cmd outside below the circle.
-       The 02→03 arrow's apex sits at y=110 (well above the cmd at
-       abs y=141), so no overlap. -->
+  <!-- Node 02 — EVOLVE (bottom-right) -->
   <g transform="translate(112.6,65)">
-    <circle cx="0" cy="0" r="54" fill="#ffffff" stroke="#7c1ade" stroke-width="1.5"/>
-    <text x="0" y="-12" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-size="11" font-weight="700" fill="#7c1ade" letter-spacing="0.18em">02</text>
-    <text x="0" y="6" text-anchor="middle" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="14" letter-spacing="0.05em" class="text-strong">EVOLVE</text>
-    <text x="0" y="68" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-size="8" letter-spacing="0.28em" fill="#7c1ade">/distill · /learn</text>
+    <circle class="core-2" cx="0" cy="0" r="54" fill="url(#g-evolve-fill)"/>
+    <text x="0" y="-12" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-size="11" font-weight="700" fill="rgba(255,255,255,0.85)" letter-spacing="0.18em">02</text>
+    <text x="0" y="6" text-anchor="middle" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="14" letter-spacing="0.05em" fill="#ffffff">EVOLVE</text>
+    <text x="0" y="68" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-size="8" font-weight="600" letter-spacing="0.28em" fill="#9234e8">/distill · /learn</text>
   </g>
 
-  <!-- Node 03 — WRAPUP (bottom-left): cmd outside below the circle.
-       Mirror of node 02 — no arrow path crosses this cmd region. -->
+  <!-- Node 03 — WRAPUP (bottom-left) -->
   <g transform="translate(-112.6,65)">
-    <circle cx="0" cy="0" r="54" fill="#ffffff" stroke="#00788c" stroke-width="1.5"/>
-    <text x="0" y="-12" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-size="11" font-weight="700" fill="#00788c" letter-spacing="0.18em">03</text>
-    <text x="0" y="6" text-anchor="middle" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="14" letter-spacing="0.05em" class="text-strong">WRAPUP</text>
-    <text x="0" y="68" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-size="8" letter-spacing="0.28em" fill="#00788c">/wrapup · /recap</text>
+    <circle class="core-3" cx="0" cy="0" r="54" fill="url(#g-wrapup-fill)"/>
+    <text x="0" y="-12" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-size="11" font-weight="700" fill="rgba(255,255,255,0.85)" letter-spacing="0.18em">03</text>
+    <text x="0" y="6" text-anchor="middle" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="14" letter-spacing="0.05em" fill="#ffffff">WRAPUP</text>
+    <text x="0" y="68" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-size="8" font-weight="600" letter-spacing="0.28em" fill="#00a3bc">/wrapup · /recap</text>
+  </g>
+
+  <!-- Motion layer: particles flow clockwise around the triangle.
+       Each particle's cycle = 5.4s, traversing its leg in the first 1.8s
+       (keyTimes 0→0.333) then resting (invisible). Begin offsets stagger
+       the legs by 1.8s so exactly one particle is in flight at a time.
+       Ring on the destination node bursts at the moment of arrival. -->
+  <g class="motion-layer">
+    <!-- Leg 1: CAPTURE → EVOLVE -->
+    <circle r="3.5" fill="#dc1c89" opacity="0">
+      <animateMotion dur="5.4s" calcMode="linear" keyPoints="0;1;1" keyTimes="0;0.333;1" repeatCount="indefinite" path="M 27 -83.2 L 85.6 18.2"/>
+      <animate attributeName="opacity" values="0;1;1;0;0" keyTimes="0;0.02;0.31;0.333;1" dur="5.4s" repeatCount="indefinite"/>
+    </circle>
+    <!-- Ring on EVOLVE (purple) — bursts at t=0.333 -->
+    <circle cx="112.6" cy="65" r="54" fill="none" stroke="#9234e8" stroke-width="2" opacity="0">
+      <animate attributeName="r" values="54;54;76;76" keyTimes="0;0.333;0.40;1" dur="5.4s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0;0.9;0;0" keyTimes="0;0.333;0.36;0.40;1" dur="5.4s" repeatCount="indefinite"/>
+    </circle>
+
+    <!-- Leg 2: EVOLVE → WRAPUP -->
+    <circle r="3.5" fill="#9234e8" opacity="0">
+      <animateMotion dur="5.4s" begin="1.8s" calcMode="linear" keyPoints="0;1;1" keyTimes="0;0.333;1" repeatCount="indefinite" path="M 58.6 65 L -58.6 65"/>
+      <animate attributeName="opacity" values="0;1;1;0;0" keyTimes="0;0.02;0.31;0.333;1" dur="5.4s" begin="1.8s" repeatCount="indefinite"/>
+    </circle>
+    <!-- Ring on WRAPUP (teal) — bursts at t=0.333 of leg-2's cycle -->
+    <circle cx="-112.6" cy="65" r="54" fill="none" stroke="#00a3bc" stroke-width="2" opacity="0">
+      <animate attributeName="r" values="54;54;76;76" keyTimes="0;0.333;0.40;1" dur="5.4s" begin="1.8s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0;0.9;0;0" keyTimes="0;0.333;0.36;0.40;1" dur="5.4s" begin="1.8s" repeatCount="indefinite"/>
+    </circle>
+
+    <!-- Leg 3: WRAPUP → CAPTURE -->
+    <circle r="3.5" fill="#00a3bc" opacity="0">
+      <animateMotion dur="5.4s" begin="3.6s" calcMode="linear" keyPoints="0;1;1" keyTimes="0;0.333;1" repeatCount="indefinite" path="M -85.6 18.2 L -27 -83.2"/>
+      <animate attributeName="opacity" values="0;1;1;0;0" keyTimes="0;0.02;0.31;0.333;1" dur="5.4s" begin="3.6s" repeatCount="indefinite"/>
+    </circle>
+    <!-- Ring on CAPTURE (pink) — bursts at t=0.333 of leg-3's cycle -->
+    <circle cx="0" cy="-130" r="54" fill="none" stroke="#dc1c89" stroke-width="2" opacity="0">
+      <animate attributeName="r" values="54;54;76;76" keyTimes="0;0.333;0.40;1" dur="5.4s" begin="3.6s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0;0.9;0;0" keyTimes="0;0.333;0.36;0.40;1" dur="5.4s" begin="3.6s" repeatCount="indefinite"/>
+    </circle>
   </g>
 
 </svg>

--- a/assets/diagrams/harness-os-stack-dark.svg
+++ b/assets/diagrams/harness-os-stack-dark.svg
@@ -1,184 +1,132 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 100 880 492" width="880" height="492" role="img" aria-labelledby="title desc" font-family="'Chakra Petch', 'Inter', ui-sans-serif, system-ui, sans-serif">
-  <title id="title">OneBrain Harness OS — 4-Layer Architecture (dark)</title>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 100 880 600" width="880" height="600" role="img" aria-labelledby="title desc" font-family="'Chakra Petch', 'Inter', ui-sans-serif, system-ui, sans-serif">
+  <title id="title">OneBrain Harness OS — 4-Layer Architecture</title>
   <desc id="desc">Four stacked layers from top to bottom: OneBrain (plugin and CLI — skills, hooks, vault sync, indexing, checkpoints), Harness (Claude Code, Gemini CLI, Codex, Qwen), LLM (local, cloud, or API), and Obsidian Vault as the source of truth (plain Markdown notes, memory, decisions, knowledge graph).</desc>
 
   <style>
-    .text-strong { fill: #ffffff; }
-    .text-soft   { fill: rgba(255,255,255,0.70); }
-    .text-fade   { fill: rgba(255,255,255,0.50); }
-    .text-mute   { fill: rgba(255,255,255,0.35); }
-    .frame-corner { stroke: rgba(255,255,255,0.22); }
-    .grid-line    { stroke: rgba(255,255,255,0.06); }
-    .divider      { stroke: rgba(255,255,255,0.10); }
-    .arrow-line   { stroke: rgba(255,255,255,0.50); }
-    .arrow-head   { stroke: rgba(255,255,255,0.60); }
+    .flow { stroke: #ffffff; stroke-width: 2; stroke-linecap: round; stroke-dasharray: 3 5; fill: none; }
+    .flow-down { animation: flow-down 0.9s linear infinite; }
+    .flow-up   { animation: flow-up   0.9s linear infinite; }
+    @keyframes flow-down { to { stroke-dashoffset: -8; } }
+    @keyframes flow-up   { to { stroke-dashoffset:  8; } }
 
-    .arrow-pulse-down { animation: arrow-down-pulse 4.5s linear infinite; }
-    .arrow-pulse-up   { animation: arrow-up-pulse   4.5s linear infinite; }
-    .delay-1 { animation-delay: 1.5s; }
-    .delay-2 { animation-delay: 3s; }
-
-    @keyframes arrow-down-pulse {
-      0%, 22%, 100% { opacity: 0.55; }
-      6%            { opacity: 1; }
+    .icon-pulse {
+      transform-box: fill-box;
+      transform-origin: center;
+      animation: icon-pulse 2.6s ease-in-out infinite;
     }
-    @keyframes arrow-up-pulse {
-      0%, 50%, 72%, 100% { opacity: 0.55; }
-      56%                { opacity: 1; }
+    @keyframes icon-pulse {
+      0%, 100% { transform: scale(1);    }
+      50%      { transform: scale(1.08); }
     }
 
     @media (prefers-reduced-motion: reduce) {
-      .arrow-pulse-down, .arrow-pulse-up { animation: none; opacity: 0.55; }
+      .icon-pulse, .flow-down, .flow-up { animation: none; transform: none; }
     }
   </style>
 
   <defs>
     <linearGradient id="g-onebrain" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%"   stop-color="#ff2d92" stop-opacity="0.95"/>
-      <stop offset="100%" stop-color="#ff2d92" stop-opacity="0.05"/>
+      <stop offset="0%"   stop-color="#e62a93" stop-opacity="1"/>
+      <stop offset="100%" stop-color="#c91075" stop-opacity="1"/>
     </linearGradient>
     <linearGradient id="g-harness" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%"   stop-color="#bc13fe" stop-opacity="0.95"/>
-      <stop offset="100%" stop-color="#bc13fe" stop-opacity="0.05"/>
+      <stop offset="0%"   stop-color="#a855f7" stop-opacity="1"/>
+      <stop offset="100%" stop-color="#7c1ade" stop-opacity="1"/>
     </linearGradient>
     <linearGradient id="g-llm" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%"   stop-color="#c8ff00" stop-opacity="0.95"/>
-      <stop offset="100%" stop-color="#c8ff00" stop-opacity="0.05"/>
+      <stop offset="0%"   stop-color="#7a9d10" stop-opacity="1"/>
+      <stop offset="100%" stop-color="#4d6d00" stop-opacity="1"/>
     </linearGradient>
     <linearGradient id="g-vault" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%"   stop-color="#00f3ff" stop-opacity="0.95"/>
-      <stop offset="100%" stop-color="#00f3ff" stop-opacity="0.05"/>
+      <stop offset="0%"   stop-color="#00a3bc" stop-opacity="1"/>
+      <stop offset="100%" stop-color="#00788c" stop-opacity="1"/>
     </linearGradient>
 
     <linearGradient id="spine-grad" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%"   stop-color="#ff2d92" stop-opacity="0.6"/>
-      <stop offset="33%"  stop-color="#bc13fe" stop-opacity="0.6"/>
-      <stop offset="66%"  stop-color="#c8ff00" stop-opacity="0.6"/>
-      <stop offset="100%" stop-color="#00f3ff" stop-opacity="0.6"/>
+      <stop offset="0%"   stop-color="#e62a93" stop-opacity="0.85"/>
+      <stop offset="33%"  stop-color="#a855f7" stop-opacity="0.85"/>
+      <stop offset="66%"  stop-color="#7a9d10" stop-opacity="0.85"/>
+      <stop offset="100%" stop-color="#00a3bc" stop-opacity="0.85"/>
     </linearGradient>
-
-    <pattern id="grid-pattern" width="40" height="40" patternUnits="userSpaceOnUse">
-      <path d="M 40 0 L 0 0 0 40" fill="none" class="grid-line" stroke-width="0.5"/>
-    </pattern>
-
-    <filter id="soft-glow" x="-20%" y="-50%" width="140%" height="200%">
-      <feGaussianBlur stdDeviation="2" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
   </defs>
 
-  <!-- Vertical accent spine running through all layers -->
-  <line x1="48" y1="110" x2="48" y2="582" stroke="url(#spine-grad)" stroke-width="2" stroke-dasharray="2 4" opacity="0.55"/>
-
+  <line x1="48" y1="110" x2="48" y2="690" stroke="url(#spine-grad)" stroke-width="2" stroke-dasharray="2 4" opacity="0.7"/>
 
   <!-- ════════ LAYER 01 — ONEBRAIN ════════ -->
   <g transform="translate(60, 110)">
-    <rect width="780" height="100" fill="none" stroke="#ff2d92" stroke-opacity="0.45" stroke-width="1"/>
-    <rect width="780" height="3" fill="url(#g-onebrain)" filter="url(#soft-glow)"/>
-    <path d="M 0 0 L 14 0 M 0 0 L 0 14" stroke="#ff2d92" stroke-width="1.5" fill="none"/>
-    <path d="M 766 100 L 780 100 M 780 86 L 780 100" stroke="#ff2d92" stroke-width="1.5" fill="none"/>
-    <text x="22" y="66" font-size="26" aria-hidden="true">🧠</text>
-    <text x="70" y="34" font-family="'JetBrains Mono', monospace" font-size="11" font-weight="700" fill="#ff2d92" letter-spacing="0.08em">LAYER_01</text>
-    <text x="70" y="64" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="22" class="text-strong" letter-spacing="0.04em">ONEBRAIN</text>
-    <text x="70" y="80" font-family="'JetBrains Mono', monospace" font-size="9" fill="#ff2d92" letter-spacing="0.3em">PLUGIN · CLI · ORCHESTRATOR</text>
-    <text x="320" y="50" font-family="'JetBrains Mono', monospace" font-size="11" class="text-soft">The OS layer driving every harness consistently.</text>
-    <text x="320" y="68" font-family="'JetBrains Mono', monospace" font-size="11" class="text-fade">skills · hooks · sync · indexing · checkpoints</text>
-    <g transform="translate(640, 38)">
-      <rect width="124" height="22" fill="rgba(255,45,146,0.08)" stroke="#ff2d92" stroke-opacity="0.5" stroke-width="1"/>
-      <text x="62" y="15" font-family="'JetBrains Mono', monospace" font-size="9" fill="#ff2d92" letter-spacing="0.18em" text-anchor="middle">OS_LAYER</text>
+    <rect width="780" height="130" fill="url(#g-onebrain)"/>
+    <text class="icon-pulse" x="38" y="78" font-size="32" text-anchor="middle" dominant-baseline="central" aria-hidden="true">🧠</text>
+    <text x="74" y="42" font-family="'JetBrains Mono', monospace" font-size="13" font-weight="700" fill="rgba(255,255,255,0.85)" letter-spacing="0.08em">LAYER_01</text>
+    <text x="74" y="82" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="28" fill="#ffffff" letter-spacing="0.04em">ONEBRAIN</text>
+    <text x="74" y="112" font-family="'JetBrains Mono', monospace" font-size="11" fill="rgba(255,255,255,0.85)" letter-spacing="0.30em">PLUGIN · CLI · ORCHESTRATOR</text>
+    <text x="290" y="68" font-family="'JetBrains Mono', monospace" font-size="13" fill="#ffffff">The OS layer driving every harness consistently.</text>
+    <text x="290" y="98" font-family="'JetBrains Mono', monospace" font-size="13" fill="rgba(255,255,255,0.78)">skills · hooks · sync · indexing · checkpoints</text>
+    <g transform="translate(668, 53)">
+      <rect width="100" height="24" fill="#ffffff"/>
+      <text x="50" y="16" font-family="'JetBrains Mono', monospace" font-size="10" fill="#c91075" font-weight="700" letter-spacing="0.14em" text-anchor="middle">OS_LAYER</text>
     </g>
   </g>
 
-  <!-- arrow 01 → 02 -->
-  <g transform="translate(440, 214)">
-    <g class="arrow-pulse-down">
-      <line x1="-9" y1="0" x2="-9" y2="12" class="arrow-line" stroke-width="1.4"/>
-      <path d="M -14 9 L -9 16 L -4 9" fill="none" class="arrow-head" stroke-width="1.4"/>
-    </g>
-    <g class="arrow-pulse-up">
-      <line x1="9" y1="4" x2="9" y2="16" class="arrow-line" stroke-width="1.4"/>
-      <path d="M 4 7 L 9 0 L 14 7" fill="none" class="arrow-head" stroke-width="1.4"/>
-    </g>
+  <!-- arrow gap 1 -->
+  <g transform="translate(440, 240)">
+    <line class="flow flow-down" x1="-9" y1="0" x2="-9" y2="20"/>
+    <line class="flow flow-up"   x1="9"  y1="0" x2="9"  y2="20"/>
   </g>
 
   <!-- ════════ LAYER 02 — HARNESS ════════ -->
-  <g transform="translate(60, 234)">
-    <rect width="780" height="100" fill="none" stroke="#bc13fe" stroke-opacity="0.45" stroke-width="1"/>
-    <rect width="780" height="3" fill="url(#g-harness)" filter="url(#soft-glow)"/>
-    <path d="M 0 0 L 14 0 M 0 0 L 0 14" stroke="#bc13fe" stroke-width="1.5" fill="none"/>
-    <path d="M 766 100 L 780 100 M 780 86 L 780 100" stroke="#bc13fe" stroke-width="1.5" fill="none"/>
-    <text x="22" y="66" font-size="26" aria-hidden="true">🤖</text>
-    <text x="70" y="34" font-family="'JetBrains Mono', monospace" font-size="11" font-weight="700" fill="#bc13fe" letter-spacing="0.08em">LAYER_02</text>
-    <text x="70" y="64" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="22" class="text-strong" letter-spacing="0.04em">HARNESS</text>
-    <text x="70" y="80" font-family="'JetBrains Mono', monospace" font-size="9" fill="#bc13fe" letter-spacing="0.3em">AGENTIC_RUNTIME</text>
-    <text x="320" y="50" font-family="'JetBrains Mono', monospace" font-size="11" class="text-soft">Bring your own. Switch any time.</text>
-    <text x="320" y="68" font-family="'JetBrains Mono', monospace" font-size="11" class="text-fade">claude code · gemini cli · codex · qwen</text>
-    <g transform="translate(640, 38)">
-      <rect width="124" height="22" fill="rgba(188,19,254,0.08)" stroke="#bc13fe" stroke-opacity="0.5" stroke-width="1"/>
-      <text x="62" y="15" font-family="'JetBrains Mono', monospace" font-size="9" fill="#bc13fe" letter-spacing="0.18em" text-anchor="middle">BYO_HARNESS</text>
+  <g transform="translate(60, 260)">
+    <rect width="780" height="130" fill="url(#g-harness)"/>
+    <text class="icon-pulse" x="38" y="78" font-size="32" text-anchor="middle" dominant-baseline="central" aria-hidden="true" style="animation-delay: 0.65s;">🤖</text>
+    <text x="74" y="42" font-family="'JetBrains Mono', monospace" font-size="13" font-weight="700" fill="rgba(255,255,255,0.85)" letter-spacing="0.08em">LAYER_02</text>
+    <text x="74" y="82" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="28" fill="#ffffff" letter-spacing="0.04em">HARNESS</text>
+    <text x="74" y="112" font-family="'JetBrains Mono', monospace" font-size="11" fill="rgba(255,255,255,0.85)" letter-spacing="0.30em">AGENTIC_RUNTIME</text>
+    <text x="290" y="68" font-family="'JetBrains Mono', monospace" font-size="13" fill="#ffffff">Bring your own. Switch any time.</text>
+    <text x="290" y="98" font-family="'JetBrains Mono', monospace" font-size="13" fill="rgba(255,255,255,0.78)">claude code · gemini cli · codex · qwen</text>
+    <g transform="translate(668, 53)">
+      <rect width="100" height="24" fill="#ffffff"/>
+      <text x="50" y="16" font-family="'JetBrains Mono', monospace" font-size="10" fill="#7c1ade" font-weight="700" letter-spacing="0.14em" text-anchor="middle">BYO_HARNESS</text>
     </g>
   </g>
 
-  <!-- arrow 02 → 03 -->
-  <g transform="translate(440, 338)">
-    <g class="arrow-pulse-down delay-1">
-      <line x1="-9" y1="0" x2="-9" y2="12" class="arrow-line" stroke-width="1.4"/>
-      <path d="M -14 9 L -9 16 L -4 9" fill="none" class="arrow-head" stroke-width="1.4"/>
-    </g>
-    <g class="arrow-pulse-up delay-1">
-      <line x1="9" y1="4" x2="9" y2="16" class="arrow-line" stroke-width="1.4"/>
-      <path d="M 4 7 L 9 0 L 14 7" fill="none" class="arrow-head" stroke-width="1.4"/>
-    </g>
+  <!-- arrow gap 2 -->
+  <g transform="translate(440, 390)">
+    <line class="flow flow-down" x1="-9" y1="0" x2="-9" y2="20" style="animation-delay: 0.3s;"/>
+    <line class="flow flow-up"   x1="9"  y1="0" x2="9"  y2="20" style="animation-delay: 0.3s;"/>
   </g>
 
   <!-- ════════ LAYER 03 — LLM ════════ -->
-  <g transform="translate(60, 358)">
-    <rect width="780" height="100" fill="none" stroke="#c8ff00" stroke-opacity="0.45" stroke-width="1"/>
-    <rect width="780" height="3" fill="url(#g-llm)" filter="url(#soft-glow)"/>
-    <path d="M 0 0 L 14 0 M 0 0 L 0 14" stroke="#c8ff00" stroke-width="1.5" fill="none"/>
-    <path d="M 766 100 L 780 100 M 780 86 L 780 100" stroke="#c8ff00" stroke-width="1.5" fill="none"/>
-    <text x="22" y="66" font-size="26" aria-hidden="true">✨</text>
-    <text x="70" y="34" font-family="'JetBrains Mono', monospace" font-size="11" font-weight="700" fill="#c8ff00" letter-spacing="0.08em">LAYER_03</text>
-    <text x="70" y="64" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="22" class="text-strong" letter-spacing="0.04em">LLM</text>
-    <text x="70" y="80" font-family="'JetBrains Mono', monospace" font-size="9" fill="#c8ff00" letter-spacing="0.3em">INTELLIGENCE_SOURCE</text>
-    <text x="320" y="50" font-family="'JetBrains Mono', monospace" font-size="11" class="text-soft">Powered by anything. OneBrain stays the same.</text>
-    <text x="320" y="68" font-family="'JetBrains Mono', monospace" font-size="11" class="text-fade">local: mlx, ollama · cloud: claude, gemini, gpt</text>
-    <g transform="translate(640, 38)">
-      <rect width="124" height="22" fill="rgba(200,255,0,0.08)" stroke="#c8ff00" stroke-opacity="0.5" stroke-width="1"/>
-      <text x="62" y="15" font-family="'JetBrains Mono', monospace" font-size="9" fill="#c8ff00" letter-spacing="0.18em" text-anchor="middle">RAW_TOKENS</text>
+  <g transform="translate(60, 410)">
+    <rect width="780" height="130" fill="url(#g-llm)"/>
+    <text class="icon-pulse" x="38" y="78" font-size="32" text-anchor="middle" dominant-baseline="central" aria-hidden="true" style="animation-delay: 1.3s;">✨</text>
+    <text x="74" y="42" font-family="'JetBrains Mono', monospace" font-size="13" font-weight="700" fill="rgba(255,255,255,0.85)" letter-spacing="0.08em">LAYER_03</text>
+    <text x="74" y="82" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="28" fill="#ffffff" letter-spacing="0.04em">LLM</text>
+    <text x="74" y="112" font-family="'JetBrains Mono', monospace" font-size="11" fill="rgba(255,255,255,0.85)" letter-spacing="0.30em">INTELLIGENCE_SOURCE</text>
+    <text x="290" y="68" font-family="'JetBrains Mono', monospace" font-size="13" fill="#ffffff">Powered by anything. OneBrain stays the same.</text>
+    <text x="290" y="98" font-family="'JetBrains Mono', monospace" font-size="13" fill="rgba(255,255,255,0.78)">local: mlx, ollama · cloud: claude, gemini, gpt</text>
+    <g transform="translate(668, 53)">
+      <rect width="100" height="24" fill="#ffffff"/>
+      <text x="50" y="16" font-family="'JetBrains Mono', monospace" font-size="10" fill="#4d6d00" font-weight="700" letter-spacing="0.14em" text-anchor="middle">RAW_TOKENS</text>
     </g>
   </g>
 
-  <!-- arrow 03 → 04 -->
-  <g transform="translate(440, 462)">
-    <g class="arrow-pulse-down delay-2">
-      <line x1="-9" y1="0" x2="-9" y2="12" class="arrow-line" stroke-width="1.4"/>
-      <path d="M -14 9 L -9 16 L -4 9" fill="none" class="arrow-head" stroke-width="1.4"/>
-    </g>
-    <g class="arrow-pulse-up delay-2">
-      <line x1="9" y1="4" x2="9" y2="16" class="arrow-line" stroke-width="1.4"/>
-      <path d="M 4 7 L 9 0 L 14 7" fill="none" class="arrow-head" stroke-width="1.4"/>
-    </g>
+  <!-- arrow gap 3 -->
+  <g transform="translate(440, 540)">
+    <line class="flow flow-down" x1="-9" y1="0" x2="-9" y2="20" style="animation-delay: 0.6s;"/>
+    <line class="flow flow-up"   x1="9"  y1="0" x2="9"  y2="20" style="animation-delay: 0.6s;"/>
   </g>
 
-  <!-- ════════ LAYER 04 — OBSIDIAN VAULT (base · source of truth) ════════ -->
-  <g transform="translate(60, 482)">
-    <rect width="780" height="100" fill="none" stroke="#00f3ff" stroke-opacity="0.45" stroke-width="1"/>
-    <rect width="780" height="3" fill="url(#g-vault)" filter="url(#soft-glow)"/>
-    <path d="M 0 0 L 14 0 M 0 0 L 0 14" stroke="#00f3ff" stroke-width="1.5" fill="none"/>
-    <path d="M 766 100 L 780 100 M 780 86 L 780 100" stroke="#00f3ff" stroke-width="1.5" fill="none"/>
-    <text x="22" y="66" font-size="26" aria-hidden="true">💎</text>
-    <text x="70" y="34" font-family="'JetBrains Mono', monospace" font-size="11" font-weight="700" fill="#00f3ff" letter-spacing="0.08em">LAYER_04</text>
-    <text x="70" y="64" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="22" class="text-strong" letter-spacing="0.04em">OBSIDIAN VAULT</text>
-    <text x="70" y="80" font-family="'JetBrains Mono', monospace" font-size="9" fill="#00f3ff" letter-spacing="0.3em">SOURCE_OF_TRUTH</text>
-    <text x="320" y="50" font-family="'JetBrains Mono', monospace" font-size="11" class="text-soft">Plain Markdown · durable state for every layer.</text>
-    <text x="320" y="68" font-family="'JetBrains Mono', monospace" font-size="11" class="text-fade">notes · memory · decisions · knowledge graph</text>
-    <g transform="translate(640, 38)">
-      <rect width="124" height="22" fill="rgba(0,243,255,0.08)" stroke="#00f3ff" stroke-opacity="0.5" stroke-width="1"/>
-      <text x="62" y="15" font-family="'JetBrains Mono', monospace" font-size="9" fill="#00f3ff" letter-spacing="0.18em" text-anchor="middle">BASE_LAYER</text>
+  <!-- ════════ LAYER 04 — OBSIDIAN VAULT ════════ -->
+  <g transform="translate(60, 560)">
+    <rect width="780" height="130" fill="url(#g-vault)"/>
+    <text class="icon-pulse" x="38" y="78" font-size="32" text-anchor="middle" dominant-baseline="central" aria-hidden="true" style="animation-delay: 1.95s;">💎</text>
+    <text x="74" y="42" font-family="'JetBrains Mono', monospace" font-size="13" font-weight="700" fill="rgba(255,255,255,0.85)" letter-spacing="0.08em">LAYER_04</text>
+    <text x="74" y="82" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="28" fill="#ffffff" letter-spacing="0.04em">OBSIDIAN VAULT</text>
+    <text x="74" y="112" font-family="'JetBrains Mono', monospace" font-size="11" fill="rgba(255,255,255,0.85)" letter-spacing="0.30em">SOURCE_OF_TRUTH</text>
+    <text x="290" y="68" font-family="'JetBrains Mono', monospace" font-size="13" fill="#ffffff">Plain Markdown · durable state for every layer.</text>
+    <text x="290" y="98" font-family="'JetBrains Mono', monospace" font-size="13" fill="rgba(255,255,255,0.78)">notes · memory · decisions · knowledge graph</text>
+    <g transform="translate(668, 53)">
+      <rect width="100" height="24" fill="#ffffff"/>
+      <text x="50" y="16" font-family="'JetBrains Mono', monospace" font-size="10" fill="#00788c" font-weight="700" letter-spacing="0.14em" text-anchor="middle">BASE_LAYER</text>
     </g>
   </g>
 

--- a/assets/diagrams/harness-os-stack-light.svg
+++ b/assets/diagrams/harness-os-stack-light.svg
@@ -1,53 +1,45 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 100 880 492" width="880" height="492" role="img" aria-labelledby="title desc" font-family="'Chakra Petch', 'Inter', ui-sans-serif, system-ui, sans-serif">
-  <title id="title">OneBrain Harness OS — 4-Layer Architecture (light)</title>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 100 880 600" width="880" height="600" role="img" aria-labelledby="title desc" font-family="'Chakra Petch', 'Inter', ui-sans-serif, system-ui, sans-serif">
+  <title id="title">OneBrain Harness OS — 4-Layer Architecture</title>
   <desc id="desc">Four stacked layers from top to bottom: OneBrain (plugin and CLI — skills, hooks, vault sync, indexing, checkpoints), Harness (Claude Code, Gemini CLI, Codex, Qwen), LLM (local, cloud, or API), and Obsidian Vault as the source of truth (plain Markdown notes, memory, decisions, knowledge graph).</desc>
 
   <style>
-    .text-strong { fill: #0a0a14; }
-    .text-soft   { fill: rgba(10,10,20,0.82); }
-    .text-fade   { fill: rgba(10,10,20,0.65); }
-    .text-mute   { fill: rgba(10,10,20,0.50); }
-    .frame-corner { stroke: rgba(10,10,20,0.40); }
-    .grid-line    { stroke: rgba(10,10,20,0.07); }
-    .divider      { stroke: rgba(10,10,20,0.18); }
-    .arrow-line   { stroke: rgba(10,10,20,0.65); }
-    .arrow-head   { stroke: rgba(10,10,20,0.75); }
+    .flow { stroke: #0a0a14; stroke-width: 2; stroke-linecap: round; stroke-dasharray: 3 5; fill: none; }
+    .flow-down { animation: flow-down 0.9s linear infinite; }
+    .flow-up   { animation: flow-up   0.9s linear infinite; }
+    @keyframes flow-down { to { stroke-dashoffset: -8; } }
+    @keyframes flow-up   { to { stroke-dashoffset:  8; } }
 
-    .arrow-pulse-down { animation: arrow-down-pulse 4.5s linear infinite; }
-    .arrow-pulse-up   { animation: arrow-up-pulse   4.5s linear infinite; }
-    .delay-1 { animation-delay: 1.5s; }
-    .delay-2 { animation-delay: 3s; }
-
-    @keyframes arrow-down-pulse {
-      0%, 22%, 100% { opacity: 0.6; }
-      6%            { opacity: 1; }
+    .icon-pulse {
+      transform-box: fill-box;
+      transform-origin: center;
+      animation: icon-pulse 2.6s ease-in-out infinite;
     }
-    @keyframes arrow-up-pulse {
-      0%, 50%, 72%, 100% { opacity: 0.6; }
-      56%                { opacity: 1; }
+    @keyframes icon-pulse {
+      0%, 100% { transform: scale(1);    }
+      50%      { transform: scale(1.08); }
     }
 
     @media (prefers-reduced-motion: reduce) {
-      .arrow-pulse-down, .arrow-pulse-up { animation: none; opacity: 0.6; }
+      .icon-pulse, .flow-down, .flow-up { animation: none; transform: none; }
     }
   </style>
 
   <defs>
     <linearGradient id="g-onebrain" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%"   stop-color="#c91075" stop-opacity="0.95"/>
-      <stop offset="100%" stop-color="#c91075" stop-opacity="0.05"/>
+      <stop offset="0%"   stop-color="#e62a93" stop-opacity="1"/>
+      <stop offset="100%" stop-color="#c91075" stop-opacity="1"/>
     </linearGradient>
     <linearGradient id="g-harness" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%"   stop-color="#7c1ade" stop-opacity="0.95"/>
-      <stop offset="100%" stop-color="#7c1ade" stop-opacity="0.05"/>
+      <stop offset="0%"   stop-color="#a855f7" stop-opacity="1"/>
+      <stop offset="100%" stop-color="#7c1ade" stop-opacity="1"/>
     </linearGradient>
     <linearGradient id="g-llm" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%"   stop-color="#4d6d00" stop-opacity="0.95"/>
-      <stop offset="100%" stop-color="#4d6d00" stop-opacity="0.05"/>
+      <stop offset="0%"   stop-color="#7a9d10" stop-opacity="1"/>
+      <stop offset="100%" stop-color="#4d6d00" stop-opacity="1"/>
     </linearGradient>
     <linearGradient id="g-vault" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%"   stop-color="#00788c" stop-opacity="0.95"/>
-      <stop offset="100%" stop-color="#00788c" stop-opacity="0.05"/>
+      <stop offset="0%"   stop-color="#00a3bc" stop-opacity="1"/>
+      <stop offset="100%" stop-color="#00788c" stop-opacity="1"/>
     </linearGradient>
 
     <linearGradient id="spine-grad" x1="0" y1="0" x2="0" y2="1">
@@ -56,129 +48,85 @@
       <stop offset="66%"  stop-color="#4d6d00" stop-opacity="0.75"/>
       <stop offset="100%" stop-color="#00788c" stop-opacity="0.75"/>
     </linearGradient>
-
-    <pattern id="grid-pattern" width="40" height="40" patternUnits="userSpaceOnUse">
-      <path d="M 40 0 L 0 0 0 40" fill="none" class="grid-line" stroke-width="0.5"/>
-    </pattern>
-
-    <filter id="soft-glow" x="-20%" y="-50%" width="140%" height="200%">
-      <feGaussianBlur stdDeviation="1.5" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
   </defs>
 
-  <!-- Vertical accent spine running through all layers -->
-  <line x1="48" y1="110" x2="48" y2="582" stroke="url(#spine-grad)" stroke-width="2" stroke-dasharray="2 4" opacity="0.6"/>
-
+  <line x1="48" y1="110" x2="48" y2="690" stroke="url(#spine-grad)" stroke-width="2" stroke-dasharray="2 4" opacity="0.6"/>
 
   <!-- ════════ LAYER 01 — ONEBRAIN ════════ -->
   <g transform="translate(60, 110)">
-    <rect width="780" height="100" fill="none" stroke="#c91075" stroke-opacity="0.85" stroke-width="1"/>
-    <rect width="780" height="3" fill="url(#g-onebrain)" filter="url(#soft-glow)"/>
-    <path d="M 0 0 L 14 0 M 0 0 L 0 14" stroke="#c91075" stroke-width="1.5" fill="none"/>
-    <path d="M 766 100 L 780 100 M 780 86 L 780 100" stroke="#c91075" stroke-width="1.5" fill="none"/>
-    <text x="22" y="66" font-size="26" aria-hidden="true">🧠</text>
-    <text x="70" y="34" font-family="'JetBrains Mono', monospace" font-size="11" font-weight="700" fill="#c91075" letter-spacing="0.08em">LAYER_01</text>
-    <text x="70" y="64" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="22" class="text-strong" letter-spacing="0.04em">ONEBRAIN</text>
-    <text x="70" y="80" font-family="'JetBrains Mono', monospace" font-size="9" fill="#c91075" letter-spacing="0.3em">PLUGIN · CLI · ORCHESTRATOR</text>
-    <text x="320" y="50" font-family="'JetBrains Mono', monospace" font-size="11" class="text-soft">The OS layer driving every harness consistently.</text>
-    <text x="320" y="68" font-family="'JetBrains Mono', monospace" font-size="11" class="text-fade">skills · hooks · sync · indexing · checkpoints</text>
-    <g transform="translate(640, 38)">
-      <rect width="124" height="22" fill="rgba(201,16,117,0.18)" stroke="#c91075" stroke-opacity="1.0" stroke-width="1"/>
-      <text x="62" y="15" font-family="'JetBrains Mono', monospace" font-size="9" fill="#c91075" letter-spacing="0.18em" text-anchor="middle">OS_LAYER</text>
+    <rect width="780" height="130" fill="url(#g-onebrain)"/>
+    <text class="icon-pulse" x="38" y="78" font-size="32" text-anchor="middle" dominant-baseline="central" aria-hidden="true">🧠</text>
+    <text x="74" y="42" font-family="'JetBrains Mono', monospace" font-size="13" font-weight="700" fill="rgba(255,255,255,0.85)" letter-spacing="0.08em">LAYER_01</text>
+    <text x="74" y="82" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="28" fill="#ffffff" letter-spacing="0.04em">ONEBRAIN</text>
+    <text x="74" y="112" font-family="'JetBrains Mono', monospace" font-size="11" fill="rgba(255,255,255,0.85)" letter-spacing="0.30em">PLUGIN · CLI · ORCHESTRATOR</text>
+    <text x="290" y="68" font-family="'JetBrains Mono', monospace" font-size="13" fill="#ffffff">The OS layer driving every harness consistently.</text>
+    <text x="290" y="98" font-family="'JetBrains Mono', monospace" font-size="13" fill="rgba(255,255,255,0.78)">skills · hooks · sync · indexing · checkpoints</text>
+    <g transform="translate(668, 53)">
+      <rect width="100" height="24" fill="#ffffff"/>
+      <text x="50" y="16" font-family="'JetBrains Mono', monospace" font-size="10" fill="#c91075" font-weight="700" letter-spacing="0.14em" text-anchor="middle">OS_LAYER</text>
     </g>
   </g>
 
-  <!-- arrow 01 → 02 -->
-  <g transform="translate(440, 214)">
-    <g class="arrow-pulse-down">
-      <line x1="-9" y1="0" x2="-9" y2="12" class="arrow-line" stroke-width="1.4"/>
-      <path d="M -14 9 L -9 16 L -4 9" fill="none" class="arrow-head" stroke-width="1.4"/>
-    </g>
-    <g class="arrow-pulse-up">
-      <line x1="9" y1="4" x2="9" y2="16" class="arrow-line" stroke-width="1.4"/>
-      <path d="M 4 7 L 9 0 L 14 7" fill="none" class="arrow-head" stroke-width="1.4"/>
-    </g>
+  <!-- arrow gap 1 -->
+  <g transform="translate(440, 240)">
+    <line class="flow flow-down" x1="-9" y1="0" x2="-9" y2="20"/>
+    <line class="flow flow-up"   x1="9"  y1="0" x2="9"  y2="20"/>
   </g>
 
   <!-- ════════ LAYER 02 — HARNESS ════════ -->
-  <g transform="translate(60, 234)">
-    <rect width="780" height="100" fill="none" stroke="#7c1ade" stroke-opacity="0.85" stroke-width="1"/>
-    <rect width="780" height="3" fill="url(#g-harness)" filter="url(#soft-glow)"/>
-    <path d="M 0 0 L 14 0 M 0 0 L 0 14" stroke="#7c1ade" stroke-width="1.5" fill="none"/>
-    <path d="M 766 100 L 780 100 M 780 86 L 780 100" stroke="#7c1ade" stroke-width="1.5" fill="none"/>
-    <text x="22" y="66" font-size="26" aria-hidden="true">🤖</text>
-    <text x="70" y="34" font-family="'JetBrains Mono', monospace" font-size="11" font-weight="700" fill="#7c1ade" letter-spacing="0.08em">LAYER_02</text>
-    <text x="70" y="64" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="22" class="text-strong" letter-spacing="0.04em">HARNESS</text>
-    <text x="70" y="80" font-family="'JetBrains Mono', monospace" font-size="9" fill="#7c1ade" letter-spacing="0.3em">AGENTIC_RUNTIME</text>
-    <text x="320" y="50" font-family="'JetBrains Mono', monospace" font-size="11" class="text-soft">Bring your own. Switch any time.</text>
-    <text x="320" y="68" font-family="'JetBrains Mono', monospace" font-size="11" class="text-fade">claude code · gemini cli · codex · qwen</text>
-    <g transform="translate(640, 38)">
-      <rect width="124" height="22" fill="rgba(124,26,222,0.18)" stroke="#7c1ade" stroke-opacity="1.0" stroke-width="1"/>
-      <text x="62" y="15" font-family="'JetBrains Mono', monospace" font-size="9" fill="#7c1ade" letter-spacing="0.18em" text-anchor="middle">BYO_HARNESS</text>
+  <g transform="translate(60, 260)">
+    <rect width="780" height="130" fill="url(#g-harness)"/>
+    <text class="icon-pulse" x="38" y="78" font-size="32" text-anchor="middle" dominant-baseline="central" aria-hidden="true" style="animation-delay: 0.65s;">🤖</text>
+    <text x="74" y="42" font-family="'JetBrains Mono', monospace" font-size="13" font-weight="700" fill="rgba(255,255,255,0.85)" letter-spacing="0.08em">LAYER_02</text>
+    <text x="74" y="82" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="28" fill="#ffffff" letter-spacing="0.04em">HARNESS</text>
+    <text x="74" y="112" font-family="'JetBrains Mono', monospace" font-size="11" fill="rgba(255,255,255,0.85)" letter-spacing="0.30em">AGENTIC_RUNTIME</text>
+    <text x="290" y="68" font-family="'JetBrains Mono', monospace" font-size="13" fill="#ffffff">Bring your own. Switch any time.</text>
+    <text x="290" y="98" font-family="'JetBrains Mono', monospace" font-size="13" fill="rgba(255,255,255,0.78)">claude code · gemini cli · codex · qwen</text>
+    <g transform="translate(668, 53)">
+      <rect width="100" height="24" fill="#ffffff"/>
+      <text x="50" y="16" font-family="'JetBrains Mono', monospace" font-size="10" fill="#7c1ade" font-weight="700" letter-spacing="0.14em" text-anchor="middle">BYO_HARNESS</text>
     </g>
   </g>
 
-  <!-- arrow 02 → 03 -->
-  <g transform="translate(440, 338)">
-    <g class="arrow-pulse-down delay-1">
-      <line x1="-9" y1="0" x2="-9" y2="12" class="arrow-line" stroke-width="1.4"/>
-      <path d="M -14 9 L -9 16 L -4 9" fill="none" class="arrow-head" stroke-width="1.4"/>
-    </g>
-    <g class="arrow-pulse-up delay-1">
-      <line x1="9" y1="4" x2="9" y2="16" class="arrow-line" stroke-width="1.4"/>
-      <path d="M 4 7 L 9 0 L 14 7" fill="none" class="arrow-head" stroke-width="1.4"/>
-    </g>
+  <!-- arrow gap 2 -->
+  <g transform="translate(440, 390)">
+    <line class="flow flow-down" x1="-9" y1="0" x2="-9" y2="20" style="animation-delay: 0.3s;"/>
+    <line class="flow flow-up"   x1="9"  y1="0" x2="9"  y2="20" style="animation-delay: 0.3s;"/>
   </g>
 
   <!-- ════════ LAYER 03 — LLM ════════ -->
-  <g transform="translate(60, 358)">
-    <rect width="780" height="100" fill="none" stroke="#4d6d00" stroke-opacity="0.85" stroke-width="1"/>
-    <rect width="780" height="3" fill="url(#g-llm)" filter="url(#soft-glow)"/>
-    <path d="M 0 0 L 14 0 M 0 0 L 0 14" stroke="#4d6d00" stroke-width="1.5" fill="none"/>
-    <path d="M 766 100 L 780 100 M 780 86 L 780 100" stroke="#4d6d00" stroke-width="1.5" fill="none"/>
-    <text x="22" y="66" font-size="26" aria-hidden="true">✨</text>
-    <text x="70" y="34" font-family="'JetBrains Mono', monospace" font-size="11" font-weight="700" fill="#4d6d00" letter-spacing="0.08em">LAYER_03</text>
-    <text x="70" y="64" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="22" class="text-strong" letter-spacing="0.04em">LLM</text>
-    <text x="70" y="80" font-family="'JetBrains Mono', monospace" font-size="9" fill="#4d6d00" letter-spacing="0.3em">INTELLIGENCE_SOURCE</text>
-    <text x="320" y="50" font-family="'JetBrains Mono', monospace" font-size="11" class="text-soft">Powered by anything. OneBrain stays the same.</text>
-    <text x="320" y="68" font-family="'JetBrains Mono', monospace" font-size="11" class="text-fade">local: mlx, ollama · cloud: claude, gemini, gpt</text>
-    <g transform="translate(640, 38)">
-      <rect width="124" height="22" fill="rgba(77,109,0,0.18)" stroke="#4d6d00" stroke-opacity="1.0" stroke-width="1"/>
-      <text x="62" y="15" font-family="'JetBrains Mono', monospace" font-size="9" fill="#4d6d00" letter-spacing="0.18em" text-anchor="middle">RAW_TOKENS</text>
+  <g transform="translate(60, 410)">
+    <rect width="780" height="130" fill="url(#g-llm)"/>
+    <text class="icon-pulse" x="38" y="78" font-size="32" text-anchor="middle" dominant-baseline="central" aria-hidden="true" style="animation-delay: 1.3s;">✨</text>
+    <text x="74" y="42" font-family="'JetBrains Mono', monospace" font-size="13" font-weight="700" fill="rgba(255,255,255,0.85)" letter-spacing="0.08em">LAYER_03</text>
+    <text x="74" y="82" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="28" fill="#ffffff" letter-spacing="0.04em">LLM</text>
+    <text x="74" y="112" font-family="'JetBrains Mono', monospace" font-size="11" fill="rgba(255,255,255,0.85)" letter-spacing="0.30em">INTELLIGENCE_SOURCE</text>
+    <text x="290" y="68" font-family="'JetBrains Mono', monospace" font-size="13" fill="#ffffff">Powered by anything. OneBrain stays the same.</text>
+    <text x="290" y="98" font-family="'JetBrains Mono', monospace" font-size="13" fill="rgba(255,255,255,0.78)">local: mlx, ollama · cloud: claude, gemini, gpt</text>
+    <g transform="translate(668, 53)">
+      <rect width="100" height="24" fill="#ffffff"/>
+      <text x="50" y="16" font-family="'JetBrains Mono', monospace" font-size="10" fill="#4d6d00" font-weight="700" letter-spacing="0.14em" text-anchor="middle">RAW_TOKENS</text>
     </g>
   </g>
 
-  <!-- arrow 03 → 04 -->
-  <g transform="translate(440, 462)">
-    <g class="arrow-pulse-down delay-2">
-      <line x1="-9" y1="0" x2="-9" y2="12" class="arrow-line" stroke-width="1.4"/>
-      <path d="M -14 9 L -9 16 L -4 9" fill="none" class="arrow-head" stroke-width="1.4"/>
-    </g>
-    <g class="arrow-pulse-up delay-2">
-      <line x1="9" y1="4" x2="9" y2="16" class="arrow-line" stroke-width="1.4"/>
-      <path d="M 4 7 L 9 0 L 14 7" fill="none" class="arrow-head" stroke-width="1.4"/>
-    </g>
+  <!-- arrow gap 3 -->
+  <g transform="translate(440, 540)">
+    <line class="flow flow-down" x1="-9" y1="0" x2="-9" y2="20" style="animation-delay: 0.6s;"/>
+    <line class="flow flow-up"   x1="9"  y1="0" x2="9"  y2="20" style="animation-delay: 0.6s;"/>
   </g>
 
-  <!-- ════════ LAYER 04 — OBSIDIAN VAULT (base · source of truth) ════════ -->
-  <g transform="translate(60, 482)">
-    <rect width="780" height="100" fill="none" stroke="#00788c" stroke-opacity="0.85" stroke-width="1"/>
-    <rect width="780" height="3" fill="url(#g-vault)" filter="url(#soft-glow)"/>
-    <path d="M 0 0 L 14 0 M 0 0 L 0 14" stroke="#00788c" stroke-width="1.5" fill="none"/>
-    <path d="M 766 100 L 780 100 M 780 86 L 780 100" stroke="#00788c" stroke-width="1.5" fill="none"/>
-    <text x="22" y="66" font-size="26" aria-hidden="true">💎</text>
-    <text x="70" y="34" font-family="'JetBrains Mono', monospace" font-size="11" font-weight="700" fill="#00788c" letter-spacing="0.08em">LAYER_04</text>
-    <text x="70" y="64" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="22" class="text-strong" letter-spacing="0.04em">OBSIDIAN VAULT</text>
-    <text x="70" y="80" font-family="'JetBrains Mono', monospace" font-size="9" fill="#00788c" letter-spacing="0.3em">SOURCE_OF_TRUTH</text>
-    <text x="320" y="50" font-family="'JetBrains Mono', monospace" font-size="11" class="text-soft">Plain Markdown · durable state for every layer.</text>
-    <text x="320" y="68" font-family="'JetBrains Mono', monospace" font-size="11" class="text-fade">notes · memory · decisions · knowledge graph</text>
-    <g transform="translate(640, 38)">
-      <rect width="124" height="22" fill="rgba(0,120,140,0.18)" stroke="#00788c" stroke-opacity="1.0" stroke-width="1"/>
-      <text x="62" y="15" font-family="'JetBrains Mono', monospace" font-size="9" fill="#00788c" letter-spacing="0.18em" text-anchor="middle">BASE_LAYER</text>
+  <!-- ════════ LAYER 04 — OBSIDIAN VAULT ════════ -->
+  <g transform="translate(60, 560)">
+    <rect width="780" height="130" fill="url(#g-vault)"/>
+    <text class="icon-pulse" x="38" y="78" font-size="32" text-anchor="middle" dominant-baseline="central" aria-hidden="true" style="animation-delay: 1.95s;">💎</text>
+    <text x="74" y="42" font-family="'JetBrains Mono', monospace" font-size="13" font-weight="700" fill="rgba(255,255,255,0.85)" letter-spacing="0.08em">LAYER_04</text>
+    <text x="74" y="82" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="28" fill="#ffffff" letter-spacing="0.04em">OBSIDIAN VAULT</text>
+    <text x="74" y="112" font-family="'JetBrains Mono', monospace" font-size="11" fill="rgba(255,255,255,0.85)" letter-spacing="0.30em">SOURCE_OF_TRUTH</text>
+    <text x="290" y="68" font-family="'JetBrains Mono', monospace" font-size="13" fill="#ffffff">Plain Markdown · durable state for every layer.</text>
+    <text x="290" y="98" font-family="'JetBrains Mono', monospace" font-size="13" fill="rgba(255,255,255,0.78)">notes · memory · decisions · knowledge graph</text>
+    <g transform="translate(668, 53)">
+      <rect width="100" height="24" fill="#ffffff"/>
+      <text x="50" y="16" font-family="'JetBrains Mono', monospace" font-size="10" fill="#00788c" font-weight="700" letter-spacing="0.14em" text-anchor="middle">BASE_LAYER</text>
     </g>
   </g>
 

--- a/assets/diagrams/memory-tiers-dark.svg
+++ b/assets/diagrams/memory-tiers-dark.svg
@@ -1,174 +1,132 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 100 880 360" width="880" height="360" role="img" aria-labelledby="title desc" font-family="'Chakra Petch', 'Inter', ui-sans-serif, system-ui, sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 100 880 600" width="880" height="600" role="img" aria-labelledby="title desc" font-family="'Chakra Petch', 'Inter', ui-sans-serif, system-ui, sans-serif">
   <title id="title">Memory tiers — four-stage persistence</title>
   <desc id="desc">Four memory tiers stacked top to bottom. Tier 1 working memory in the inbox and current session, Tier 2 episodic memory in 07-logs, Tier 3 semantic memory in MEMORY.md and the memory folder, Tier 4 distilled knowledge in 03-knowledge. Knowledge sinks downward as it gets validated.</desc>
 
   <style>
-    .text-strong { fill: #ffffff; }
-    .text-soft   { fill: rgba(255,255,255,0.70); }
-    .text-fade   { fill: rgba(255,255,255,0.50); }
-    .text-mute   { fill: rgba(255,255,255,0.35); }
-    .frame-corner { stroke: rgba(255,255,255,0.22); }
-    .grid-line    { stroke: rgba(255,255,255,0.06); }
-    .divider      { stroke: rgba(255,255,255,0.10); }
-    .arrow-line   { stroke: rgba(255,255,255,0.50); }
-    .arrow-head   { stroke: rgba(255,255,255,0.60); }
+    .flow { stroke: #ffffff; stroke-width: 2; stroke-linecap: round; stroke-dasharray: 3 5; fill: none; }
+    .flow-down { animation: flow-down 0.9s linear infinite; }
+    .flow-up   { animation: flow-up   0.9s linear infinite; }
+    @keyframes flow-down { to { stroke-dashoffset: -8; } }
+    @keyframes flow-up   { to { stroke-dashoffset:  8; } }
 
-    .promote { animation: promote-pulse 4.5s linear infinite; }
-    .recall  { animation: recall-pulse 4.5s linear infinite; }
-    .delay-1 { animation-delay: 1.5s; }
-    .delay-2 { animation-delay: 3s; }
-    @keyframes promote-pulse {
-      0%, 22%, 100% { opacity: 0.55; }
-      6%            { opacity: 1; }
+    .icon-pulse {
+      transform-box: fill-box;
+      transform-origin: center;
+      animation: icon-pulse 2.6s ease-in-out infinite;
     }
-    @keyframes recall-pulse {
-      0%, 50%, 72%, 100% { opacity: 0.55; }
-      56%                { opacity: 1; }
+    @keyframes icon-pulse {
+      0%, 100% { transform: scale(1);    }
+      50%      { transform: scale(1.08); }
     }
 
     @media (prefers-reduced-motion: reduce) {
-      .promote, .recall { animation: none; opacity: 0.55; }
+      .icon-pulse, .flow-down, .flow-up { animation: none; transform: none; }
     }
   </style>
 
   <defs>
-    <linearGradient id="g-t1" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%"   stop-color="#ff2d92" stop-opacity="0.95"/>
-      <stop offset="100%" stop-color="#ff2d92" stop-opacity="0.05"/>
+    <linearGradient id="g-t1-fill" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%"   stop-color="#e62a93" stop-opacity="1"/>
+      <stop offset="100%" stop-color="#c91075" stop-opacity="1"/>
     </linearGradient>
-    <linearGradient id="g-t2" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%"   stop-color="#bc13fe" stop-opacity="0.95"/>
-      <stop offset="100%" stop-color="#bc13fe" stop-opacity="0.05"/>
+    <linearGradient id="g-t2-fill" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%"   stop-color="#a855f7" stop-opacity="1"/>
+      <stop offset="100%" stop-color="#7c1ade" stop-opacity="1"/>
     </linearGradient>
-    <linearGradient id="g-t3" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%"   stop-color="#c8ff00" stop-opacity="0.95"/>
-      <stop offset="100%" stop-color="#c8ff00" stop-opacity="0.05"/>
+    <linearGradient id="g-t3-fill" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%"   stop-color="#7a9d10" stop-opacity="1"/>
+      <stop offset="100%" stop-color="#4d6d00" stop-opacity="1"/>
     </linearGradient>
-    <linearGradient id="g-t4" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%"   stop-color="#00f3ff" stop-opacity="0.95"/>
-      <stop offset="100%" stop-color="#00f3ff" stop-opacity="0.05"/>
+    <linearGradient id="g-t4-fill" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%"   stop-color="#00a3bc" stop-opacity="1"/>
+      <stop offset="100%" stop-color="#00788c" stop-opacity="1"/>
     </linearGradient>
 
     <linearGradient id="spine-grad" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%"   stop-color="#ff2d92" stop-opacity="0.6"/>
-      <stop offset="33%"  stop-color="#bc13fe" stop-opacity="0.6"/>
-      <stop offset="66%"  stop-color="#c8ff00" stop-opacity="0.6"/>
-      <stop offset="100%" stop-color="#00f3ff" stop-opacity="0.6"/>
+      <stop offset="0%"   stop-color="#e62a93" stop-opacity="0.85"/>
+      <stop offset="33%"  stop-color="#a855f7" stop-opacity="0.85"/>
+      <stop offset="66%"  stop-color="#7a9d10" stop-opacity="0.85"/>
+      <stop offset="100%" stop-color="#00a3bc" stop-opacity="0.85"/>
     </linearGradient>
-
-    <pattern id="grid-pattern" width="40" height="40" patternUnits="userSpaceOnUse">
-      <path d="M 40 0 L 0 0 0 40" fill="none" class="grid-line" stroke-width="0.5"/>
-    </pattern>
-
-    <filter id="soft-glow" x="-20%" y="-50%" width="140%" height="200%">
-      <feGaussianBlur stdDeviation="2" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
   </defs>
 
-  <line x1="48" y1="110" x2="48" y2="450" stroke="url(#spine-grad)" stroke-width="2" stroke-dasharray="2 4" opacity="0.55"/>
+  <line x1="48" y1="110" x2="48" y2="690" stroke="url(#spine-grad)" stroke-width="2" stroke-dasharray="2 4" opacity="0.7"/>
 
+  <!-- ════════ TIER 01 — WORKING ════════ -->
   <g transform="translate(60, 110)">
-    <rect width="780" height="70" fill="none" stroke="#ff2d92" stroke-opacity="0.45" stroke-width="1"/>
-    <rect width="780" height="3" fill="url(#g-t1)" filter="url(#soft-glow)"/>
-    <path d="M 0 0 L 14 0 M 0 0 L 0 14" stroke="#ff2d92" stroke-width="1.5" fill="none"/>
-    <path d="M 766 70 L 780 70 M 780 56 L 780 70" stroke="#ff2d92" stroke-width="1.5" fill="none"/>
-    <text x="22" y="48" font-size="22" aria-hidden="true">📥</text>
-    <text x="70" y="26" font-family="'JetBrains Mono', monospace" font-size="11" font-weight="700" fill="#ff2d92" letter-spacing="0.08em">TIER_01</text>
-    <text x="70" y="48" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="18" class="text-strong" letter-spacing="0.04em">WORKING</text>
-    <text x="70" y="62" font-family="'JetBrains Mono', monospace" font-size="9" fill="#ff2d92" letter-spacing="0.30em">00-inbox · current session</text>
-    <text x="320" y="38" font-family="'JetBrains Mono', monospace" font-size="11" class="text-soft">Raw captures, unprocessed thoughts.</text>
-    <text x="320" y="56" font-family="'JetBrains Mono', monospace" font-size="11" class="text-fade">/braindump · /capture · /bookmark</text>
-    <g transform="translate(640, 24)">
-      <rect width="124" height="22" fill="rgba(255,45,146,0.08)" stroke="#ff2d92" stroke-opacity="0.5" stroke-width="1"/>
-      <text x="62" y="15" font-family="'JetBrains Mono', monospace" font-size="9" fill="#ff2d92" letter-spacing="0.18em" text-anchor="middle">EPHEMERAL</text>
+    <rect width="780" height="130" fill="url(#g-t1-fill)"/>
+    <text class="icon-pulse" x="38" y="78" font-size="32" text-anchor="middle" dominant-baseline="central" aria-hidden="true">📥</text>
+    <text x="74" y="42" font-family="'JetBrains Mono', monospace" font-size="13" font-weight="700" fill="rgba(255,255,255,0.85)" letter-spacing="0.08em">TIER_01</text>
+    <text x="74" y="82" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="28" fill="#ffffff" letter-spacing="0.04em">WORKING</text>
+    <text x="74" y="112" font-family="'JetBrains Mono', monospace" font-size="11" fill="rgba(255,255,255,0.85)" letter-spacing="0.30em">00-inbox · current session</text>
+    <text x="290" y="68" font-family="'JetBrains Mono', monospace" font-size="13" fill="#ffffff">Raw captures, unprocessed thoughts.</text>
+    <text x="290" y="98" font-family="'JetBrains Mono', monospace" font-size="13" fill="rgba(255,255,255,0.78)">/braindump · /capture · /bookmark</text>
+    <g transform="translate(668, 53)">
+      <rect width="100" height="24" fill="#ffffff"/>
+      <text x="50" y="16" font-family="'JetBrains Mono', monospace" font-size="10" fill="#c91075" font-weight="700" letter-spacing="0.14em" text-anchor="middle">EPHEMERAL</text>
     </g>
   </g>
 
-  <g transform="translate(440, 184)">
-    <g class="promote">
-      <line x1="-9" y1="0" x2="-9" y2="9" class="arrow-line" stroke-width="1.4"/>
-      <path d="M -14 6 L -9 12 L -4 6" fill="none" class="arrow-head" stroke-width="1.4"/>
-    </g>
-    <g class="recall">
-      <line x1="9" y1="3" x2="9" y2="12" class="arrow-line" stroke-width="1.4"/>
-      <path d="M 4 6 L 9 0 L 14 6" fill="none" class="arrow-head" stroke-width="1.4"/>
+  <!-- arrow gap 1 — promote down (left) + recall up (right) -->
+  <g transform="translate(440, 240)">
+    <line class="flow flow-down" x1="-9" y1="0" x2="-9" y2="20"/>
+    <line class="flow flow-up"   x1="9"  y1="0" x2="9"  y2="20"/>
+  </g>
+
+  <!-- ════════ TIER 02 — EPISODIC ════════ -->
+  <g transform="translate(60, 260)">
+    <rect width="780" height="130" fill="url(#g-t2-fill)"/>
+    <text class="icon-pulse" x="38" y="78" font-size="32" text-anchor="middle" dominant-baseline="central" aria-hidden="true" style="animation-delay: 0.65s;">📜</text>
+    <text x="74" y="42" font-family="'JetBrains Mono', monospace" font-size="13" font-weight="700" fill="rgba(255,255,255,0.85)" letter-spacing="0.08em">TIER_02</text>
+    <text x="74" y="82" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="28" fill="#ffffff" letter-spacing="0.04em">EPISODIC</text>
+    <text x="74" y="112" font-family="'JetBrains Mono', monospace" font-size="11" fill="rgba(255,255,255,0.85)" letter-spacing="0.30em">07-logs · session + checkpoint</text>
+    <text x="290" y="68" font-family="'JetBrains Mono', monospace" font-size="13" fill="#ffffff">What happened — sessions, decisions, narrative.</text>
+    <text x="290" y="98" font-family="'JetBrains Mono', monospace" font-size="13" fill="rgba(255,255,255,0.78)">/wrapup · auto-checkpoints</text>
+    <g transform="translate(668, 53)">
+      <rect width="100" height="24" fill="#ffffff"/>
+      <text x="50" y="16" font-family="'JetBrains Mono', monospace" font-size="10" fill="#7c1ade" font-weight="700" letter-spacing="0.14em" text-anchor="middle">PER_SESSION</text>
     </g>
   </g>
 
-  <g transform="translate(60, 200)">
-    <rect width="780" height="70" fill="none" stroke="#bc13fe" stroke-opacity="0.45" stroke-width="1"/>
-    <rect width="780" height="3" fill="url(#g-t2)" filter="url(#soft-glow)"/>
-    <path d="M 0 0 L 14 0 M 0 0 L 0 14" stroke="#bc13fe" stroke-width="1.5" fill="none"/>
-    <path d="M 766 70 L 780 70 M 780 56 L 780 70" stroke="#bc13fe" stroke-width="1.5" fill="none"/>
-    <text x="22" y="48" font-size="22" aria-hidden="true">📜</text>
-    <text x="70" y="26" font-family="'JetBrains Mono', monospace" font-size="11" font-weight="700" fill="#bc13fe" letter-spacing="0.08em">TIER_02</text>
-    <text x="70" y="48" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="18" class="text-strong" letter-spacing="0.04em">EPISODIC</text>
-    <text x="70" y="62" font-family="'JetBrains Mono', monospace" font-size="9" fill="#bc13fe" letter-spacing="0.30em">07-logs · session + checkpoint</text>
-    <text x="320" y="38" font-family="'JetBrains Mono', monospace" font-size="11" class="text-soft">What happened — sessions, decisions, narrative.</text>
-    <text x="320" y="56" font-family="'JetBrains Mono', monospace" font-size="11" class="text-fade">/wrapup · auto-checkpoints</text>
-    <g transform="translate(640, 24)">
-      <rect width="124" height="22" fill="rgba(188,19,254,0.08)" stroke="#bc13fe" stroke-opacity="0.5" stroke-width="1"/>
-      <text x="62" y="15" font-family="'JetBrains Mono', monospace" font-size="9" fill="#bc13fe" letter-spacing="0.18em" text-anchor="middle">PER_SESSION</text>
+  <!-- arrow gap 2 -->
+  <g transform="translate(440, 390)">
+    <line class="flow flow-down" x1="-9" y1="0" x2="-9" y2="20" style="animation-delay: 0.3s;"/>
+    <line class="flow flow-up"   x1="9"  y1="0" x2="9"  y2="20" style="animation-delay: 0.3s;"/>
+  </g>
+
+  <!-- ════════ TIER 03 — SEMANTIC ════════ -->
+  <g transform="translate(60, 410)">
+    <rect width="780" height="130" fill="url(#g-t3-fill)"/>
+    <text class="icon-pulse" x="38" y="78" font-size="32" text-anchor="middle" dominant-baseline="central" aria-hidden="true" style="animation-delay: 1.3s;">🧬</text>
+    <text x="74" y="42" font-family="'JetBrains Mono', monospace" font-size="13" font-weight="700" fill="rgba(255,255,255,0.85)" letter-spacing="0.08em">TIER_03</text>
+    <text x="74" y="82" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="28" fill="#ffffff" letter-spacing="0.04em">SEMANTIC</text>
+    <text x="74" y="112" font-family="'JetBrains Mono', monospace" font-size="11" fill="rgba(255,255,255,0.85)" letter-spacing="0.30em">05-agent · MEMORY.md + memory/</text>
+    <text x="290" y="68" font-family="'JetBrains Mono', monospace" font-size="13" fill="#ffffff">Identity, preferences, recurring patterns.</text>
+    <text x="290" y="98" font-family="'JetBrains Mono', monospace" font-size="13" fill="rgba(255,255,255,0.78)">/learn · /recap · /memory-review</text>
+    <g transform="translate(668, 53)">
+      <rect width="100" height="24" fill="#ffffff"/>
+      <text x="50" y="16" font-family="'JetBrains Mono', monospace" font-size="10" fill="#4d6d00" font-weight="700" letter-spacing="0.14em" text-anchor="middle">CROSS_SESSION</text>
     </g>
   </g>
 
-  <g transform="translate(440, 274)">
-    <g class="promote delay-1">
-      <line x1="-9" y1="0" x2="-9" y2="9" class="arrow-line" stroke-width="1.4"/>
-      <path d="M -14 6 L -9 12 L -4 6" fill="none" class="arrow-head" stroke-width="1.4"/>
-    </g>
-    <g class="recall delay-1">
-      <line x1="9" y1="3" x2="9" y2="12" class="arrow-line" stroke-width="1.4"/>
-      <path d="M 4 6 L 9 0 L 14 6" fill="none" class="arrow-head" stroke-width="1.4"/>
-    </g>
+  <!-- arrow gap 3 -->
+  <g transform="translate(440, 540)">
+    <line class="flow flow-down" x1="-9" y1="0" x2="-9" y2="20" style="animation-delay: 0.6s;"/>
+    <line class="flow flow-up"   x1="9"  y1="0" x2="9"  y2="20" style="animation-delay: 0.6s;"/>
   </g>
 
-  <g transform="translate(60, 290)">
-    <rect width="780" height="70" fill="none" stroke="#c8ff00" stroke-opacity="0.45" stroke-width="1"/>
-    <rect width="780" height="3" fill="url(#g-t3)" filter="url(#soft-glow)"/>
-    <path d="M 0 0 L 14 0 M 0 0 L 0 14" stroke="#c8ff00" stroke-width="1.5" fill="none"/>
-    <path d="M 766 70 L 780 70 M 780 56 L 780 70" stroke="#c8ff00" stroke-width="1.5" fill="none"/>
-    <text x="22" y="48" font-size="22" aria-hidden="true">🧬</text>
-    <text x="70" y="26" font-family="'JetBrains Mono', monospace" font-size="11" font-weight="700" fill="#c8ff00" letter-spacing="0.08em">TIER_03</text>
-    <text x="70" y="48" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="18" class="text-strong" letter-spacing="0.04em">SEMANTIC</text>
-    <text x="70" y="62" font-family="'JetBrains Mono', monospace" font-size="9" fill="#c8ff00" letter-spacing="0.30em">05-agent · MEMORY.md + memory/</text>
-    <text x="320" y="38" font-family="'JetBrains Mono', monospace" font-size="11" class="text-soft">Identity, preferences, recurring patterns.</text>
-    <text x="320" y="56" font-family="'JetBrains Mono', monospace" font-size="11" class="text-fade">/learn · /recap · /memory-review</text>
-    <g transform="translate(640, 24)">
-      <rect width="124" height="22" fill="rgba(200,255,0,0.08)" stroke="#c8ff00" stroke-opacity="0.5" stroke-width="1"/>
-      <text x="62" y="15" font-family="'JetBrains Mono', monospace" font-size="9" fill="#c8ff00" letter-spacing="0.18em" text-anchor="middle">CROSS_SESSION</text>
-    </g>
-  </g>
-
-  <g transform="translate(440, 364)">
-    <g class="promote delay-2">
-      <line x1="-9" y1="0" x2="-9" y2="9" class="arrow-line" stroke-width="1.4"/>
-      <path d="M -14 6 L -9 12 L -4 6" fill="none" class="arrow-head" stroke-width="1.4"/>
-    </g>
-    <g class="recall delay-2">
-      <line x1="9" y1="3" x2="9" y2="12" class="arrow-line" stroke-width="1.4"/>
-      <path d="M 4 6 L 9 0 L 14 6" fill="none" class="arrow-head" stroke-width="1.4"/>
-    </g>
-  </g>
-
-  <g transform="translate(60, 380)">
-    <rect width="780" height="70" fill="none" stroke="#00f3ff" stroke-opacity="0.45" stroke-width="1"/>
-    <rect width="780" height="3" fill="url(#g-t4)" filter="url(#soft-glow)"/>
-    <path d="M 0 0 L 14 0 M 0 0 L 0 14" stroke="#00f3ff" stroke-width="1.5" fill="none"/>
-    <path d="M 766 70 L 780 70 M 780 56 L 780 70" stroke="#00f3ff" stroke-width="1.5" fill="none"/>
-    <text x="22" y="48" font-size="22" aria-hidden="true">💎</text>
-    <text x="70" y="26" font-family="'JetBrains Mono', monospace" font-size="11" font-weight="700" fill="#00f3ff" letter-spacing="0.08em">TIER_04</text>
-    <text x="70" y="48" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="18" class="text-strong" letter-spacing="0.04em">KNOWLEDGE</text>
-    <text x="70" y="62" font-family="'JetBrains Mono', monospace" font-size="9" fill="#00f3ff" letter-spacing="0.30em">03-knowledge · distilled notes</text>
-    <text x="320" y="38" font-family="'JetBrains Mono', monospace" font-size="11" class="text-soft">Crystallized insights — what you know forever.</text>
-    <text x="320" y="56" font-family="'JetBrains Mono', monospace" font-size="11" class="text-fade">/distill · /connect · /weekly</text>
-    <g transform="translate(640, 24)">
-      <rect width="124" height="22" fill="rgba(0,243,255,0.08)" stroke="#00f3ff" stroke-opacity="0.5" stroke-width="1"/>
-      <text x="62" y="15" font-family="'JetBrains Mono', monospace" font-size="9" fill="#00f3ff" letter-spacing="0.18em" text-anchor="middle">FOREVER</text>
+  <!-- ════════ TIER 04 — KNOWLEDGE ════════ -->
+  <g transform="translate(60, 560)">
+    <rect width="780" height="130" fill="url(#g-t4-fill)"/>
+    <text class="icon-pulse" x="38" y="78" font-size="32" text-anchor="middle" dominant-baseline="central" aria-hidden="true" style="animation-delay: 1.95s;">💎</text>
+    <text x="74" y="42" font-family="'JetBrains Mono', monospace" font-size="13" font-weight="700" fill="rgba(255,255,255,0.85)" letter-spacing="0.08em">TIER_04</text>
+    <text x="74" y="82" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="28" fill="#ffffff" letter-spacing="0.04em">KNOWLEDGE</text>
+    <text x="74" y="112" font-family="'JetBrains Mono', monospace" font-size="11" fill="rgba(255,255,255,0.85)" letter-spacing="0.30em">03-knowledge · distilled notes</text>
+    <text x="290" y="68" font-family="'JetBrains Mono', monospace" font-size="13" fill="#ffffff">Crystallized insights — what you know forever.</text>
+    <text x="290" y="98" font-family="'JetBrains Mono', monospace" font-size="13" fill="rgba(255,255,255,0.78)">/distill · /connect · /weekly</text>
+    <g transform="translate(668, 53)">
+      <rect width="100" height="24" fill="#ffffff"/>
+      <text x="50" y="16" font-family="'JetBrains Mono', monospace" font-size="10" fill="#00788c" font-weight="700" letter-spacing="0.14em" text-anchor="middle">FOREVER</text>
     </g>
   </g>
 

--- a/assets/diagrams/memory-tiers-light.svg
+++ b/assets/diagrams/memory-tiers-light.svg
@@ -1,52 +1,45 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 100 880 360" width="880" height="360" role="img" aria-labelledby="title desc" font-family="'Chakra Petch', 'Inter', ui-sans-serif, system-ui, sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 100 880 600" width="880" height="600" role="img" aria-labelledby="title desc" font-family="'Chakra Petch', 'Inter', ui-sans-serif, system-ui, sans-serif">
   <title id="title">Memory tiers — four-stage persistence</title>
   <desc id="desc">Four memory tiers stacked top to bottom. Tier 1 working memory in the inbox and current session, Tier 2 episodic memory in 07-logs, Tier 3 semantic memory in MEMORY.md and the memory folder, Tier 4 distilled knowledge in 03-knowledge. Knowledge sinks downward as it gets validated.</desc>
 
   <style>
-    .text-strong { fill: #0a0a14; }
-    .text-soft   { fill: rgba(10,10,20,0.82); }
-    .text-fade   { fill: rgba(10,10,20,0.65); }
-    .text-mute   { fill: rgba(10,10,20,0.50); }
-    .frame-corner { stroke: rgba(10,10,20,0.40); }
-    .grid-line    { stroke: rgba(10,10,20,0.07); }
-    .divider      { stroke: rgba(10,10,20,0.18); }
-    .arrow-line   { stroke: rgba(10,10,20,0.65); }
-    .arrow-head   { stroke: rgba(10,10,20,0.75); }
+    .flow { stroke: #0a0a14; stroke-width: 2; stroke-linecap: round; stroke-dasharray: 3 5; fill: none; }
+    .flow-down { animation: flow-down 0.9s linear infinite; }
+    .flow-up   { animation: flow-up   0.9s linear infinite; }
+    @keyframes flow-down { to { stroke-dashoffset: -8; } }
+    @keyframes flow-up   { to { stroke-dashoffset:  8; } }
 
-    .promote { animation: promote-pulse 4.5s linear infinite; }
-    .recall  { animation: recall-pulse 4.5s linear infinite; }
-    .delay-1 { animation-delay: 1.5s; }
-    .delay-2 { animation-delay: 3s; }
-    @keyframes promote-pulse {
-      0%, 22%, 100% { opacity: 0.6; }
-      6%            { opacity: 1; }
+    .icon-pulse {
+      transform-box: fill-box;
+      transform-origin: center;
+      animation: icon-pulse 2.6s ease-in-out infinite;
     }
-    @keyframes recall-pulse {
-      0%, 50%, 72%, 100% { opacity: 0.6; }
-      56%                { opacity: 1; }
+    @keyframes icon-pulse {
+      0%, 100% { transform: scale(1);    }
+      50%      { transform: scale(1.08); }
     }
 
     @media (prefers-reduced-motion: reduce) {
-      .promote, .recall { animation: none; opacity: 0.6; }
+      .icon-pulse, .flow-down, .flow-up { animation: none; transform: none; }
     }
   </style>
 
   <defs>
-    <linearGradient id="g-t1" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%"   stop-color="#c91075" stop-opacity="0.95"/>
-      <stop offset="100%" stop-color="#c91075" stop-opacity="0.05"/>
+    <linearGradient id="g-t1-fill" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%"   stop-color="#e62a93" stop-opacity="1"/>
+      <stop offset="100%" stop-color="#c91075" stop-opacity="1"/>
     </linearGradient>
-    <linearGradient id="g-t2" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%"   stop-color="#7c1ade" stop-opacity="0.95"/>
-      <stop offset="100%" stop-color="#7c1ade" stop-opacity="0.05"/>
+    <linearGradient id="g-t2-fill" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%"   stop-color="#a855f7" stop-opacity="1"/>
+      <stop offset="100%" stop-color="#7c1ade" stop-opacity="1"/>
     </linearGradient>
-    <linearGradient id="g-t3" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%"   stop-color="#4d6d00" stop-opacity="0.95"/>
-      <stop offset="100%" stop-color="#4d6d00" stop-opacity="0.05"/>
+    <linearGradient id="g-t3-fill" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%"   stop-color="#7a9d10" stop-opacity="1"/>
+      <stop offset="100%" stop-color="#4d6d00" stop-opacity="1"/>
     </linearGradient>
-    <linearGradient id="g-t4" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%"   stop-color="#00788c" stop-opacity="0.95"/>
-      <stop offset="100%" stop-color="#00788c" stop-opacity="0.05"/>
+    <linearGradient id="g-t4-fill" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%"   stop-color="#00a3bc" stop-opacity="1"/>
+      <stop offset="100%" stop-color="#00788c" stop-opacity="1"/>
     </linearGradient>
 
     <linearGradient id="spine-grad" x1="0" y1="0" x2="0" y2="1">
@@ -55,127 +48,85 @@
       <stop offset="66%"  stop-color="#4d6d00" stop-opacity="0.75"/>
       <stop offset="100%" stop-color="#00788c" stop-opacity="0.75"/>
     </linearGradient>
-
-    <pattern id="grid-pattern" width="40" height="40" patternUnits="userSpaceOnUse">
-      <path d="M 40 0 L 0 0 0 40" fill="none" class="grid-line" stroke-width="0.5"/>
-    </pattern>
-
-    <filter id="soft-glow" x="-20%" y="-50%" width="140%" height="200%">
-      <feGaussianBlur stdDeviation="1.5" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
   </defs>
 
-  <line x1="48" y1="110" x2="48" y2="450" stroke="url(#spine-grad)" stroke-width="2" stroke-dasharray="2 4" opacity="0.6"/>
+  <line x1="48" y1="110" x2="48" y2="690" stroke="url(#spine-grad)" stroke-width="2" stroke-dasharray="2 4" opacity="0.6"/>
 
   <!-- ════════ TIER 01 — WORKING ════════ -->
   <g transform="translate(60, 110)">
-    <rect width="780" height="70" fill="none" stroke="#c91075" stroke-opacity="0.85" stroke-width="1"/>
-    <rect width="780" height="3" fill="url(#g-t1)" filter="url(#soft-glow)"/>
-    <path d="M 0 0 L 14 0 M 0 0 L 0 14" stroke="#c91075" stroke-width="1.5" fill="none"/>
-    <path d="M 766 70 L 780 70 M 780 56 L 780 70" stroke="#c91075" stroke-width="1.5" fill="none"/>
-    <text x="22" y="48" font-size="22" aria-hidden="true">📥</text>
-    <text x="70" y="26" font-family="'JetBrains Mono', monospace" font-size="11" font-weight="700" fill="#c91075" letter-spacing="0.08em">TIER_01</text>
-    <text x="70" y="48" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="18" class="text-strong" letter-spacing="0.04em">WORKING</text>
-    <text x="70" y="62" font-family="'JetBrains Mono', monospace" font-size="9" fill="#c91075" letter-spacing="0.30em">00-inbox · current session</text>
-    <text x="320" y="38" font-family="'JetBrains Mono', monospace" font-size="11" class="text-soft">Raw captures, unprocessed thoughts.</text>
-    <text x="320" y="56" font-family="'JetBrains Mono', monospace" font-size="11" class="text-fade">/braindump · /capture · /bookmark</text>
-    <g transform="translate(640, 24)">
-      <rect width="124" height="22" fill="rgba(201,16,117,0.18)" stroke="#c91075" stroke-opacity="1.0" stroke-width="1"/>
-      <text x="62" y="15" font-family="'JetBrains Mono', monospace" font-size="9" fill="#c91075" letter-spacing="0.18em" text-anchor="middle">EPHEMERAL</text>
+    <rect width="780" height="130" fill="url(#g-t1-fill)"/>
+    <text class="icon-pulse" x="38" y="78" font-size="32" text-anchor="middle" dominant-baseline="central" aria-hidden="true">📥</text>
+    <text x="74" y="42" font-family="'JetBrains Mono', monospace" font-size="13" font-weight="700" fill="rgba(255,255,255,0.85)" letter-spacing="0.08em">TIER_01</text>
+    <text x="74" y="82" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="28" fill="#ffffff" letter-spacing="0.04em">WORKING</text>
+    <text x="74" y="112" font-family="'JetBrains Mono', monospace" font-size="11" fill="rgba(255,255,255,0.85)" letter-spacing="0.30em">00-inbox · current session</text>
+    <text x="290" y="68" font-family="'JetBrains Mono', monospace" font-size="13" fill="#ffffff">Raw captures, unprocessed thoughts.</text>
+    <text x="290" y="98" font-family="'JetBrains Mono', monospace" font-size="13" fill="rgba(255,255,255,0.78)">/braindump · /capture · /bookmark</text>
+    <g transform="translate(668, 53)">
+      <rect width="100" height="24" fill="#ffffff"/>
+      <text x="50" y="16" font-family="'JetBrains Mono', monospace" font-size="10" fill="#c91075" font-weight="700" letter-spacing="0.14em" text-anchor="middle">EPHEMERAL</text>
     </g>
   </g>
 
-  <!-- arrow gap 1 — promote down (↓), recall up (↑) -->
-  <g transform="translate(440, 184)">
-    <g class="promote">
-      <line x1="-9" y1="0" x2="-9" y2="9" class="arrow-line" stroke-width="1.4"/>
-      <path d="M -14 6 L -9 12 L -4 6" fill="none" class="arrow-head" stroke-width="1.4"/>
-    </g>
-    <g class="recall">
-      <line x1="9" y1="3" x2="9" y2="12" class="arrow-line" stroke-width="1.4"/>
-      <path d="M 4 6 L 9 0 L 14 6" fill="none" class="arrow-head" stroke-width="1.4"/>
-    </g>
+  <!-- arrow gap 1 — promote down (left) + recall up (right) -->
+  <g transform="translate(440, 240)">
+    <line class="flow flow-down" x1="-9" y1="0" x2="-9" y2="20"/>
+    <line class="flow flow-up"   x1="9"  y1="0" x2="9"  y2="20"/>
   </g>
 
   <!-- ════════ TIER 02 — EPISODIC ════════ -->
-  <g transform="translate(60, 200)">
-    <rect width="780" height="70" fill="none" stroke="#7c1ade" stroke-opacity="0.85" stroke-width="1"/>
-    <rect width="780" height="3" fill="url(#g-t2)" filter="url(#soft-glow)"/>
-    <path d="M 0 0 L 14 0 M 0 0 L 0 14" stroke="#7c1ade" stroke-width="1.5" fill="none"/>
-    <path d="M 766 70 L 780 70 M 780 56 L 780 70" stroke="#7c1ade" stroke-width="1.5" fill="none"/>
-    <text x="22" y="48" font-size="22" aria-hidden="true">📜</text>
-    <text x="70" y="26" font-family="'JetBrains Mono', monospace" font-size="11" font-weight="700" fill="#7c1ade" letter-spacing="0.08em">TIER_02</text>
-    <text x="70" y="48" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="18" class="text-strong" letter-spacing="0.04em">EPISODIC</text>
-    <text x="70" y="62" font-family="'JetBrains Mono', monospace" font-size="9" fill="#7c1ade" letter-spacing="0.30em">07-logs · session + checkpoint</text>
-    <text x="320" y="38" font-family="'JetBrains Mono', monospace" font-size="11" class="text-soft">What happened — sessions, decisions, narrative.</text>
-    <text x="320" y="56" font-family="'JetBrains Mono', monospace" font-size="11" class="text-fade">/wrapup · auto-checkpoints</text>
-    <g transform="translate(640, 24)">
-      <rect width="124" height="22" fill="rgba(124,26,222,0.18)" stroke="#7c1ade" stroke-opacity="1.0" stroke-width="1"/>
-      <text x="62" y="15" font-family="'JetBrains Mono', monospace" font-size="9" fill="#7c1ade" letter-spacing="0.18em" text-anchor="middle">PER_SESSION</text>
+  <g transform="translate(60, 260)">
+    <rect width="780" height="130" fill="url(#g-t2-fill)"/>
+    <text class="icon-pulse" x="38" y="78" font-size="32" text-anchor="middle" dominant-baseline="central" aria-hidden="true" style="animation-delay: 0.65s;">📜</text>
+    <text x="74" y="42" font-family="'JetBrains Mono', monospace" font-size="13" font-weight="700" fill="rgba(255,255,255,0.85)" letter-spacing="0.08em">TIER_02</text>
+    <text x="74" y="82" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="28" fill="#ffffff" letter-spacing="0.04em">EPISODIC</text>
+    <text x="74" y="112" font-family="'JetBrains Mono', monospace" font-size="11" fill="rgba(255,255,255,0.85)" letter-spacing="0.30em">07-logs · session + checkpoint</text>
+    <text x="290" y="68" font-family="'JetBrains Mono', monospace" font-size="13" fill="#ffffff">What happened — sessions, decisions, narrative.</text>
+    <text x="290" y="98" font-family="'JetBrains Mono', monospace" font-size="13" fill="rgba(255,255,255,0.78)">/wrapup · auto-checkpoints</text>
+    <g transform="translate(668, 53)">
+      <rect width="100" height="24" fill="#ffffff"/>
+      <text x="50" y="16" font-family="'JetBrains Mono', monospace" font-size="10" fill="#7c1ade" font-weight="700" letter-spacing="0.14em" text-anchor="middle">PER_SESSION</text>
     </g>
   </g>
 
   <!-- arrow gap 2 -->
-  <g transform="translate(440, 274)">
-    <g class="promote delay-1">
-      <line x1="-9" y1="0" x2="-9" y2="9" class="arrow-line" stroke-width="1.4"/>
-      <path d="M -14 6 L -9 12 L -4 6" fill="none" class="arrow-head" stroke-width="1.4"/>
-    </g>
-    <g class="recall delay-1">
-      <line x1="9" y1="3" x2="9" y2="12" class="arrow-line" stroke-width="1.4"/>
-      <path d="M 4 6 L 9 0 L 14 6" fill="none" class="arrow-head" stroke-width="1.4"/>
-    </g>
+  <g transform="translate(440, 390)">
+    <line class="flow flow-down" x1="-9" y1="0" x2="-9" y2="20" style="animation-delay: 0.3s;"/>
+    <line class="flow flow-up"   x1="9"  y1="0" x2="9"  y2="20" style="animation-delay: 0.3s;"/>
   </g>
 
   <!-- ════════ TIER 03 — SEMANTIC ════════ -->
-  <g transform="translate(60, 290)">
-    <rect width="780" height="70" fill="none" stroke="#4d6d00" stroke-opacity="0.85" stroke-width="1"/>
-    <rect width="780" height="3" fill="url(#g-t3)" filter="url(#soft-glow)"/>
-    <path d="M 0 0 L 14 0 M 0 0 L 0 14" stroke="#4d6d00" stroke-width="1.5" fill="none"/>
-    <path d="M 766 70 L 780 70 M 780 56 L 780 70" stroke="#4d6d00" stroke-width="1.5" fill="none"/>
-    <text x="22" y="48" font-size="22" aria-hidden="true">🧬</text>
-    <text x="70" y="26" font-family="'JetBrains Mono', monospace" font-size="11" font-weight="700" fill="#4d6d00" letter-spacing="0.08em">TIER_03</text>
-    <text x="70" y="48" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="18" class="text-strong" letter-spacing="0.04em">SEMANTIC</text>
-    <text x="70" y="62" font-family="'JetBrains Mono', monospace" font-size="9" fill="#4d6d00" letter-spacing="0.30em">05-agent · MEMORY.md + memory/</text>
-    <text x="320" y="38" font-family="'JetBrains Mono', monospace" font-size="11" class="text-soft">Identity, preferences, recurring patterns.</text>
-    <text x="320" y="56" font-family="'JetBrains Mono', monospace" font-size="11" class="text-fade">/learn · /recap · /memory-review</text>
-    <g transform="translate(640, 24)">
-      <rect width="124" height="22" fill="rgba(77,109,0,0.18)" stroke="#4d6d00" stroke-opacity="1.0" stroke-width="1"/>
-      <text x="62" y="15" font-family="'JetBrains Mono', monospace" font-size="9" fill="#4d6d00" letter-spacing="0.18em" text-anchor="middle">CROSS_SESSION</text>
+  <g transform="translate(60, 410)">
+    <rect width="780" height="130" fill="url(#g-t3-fill)"/>
+    <text class="icon-pulse" x="38" y="78" font-size="32" text-anchor="middle" dominant-baseline="central" aria-hidden="true" style="animation-delay: 1.3s;">🧬</text>
+    <text x="74" y="42" font-family="'JetBrains Mono', monospace" font-size="13" font-weight="700" fill="rgba(255,255,255,0.85)" letter-spacing="0.08em">TIER_03</text>
+    <text x="74" y="82" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="28" fill="#ffffff" letter-spacing="0.04em">SEMANTIC</text>
+    <text x="74" y="112" font-family="'JetBrains Mono', monospace" font-size="11" fill="rgba(255,255,255,0.85)" letter-spacing="0.30em">05-agent · MEMORY.md + memory/</text>
+    <text x="290" y="68" font-family="'JetBrains Mono', monospace" font-size="13" fill="#ffffff">Identity, preferences, recurring patterns.</text>
+    <text x="290" y="98" font-family="'JetBrains Mono', monospace" font-size="13" fill="rgba(255,255,255,0.78)">/learn · /recap · /memory-review</text>
+    <g transform="translate(668, 53)">
+      <rect width="100" height="24" fill="#ffffff"/>
+      <text x="50" y="16" font-family="'JetBrains Mono', monospace" font-size="10" fill="#4d6d00" font-weight="700" letter-spacing="0.14em" text-anchor="middle">CROSS_SESSION</text>
     </g>
   </g>
 
   <!-- arrow gap 3 -->
-  <g transform="translate(440, 364)">
-    <g class="promote delay-2">
-      <line x1="-9" y1="0" x2="-9" y2="9" class="arrow-line" stroke-width="1.4"/>
-      <path d="M -14 6 L -9 12 L -4 6" fill="none" class="arrow-head" stroke-width="1.4"/>
-    </g>
-    <g class="recall delay-2">
-      <line x1="9" y1="3" x2="9" y2="12" class="arrow-line" stroke-width="1.4"/>
-      <path d="M 4 6 L 9 0 L 14 6" fill="none" class="arrow-head" stroke-width="1.4"/>
-    </g>
+  <g transform="translate(440, 540)">
+    <line class="flow flow-down" x1="-9" y1="0" x2="-9" y2="20" style="animation-delay: 0.6s;"/>
+    <line class="flow flow-up"   x1="9"  y1="0" x2="9"  y2="20" style="animation-delay: 0.6s;"/>
   </g>
 
   <!-- ════════ TIER 04 — KNOWLEDGE ════════ -->
-  <g transform="translate(60, 380)">
-    <rect width="780" height="70" fill="none" stroke="#00788c" stroke-opacity="0.85" stroke-width="1"/>
-    <rect width="780" height="3" fill="url(#g-t4)" filter="url(#soft-glow)"/>
-    <path d="M 0 0 L 14 0 M 0 0 L 0 14" stroke="#00788c" stroke-width="1.5" fill="none"/>
-    <path d="M 766 70 L 780 70 M 780 56 L 780 70" stroke="#00788c" stroke-width="1.5" fill="none"/>
-    <text x="22" y="48" font-size="22" aria-hidden="true">💎</text>
-    <text x="70" y="26" font-family="'JetBrains Mono', monospace" font-size="11" font-weight="700" fill="#00788c" letter-spacing="0.08em">TIER_04</text>
-    <text x="70" y="48" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="18" class="text-strong" letter-spacing="0.04em">KNOWLEDGE</text>
-    <text x="70" y="62" font-family="'JetBrains Mono', monospace" font-size="9" fill="#00788c" letter-spacing="0.30em">03-knowledge · distilled notes</text>
-    <text x="320" y="38" font-family="'JetBrains Mono', monospace" font-size="11" class="text-soft">Crystallized insights — what you know forever.</text>
-    <text x="320" y="56" font-family="'JetBrains Mono', monospace" font-size="11" class="text-fade">/distill · /connect · /weekly</text>
-    <g transform="translate(640, 24)">
-      <rect width="124" height="22" fill="rgba(0,120,140,0.18)" stroke="#00788c" stroke-opacity="1.0" stroke-width="1"/>
-      <text x="62" y="15" font-family="'JetBrains Mono', monospace" font-size="9" fill="#00788c" letter-spacing="0.18em" text-anchor="middle">FOREVER</text>
+  <g transform="translate(60, 560)">
+    <rect width="780" height="130" fill="url(#g-t4-fill)"/>
+    <text class="icon-pulse" x="38" y="78" font-size="32" text-anchor="middle" dominant-baseline="central" aria-hidden="true" style="animation-delay: 1.95s;">💎</text>
+    <text x="74" y="42" font-family="'JetBrains Mono', monospace" font-size="13" font-weight="700" fill="rgba(255,255,255,0.85)" letter-spacing="0.08em">TIER_04</text>
+    <text x="74" y="82" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="28" fill="#ffffff" letter-spacing="0.04em">KNOWLEDGE</text>
+    <text x="74" y="112" font-family="'JetBrains Mono', monospace" font-size="11" fill="rgba(255,255,255,0.85)" letter-spacing="0.30em">03-knowledge · distilled notes</text>
+    <text x="290" y="68" font-family="'JetBrains Mono', monospace" font-size="13" fill="#ffffff">Crystallized insights — what you know forever.</text>
+    <text x="290" y="98" font-family="'JetBrains Mono', monospace" font-size="13" fill="rgba(255,255,255,0.78)">/distill · /connect · /weekly</text>
+    <g transform="translate(668, 53)">
+      <rect width="100" height="24" fill="#ffffff"/>
+      <text x="50" y="16" font-family="'JetBrains Mono', monospace" font-size="10" fill="#00788c" font-weight="700" letter-spacing="0.14em" text-anchor="middle">FOREVER</text>
     </g>
   </g>
 

--- a/assets/diagrams/vault-hub-dark.svg
+++ b/assets/diagrams/vault-hub-dark.svg
@@ -1,192 +1,151 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="-280 -210 560 420" width="640" role="img" aria-labelledby="title desc" font-family="'JetBrains Mono', ui-monospace, monospace">
   <title id="title">Obsidian as Command Center</title>
-  <desc id="desc">Hub-and-spoke diagram (dark theme). Obsidian vault sits at the center, with eight spokes radiating outward to CLI/repo, website, cloud infra, social media, office docs, project notes, research, and MCP server.</desc>
+  <desc id="desc">Hub-and-spoke diagram. Obsidian vault sits at the center, with eight spokes radiating outward to CLI/repo, website, cloud infra, social media, office docs, project notes, research, and MCP server.</desc>
 
   <style>
-    .ring        { fill: none; stroke: #bc13fe; stroke-opacity: 0.22; stroke-dasharray: 3 5; transform-origin: 0 0; }
-    .spoke       { stroke: #bc13fe; stroke-opacity: 0.45; stroke-width: 1; }
-    .node        { fill: #bc13fe; }
-    .node-label  { fill: rgba(255,255,255,0.78); font-size: 11px; letter-spacing: 0.18em; }
-    .particle    { fill: #ffffff; }
-    .ping        { fill: none; stroke: #bc13fe; stroke-width: 1.5; }
-    .core        { fill: rgba(2,2,4,0.92); stroke: #bc13fe; stroke-width: 1.5; transform-origin: 0 0; }
+    .spoke       { stroke: #9234e8; stroke-opacity: 0.45; stroke-width: 1.3; }
+    .node        { fill: #9234e8; }
+    .node-label  { fill: #a855f7; font-size: 11px; font-weight: 600; letter-spacing: 0.18em; }
+    .particle    { fill: #9234e8; }
+    .ping        { fill: none; stroke: #9234e8; stroke-width: 2; }
+    .core        { transform-origin: center; transform-box: fill-box; }
     .core-label  { fill: #ffffff; font-size: 11.5px; font-weight: 700; letter-spacing: 0.16em; }
-    .core-sub    { fill: #bc13fe; font-size: 9px; letter-spacing: 0.32em; }
-    .core-logo-shell { fill: #bc13fe; fill-opacity: 0.22; stroke: #bc13fe; stroke-width: 1.3; stroke-linejoin: round; }
-    .core-logo-cut   { fill: none; stroke: #bc13fe; stroke-width: 0.9; stroke-opacity: 0.85; stroke-linecap: round; }
+    .core-sub    { fill: rgba(255,255,255,0.85); font-size: 9px; letter-spacing: 0.32em; }
+    .core-logo-shell { fill: rgba(255,255,255,0.25); stroke: #ffffff; stroke-width: 1.3; stroke-linejoin: round; }
+    .core-logo-cut   { fill: none; stroke: rgba(255,255,255,0.85); stroke-width: 0.9; stroke-linecap: round; }
 
-    @keyframes ring-spin { to { transform: rotate(360deg); } }
     @keyframes core-breathe {
-      0%, 100% { stroke-width: 1.5; stroke-opacity: 0.6; }
-      50%      { stroke-width: 2.5; stroke-opacity: 1.0; }
+      0%, 100% { transform: scale(1); }
+      50%      { transform: scale(1.03); }
     }
-    .ring { animation: ring-spin 120s linear infinite; }
     .core { animation: core-breathe 9s ease-in-out infinite; }
 
     @media (prefers-reduced-motion: reduce) {
-      .ring, .core { animation: none; }
+      .core { animation: none; }
       .particle, .ping { display: none; }
     }
   </style>
 
-  <!-- Outer guide ring (slowly rotating) -->
-  <circle class="ring" cx="0" cy="0" r="150"/>
+  <defs>
+    <radialGradient id="g-core-fill" cx="0.32" cy="0.32" r="0.85">
+      <stop offset="0%"   stop-color="#a855f7" stop-opacity="1"/>
+      <stop offset="100%" stop-color="#9234e8" stop-opacity="1"/>
+    </radialGradient>
+  </defs>
 
-  <!-- N — CLI / REPO -->
+  <!-- 8 spokes — all outbound from vault → outer node.
+       cycle dur=6s, begin offsets staggered 0.75s apart so exactly
+       one spoke fires every 0.75s. Particle keyTimes 0.05–0.92 (travel),
+       0.92–0.95 (fade out at node). Ring at outer node bursts 0.92–0.99
+       with peak opacity at 0.95 — exact sync with arrival. Text label
+       flashes brighter purple 0.92–0.96 in tandem. -->
+
+  <!-- N — CLI / REPO (begin 0s) -->
   <line class="spoke" x1="0" y1="0" x2="0" y2="-150"/>
   <circle class="node" cx="0" cy="-150" r="5"/>
-  <text class="node-label" x="0" y="-183" text-anchor="middle">CLI / REPO</text>
-
-  <!-- NE — WEBSITE -->
-  <line class="spoke" x1="0" y1="0" x2="106.07" y2="-106.07"/>
-  <circle class="node" cx="106.07" cy="-106.07" r="5"/>
-  <text class="node-label" x="123.74" y="-119.74" text-anchor="start">WEBSITE</text>
-
-  <!-- E — CLOUD INFRA -->
-  <line class="spoke" x1="0" y1="0" x2="150" y2="0"/>
-  <circle class="node" cx="150" cy="0" r="5"/>
-  <text class="node-label" x="175" y="4" text-anchor="start">CLOUD INFRA</text>
-
-  <!-- SE — SOCIAL MEDIA -->
-  <line class="spoke" x1="0" y1="0" x2="106.07" y2="106.07"/>
-  <circle class="node" cx="106.07" cy="106.07" r="5"/>
-  <text class="node-label" x="123.74" y="127.74" text-anchor="start">SOCIAL MEDIA</text>
-
-  <!-- S — OFFICE DOCS -->
-  <line class="spoke" x1="0" y1="0" x2="0" y2="150"/>
-  <circle class="node" cx="0" cy="150" r="5"/>
-  <text class="node-label" x="0" y="189" text-anchor="middle">OFFICE DOCS</text>
-
-  <!-- SW — PROJECT NOTES -->
-  <line class="spoke" x1="0" y1="0" x2="-106.07" y2="106.07"/>
-  <circle class="node" cx="-106.07" cy="106.07" r="5"/>
-  <text class="node-label" x="-123.74" y="127.74" text-anchor="end">PROJECT NOTES</text>
-
-  <!-- W — RESEARCH -->
-  <line class="spoke" x1="0" y1="0" x2="-150" y2="0"/>
-  <circle class="node" cx="-150" cy="0" r="5"/>
-  <text class="node-label" x="-175" y="4" text-anchor="end">RESEARCH</text>
-
-  <!-- NW — MCP SERVER -->
-  <line class="spoke" x1="0" y1="0" x2="-106.07" y2="-106.07"/>
-  <circle class="node" cx="-106.07" cy="-106.07" r="5"/>
-  <text class="node-label" x="-123.74" y="-119.74" text-anchor="end">MCP SERVER</text>
-
-  <!-- Animated flow: particles travel along spokes, pings flash at the active end -->
-  <!-- N — out to CLI/REPO (8.5s) -->
+  <text class="node-label" x="0" y="-183" text-anchor="middle">CLI / REPO<animate attributeName="fill" values="#a855f7;#a855f7;#f5e9ff;#a855f7" keyTimes="0;0.92;0.95;1" dur="6s" repeatCount="indefinite"/></text>
   <circle class="particle" cx="0" cy="0" r="3" opacity="0">
-    <animateMotion path="M 0,0 L 0,-150" dur="8.5s" repeatCount="indefinite"/>
-    <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.08;0.92;1" dur="8.5s" repeatCount="indefinite"/>
-  </circle>
-  <circle class="particle" cx="0" cy="0" r="3" opacity="0">
-    <animateMotion path="M 0,0 L 0,-150" dur="8.5s" begin="4.25s" repeatCount="indefinite"/>
-    <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.08;0.92;1" dur="8.5s" begin="4.25s" repeatCount="indefinite"/>
+    <animateMotion path="M 0,0 L 0,-150" dur="6s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0;1;1;0;0" keyTimes="0;0.05;0.9;0.95;1" dur="6s" repeatCount="indefinite"/>
   </circle>
   <circle class="ping" cx="0" cy="-150" r="5" opacity="0">
-    <animate attributeName="r" values="5;5;13" keyTimes="0;0.86;1" dur="8.5s" repeatCount="indefinite"/>
-    <animate attributeName="opacity" values="0;0;0.9;0" keyTimes="0;0.86;0.93;1" dur="8.5s" repeatCount="indefinite"/>
+    <animate attributeName="r" values="5;5;14;14" keyTimes="0;0.92;0.99;1" dur="6s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0;0;0.9;0;0" keyTimes="0;0.92;0.95;0.99;1" dur="6s" repeatCount="indefinite"/>
   </circle>
 
-  <!-- NE — in from WEBSITE (7.5s) -->
-  <circle class="particle" cx="0" cy="0" r="3" opacity="0">
-    <animateMotion path="M 106.07,-106.07 L 0,0" dur="7.5s" begin="0.4s" repeatCount="indefinite"/>
-    <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.08;0.92;1" dur="7.5s" begin="0.4s" repeatCount="indefinite"/>
-  </circle>
-  <circle class="particle" cx="0" cy="0" r="3" opacity="0">
-    <animateMotion path="M 106.07,-106.07 L 0,0" dur="7.5s" begin="4.15s" repeatCount="indefinite"/>
-    <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.08;0.92;1" dur="7.5s" begin="4.15s" repeatCount="indefinite"/>
-  </circle>
+  <!-- NE — WEBSITE (inbound, begin 0.75s) — outer pings first, then particle leaves -->
+  <line class="spoke" x1="0" y1="0" x2="106.07" y2="-106.07"/>
+  <circle class="node" cx="106.07" cy="-106.07" r="5"/>
+  <text class="node-label" x="123.74" y="-119.74" text-anchor="start">WEBSITE<animate attributeName="fill" values="#a855f7;#a855f7;#f5e9ff;#a855f7;#a855f7" keyTimes="0;0.02;0.05;0.07;1" dur="6s" begin="0.75s" repeatCount="indefinite"/></text>
   <circle class="ping" cx="106.07" cy="-106.07" r="5" opacity="0">
-    <animate attributeName="r" values="5;13;13" keyTimes="0;0.12;1" dur="7.5s" begin="0.4s" repeatCount="indefinite"/>
-    <animate attributeName="opacity" values="0.9;0;0;0" keyTimes="0;0.12;0.99;1" dur="7.5s" begin="0.4s" repeatCount="indefinite"/>
+    <animate attributeName="r" values="5;5;14;14" keyTimes="0;0.02;0.07;1" dur="6s" begin="0.75s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0;0;0.9;0;0" keyTimes="0;0.02;0.05;0.07;1" dur="6s" begin="0.75s" repeatCount="indefinite"/>
+  </circle>
+  <circle class="particle" cx="0" cy="0" r="3" opacity="0">
+    <animateMotion path="M 106.07,-106.07 L 0,0" dur="6s" calcMode="linear" keyPoints="0;0;1;1" keyTimes="0;0.07;0.92;1" begin="0.75s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0;0;1;1;0;0" keyTimes="0;0.07;0.09;0.9;0.92;1" dur="6s" begin="0.75s" repeatCount="indefinite"/>
   </circle>
 
-  <!-- E — out to CLOUD INFRA (9.5s) -->
+  <!-- E — CLOUD INFRA (begin 1.5s) -->
+  <line class="spoke" x1="0" y1="0" x2="150" y2="0"/>
+  <circle class="node" cx="150" cy="0" r="5"/>
+  <text class="node-label" x="175" y="4" text-anchor="start">CLOUD INFRA<animate attributeName="fill" values="#a855f7;#a855f7;#f5e9ff;#a855f7" keyTimes="0;0.92;0.95;1" dur="6s" begin="1.5s" repeatCount="indefinite"/></text>
   <circle class="particle" cx="0" cy="0" r="3" opacity="0">
-    <animateMotion path="M 0,0 L 150,0" dur="9.5s" begin="0.8s" repeatCount="indefinite"/>
-    <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.08;0.92;1" dur="9.5s" begin="0.8s" repeatCount="indefinite"/>
-  </circle>
-  <circle class="particle" cx="0" cy="0" r="3" opacity="0">
-    <animateMotion path="M 0,0 L 150,0" dur="9.5s" begin="5.55s" repeatCount="indefinite"/>
-    <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.08;0.92;1" dur="9.5s" begin="5.55s" repeatCount="indefinite"/>
+    <animateMotion path="M 0,0 L 150,0" dur="6s" begin="1.5s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0;1;1;0;0" keyTimes="0;0.05;0.9;0.95;1" dur="6s" begin="1.5s" repeatCount="indefinite"/>
   </circle>
   <circle class="ping" cx="150" cy="0" r="5" opacity="0">
-    <animate attributeName="r" values="5;5;13" keyTimes="0;0.86;1" dur="9.5s" begin="0.8s" repeatCount="indefinite"/>
-    <animate attributeName="opacity" values="0;0;0.9;0" keyTimes="0;0.86;0.93;1" dur="9.5s" begin="0.8s" repeatCount="indefinite"/>
+    <animate attributeName="r" values="5;5;14;14" keyTimes="0;0.92;0.99;1" dur="6s" begin="1.5s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0;0;0.9;0;0" keyTimes="0;0.92;0.95;0.99;1" dur="6s" begin="1.5s" repeatCount="indefinite"/>
   </circle>
 
-  <!-- SE — in from SOCIAL MEDIA (10s) -->
-  <circle class="particle" cx="0" cy="0" r="3" opacity="0">
-    <animateMotion path="M 106.07,106.07 L 0,0" dur="10s" begin="1.2s" repeatCount="indefinite"/>
-    <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.08;0.92;1" dur="10s" begin="1.2s" repeatCount="indefinite"/>
-  </circle>
-  <circle class="particle" cx="0" cy="0" r="3" opacity="0">
-    <animateMotion path="M 106.07,106.07 L 0,0" dur="10s" begin="6.2s" repeatCount="indefinite"/>
-    <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.08;0.92;1" dur="10s" begin="6.2s" repeatCount="indefinite"/>
-  </circle>
+  <!-- SE — SOCIAL MEDIA (inbound, begin 2.25s) -->
+  <line class="spoke" x1="0" y1="0" x2="106.07" y2="106.07"/>
+  <circle class="node" cx="106.07" cy="106.07" r="5"/>
+  <text class="node-label" x="123.74" y="127.74" text-anchor="start">SOCIAL MEDIA<animate attributeName="fill" values="#a855f7;#a855f7;#f5e9ff;#a855f7;#a855f7" keyTimes="0;0.02;0.05;0.07;1" dur="6s" begin="2.25s" repeatCount="indefinite"/></text>
   <circle class="ping" cx="106.07" cy="106.07" r="5" opacity="0">
-    <animate attributeName="r" values="5;13;13" keyTimes="0;0.12;1" dur="10s" begin="1.2s" repeatCount="indefinite"/>
-    <animate attributeName="opacity" values="0.9;0;0;0" keyTimes="0;0.12;0.99;1" dur="10s" begin="1.2s" repeatCount="indefinite"/>
+    <animate attributeName="r" values="5;5;14;14" keyTimes="0;0.02;0.07;1" dur="6s" begin="2.25s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0;0;0.9;0;0" keyTimes="0;0.02;0.05;0.07;1" dur="6s" begin="2.25s" repeatCount="indefinite"/>
+  </circle>
+  <circle class="particle" cx="0" cy="0" r="3" opacity="0">
+    <animateMotion path="M 106.07,106.07 L 0,0" dur="6s" calcMode="linear" keyPoints="0;0;1;1" keyTimes="0;0.07;0.92;1" begin="2.25s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0;0;1;1;0;0" keyTimes="0;0.07;0.09;0.9;0.92;1" dur="6s" begin="2.25s" repeatCount="indefinite"/>
   </circle>
 
-  <!-- S — out to OFFICE DOCS (9s) -->
+  <!-- S — OFFICE DOCS (begin 3s) -->
+  <line class="spoke" x1="0" y1="0" x2="0" y2="150"/>
+  <circle class="node" cx="0" cy="150" r="5"/>
+  <text class="node-label" x="0" y="189" text-anchor="middle">OFFICE DOCS<animate attributeName="fill" values="#a855f7;#a855f7;#f5e9ff;#a855f7" keyTimes="0;0.92;0.95;1" dur="6s" begin="3s" repeatCount="indefinite"/></text>
   <circle class="particle" cx="0" cy="0" r="3" opacity="0">
-    <animateMotion path="M 0,0 L 0,150" dur="9s" begin="1.6s" repeatCount="indefinite"/>
-    <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.08;0.92;1" dur="9s" begin="1.6s" repeatCount="indefinite"/>
-  </circle>
-  <circle class="particle" cx="0" cy="0" r="3" opacity="0">
-    <animateMotion path="M 0,0 L 0,150" dur="9s" begin="6.1s" repeatCount="indefinite"/>
-    <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.08;0.92;1" dur="9s" begin="6.1s" repeatCount="indefinite"/>
+    <animateMotion path="M 0,0 L 0,150" dur="6s" begin="3s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0;1;1;0;0" keyTimes="0;0.05;0.9;0.95;1" dur="6s" begin="3s" repeatCount="indefinite"/>
   </circle>
   <circle class="ping" cx="0" cy="150" r="5" opacity="0">
-    <animate attributeName="r" values="5;5;13" keyTimes="0;0.86;1" dur="9s" begin="1.6s" repeatCount="indefinite"/>
-    <animate attributeName="opacity" values="0;0;0.9;0" keyTimes="0;0.86;0.93;1" dur="9s" begin="1.6s" repeatCount="indefinite"/>
+    <animate attributeName="r" values="5;5;14;14" keyTimes="0;0.92;0.99;1" dur="6s" begin="3s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0;0;0.9;0;0" keyTimes="0;0.92;0.95;0.99;1" dur="6s" begin="3s" repeatCount="indefinite"/>
   </circle>
 
-  <!-- SW — in from PROJECT NOTES (7s) -->
-  <circle class="particle" cx="0" cy="0" r="3" opacity="0">
-    <animateMotion path="M -106.07,106.07 L 0,0" dur="7s" begin="2s" repeatCount="indefinite"/>
-    <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.08;0.92;1" dur="7s" begin="2s" repeatCount="indefinite"/>
-  </circle>
-  <circle class="particle" cx="0" cy="0" r="3" opacity="0">
-    <animateMotion path="M -106.07,106.07 L 0,0" dur="7s" begin="5.5s" repeatCount="indefinite"/>
-    <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.08;0.92;1" dur="7s" begin="5.5s" repeatCount="indefinite"/>
-  </circle>
+  <!-- SW — PROJECT NOTES (inbound, begin 3.75s) -->
+  <line class="spoke" x1="0" y1="0" x2="-106.07" y2="106.07"/>
+  <circle class="node" cx="-106.07" cy="106.07" r="5"/>
+  <text class="node-label" x="-123.74" y="127.74" text-anchor="end">PROJECT NOTES<animate attributeName="fill" values="#a855f7;#a855f7;#f5e9ff;#a855f7;#a855f7" keyTimes="0;0.02;0.05;0.07;1" dur="6s" begin="3.75s" repeatCount="indefinite"/></text>
   <circle class="ping" cx="-106.07" cy="106.07" r="5" opacity="0">
-    <animate attributeName="r" values="5;13;13" keyTimes="0;0.12;1" dur="7s" begin="2s" repeatCount="indefinite"/>
-    <animate attributeName="opacity" values="0.9;0;0;0" keyTimes="0;0.12;0.99;1" dur="7s" begin="2s" repeatCount="indefinite"/>
+    <animate attributeName="r" values="5;5;14;14" keyTimes="0;0.02;0.07;1" dur="6s" begin="3.75s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0;0;0.9;0;0" keyTimes="0;0.02;0.05;0.07;1" dur="6s" begin="3.75s" repeatCount="indefinite"/>
+  </circle>
+  <circle class="particle" cx="0" cy="0" r="3" opacity="0">
+    <animateMotion path="M -106.07,106.07 L 0,0" dur="6s" calcMode="linear" keyPoints="0;0;1;1" keyTimes="0;0.07;0.92;1" begin="3.75s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0;0;1;1;0;0" keyTimes="0;0.07;0.09;0.9;0.92;1" dur="6s" begin="3.75s" repeatCount="indefinite"/>
   </circle>
 
-  <!-- W — out to RESEARCH (10.5s) -->
+  <!-- W — RESEARCH (begin 4.5s) -->
+  <line class="spoke" x1="0" y1="0" x2="-150" y2="0"/>
+  <circle class="node" cx="-150" cy="0" r="5"/>
+  <text class="node-label" x="-175" y="4" text-anchor="end">RESEARCH<animate attributeName="fill" values="#a855f7;#a855f7;#f5e9ff;#a855f7" keyTimes="0;0.92;0.95;1" dur="6s" begin="4.5s" repeatCount="indefinite"/></text>
   <circle class="particle" cx="0" cy="0" r="3" opacity="0">
-    <animateMotion path="M 0,0 L -150,0" dur="10.5s" begin="2.4s" repeatCount="indefinite"/>
-    <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.08;0.92;1" dur="10.5s" begin="2.4s" repeatCount="indefinite"/>
-  </circle>
-  <circle class="particle" cx="0" cy="0" r="3" opacity="0">
-    <animateMotion path="M 0,0 L -150,0" dur="10.5s" begin="7.65s" repeatCount="indefinite"/>
-    <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.08;0.92;1" dur="10.5s" begin="7.65s" repeatCount="indefinite"/>
+    <animateMotion path="M 0,0 L -150,0" dur="6s" begin="4.5s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0;1;1;0;0" keyTimes="0;0.05;0.9;0.95;1" dur="6s" begin="4.5s" repeatCount="indefinite"/>
   </circle>
   <circle class="ping" cx="-150" cy="0" r="5" opacity="0">
-    <animate attributeName="r" values="5;5;13" keyTimes="0;0.86;1" dur="10.5s" begin="2.4s" repeatCount="indefinite"/>
-    <animate attributeName="opacity" values="0;0;0.9;0" keyTimes="0;0.86;0.93;1" dur="10.5s" begin="2.4s" repeatCount="indefinite"/>
+    <animate attributeName="r" values="5;5;14;14" keyTimes="0;0.92;0.99;1" dur="6s" begin="4.5s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0;0;0.9;0;0" keyTimes="0;0.92;0.95;0.99;1" dur="6s" begin="4.5s" repeatCount="indefinite"/>
   </circle>
 
-  <!-- NW — in from MCP SERVER (8s) -->
-  <circle class="particle" cx="0" cy="0" r="3" opacity="0">
-    <animateMotion path="M -106.07,-106.07 L 0,0" dur="8s" begin="2.8s" repeatCount="indefinite"/>
-    <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.08;0.92;1" dur="8s" begin="2.8s" repeatCount="indefinite"/>
-  </circle>
-  <circle class="particle" cx="0" cy="0" r="3" opacity="0">
-    <animateMotion path="M -106.07,-106.07 L 0,0" dur="8s" begin="6.8s" repeatCount="indefinite"/>
-    <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.08;0.92;1" dur="8s" begin="6.8s" repeatCount="indefinite"/>
-  </circle>
+  <!-- NW — MCP SERVER (inbound, begin 5.25s) -->
+  <line class="spoke" x1="0" y1="0" x2="-106.07" y2="-106.07"/>
+  <circle class="node" cx="-106.07" cy="-106.07" r="5"/>
+  <text class="node-label" x="-123.74" y="-119.74" text-anchor="end">MCP SERVER<animate attributeName="fill" values="#a855f7;#a855f7;#f5e9ff;#a855f7;#a855f7" keyTimes="0;0.02;0.05;0.07;1" dur="6s" begin="5.25s" repeatCount="indefinite"/></text>
   <circle class="ping" cx="-106.07" cy="-106.07" r="5" opacity="0">
-    <animate attributeName="r" values="5;13;13" keyTimes="0;0.12;1" dur="8s" begin="2.8s" repeatCount="indefinite"/>
-    <animate attributeName="opacity" values="0.9;0;0;0" keyTimes="0;0.12;0.99;1" dur="8s" begin="2.8s" repeatCount="indefinite"/>
+    <animate attributeName="r" values="5;5;14;14" keyTimes="0;0.02;0.07;1" dur="6s" begin="5.25s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0;0;0.9;0;0" keyTimes="0;0.02;0.05;0.07;1" dur="6s" begin="5.25s" repeatCount="indefinite"/>
+  </circle>
+  <circle class="particle" cx="0" cy="0" r="3" opacity="0">
+    <animateMotion path="M -106.07,-106.07 L 0,0" dur="6s" calcMode="linear" keyPoints="0;0;1;1" keyTimes="0;0.07;0.92;1" begin="5.25s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0;0;1;1;0;0" keyTimes="0;0.07;0.09;0.9;0.92;1" dur="6s" begin="5.25s" repeatCount="indefinite"/>
   </circle>
 
   <!-- Center: Obsidian vault as command center -->
-  <circle class="core" cx="0" cy="0" r="52"/>
+  <circle class="core" cx="0" cy="0" r="52" fill="url(#g-core-fill)"/>
   <g transform="translate(0,-23)">
     <path class="core-logo-shell" d="M 0 -9 L 7.79 -4.5 L 7.79 4.5 L 0 9 L -7.79 4.5 L -7.79 -4.5 Z"/>
     <path class="core-logo-cut"   d="M 0 -9 L 0 0 M 0 0 L 7.79 4.5 M 0 0 L -7.79 4.5"/>

--- a/assets/diagrams/vault-hub-light.svg
+++ b/assets/diagrams/vault-hub-light.svg
@@ -1,192 +1,151 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="-280 -210 560 420" width="640" role="img" aria-labelledby="title desc" font-family="'JetBrains Mono', ui-monospace, monospace">
   <title id="title">Obsidian as Command Center</title>
-  <desc id="desc">Hub-and-spoke diagram (light theme). Obsidian vault sits at the center, with eight spokes radiating outward to CLI/repo, website, cloud infra, social media, office docs, project notes, research, and MCP server.</desc>
+  <desc id="desc">Hub-and-spoke diagram. Obsidian vault sits at the center, with eight spokes radiating outward to CLI/repo, website, cloud infra, social media, office docs, project notes, research, and MCP server.</desc>
 
   <style>
-    .ring        { fill: none; stroke: #7c1ade; stroke-opacity: 0.28; stroke-dasharray: 3 5; transform-origin: 0 0; }
-    .spoke       { stroke: #7c1ade; stroke-opacity: 0.55; stroke-width: 1; }
-    .node        { fill: #7c1ade; }
-    .node-label  { fill: rgba(10,10,20,0.82); font-size: 11px; letter-spacing: 0.18em; }
-    .particle    { fill: #0a0a14; }
-    .ping        { fill: none; stroke: #7c1ade; stroke-width: 1.5; }
-    .core        { fill: #ffffff; stroke: #7c1ade; stroke-width: 1.5; transform-origin: 0 0; }
-    .core-label  { fill: #0a0a14; font-size: 11.5px; font-weight: 700; letter-spacing: 0.16em; }
-    .core-sub    { fill: #7c1ade; font-size: 9px; letter-spacing: 0.32em; }
-    .core-logo-shell { fill: #7c1ade; fill-opacity: 0.22; stroke: #7c1ade; stroke-width: 1.3; stroke-linejoin: round; }
-    .core-logo-cut   { fill: none; stroke: #7c1ade; stroke-width: 0.9; stroke-opacity: 0.85; stroke-linecap: round; }
+    .spoke       { stroke: #9234e8; stroke-opacity: 0.45; stroke-width: 1.3; }
+    .node        { fill: #9234e8; }
+    .node-label  { fill: #a855f7; font-size: 11px; font-weight: 600; letter-spacing: 0.18em; }
+    .particle    { fill: #9234e8; }
+    .ping        { fill: none; stroke: #9234e8; stroke-width: 2; }
+    .core        { transform-origin: center; transform-box: fill-box; }
+    .core-label  { fill: #ffffff; font-size: 11.5px; font-weight: 700; letter-spacing: 0.16em; }
+    .core-sub    { fill: rgba(255,255,255,0.85); font-size: 9px; letter-spacing: 0.32em; }
+    .core-logo-shell { fill: rgba(255,255,255,0.25); stroke: #ffffff; stroke-width: 1.3; stroke-linejoin: round; }
+    .core-logo-cut   { fill: none; stroke: rgba(255,255,255,0.85); stroke-width: 0.9; stroke-linecap: round; }
 
-    @keyframes ring-spin { to { transform: rotate(360deg); } }
     @keyframes core-breathe {
-      0%, 100% { stroke-width: 1.5; stroke-opacity: 0.65; }
-      50%      { stroke-width: 2.5; stroke-opacity: 1.00; }
+      0%, 100% { transform: scale(1); }
+      50%      { transform: scale(1.03); }
     }
-    .ring { animation: ring-spin 120s linear infinite; }
     .core { animation: core-breathe 9s ease-in-out infinite; }
 
     @media (prefers-reduced-motion: reduce) {
-      .ring, .core { animation: none; }
+      .core { animation: none; }
       .particle, .ping { display: none; }
     }
   </style>
 
-  <!-- Outer guide ring (slowly rotating) -->
-  <circle class="ring" cx="0" cy="0" r="150"/>
+  <defs>
+    <radialGradient id="g-core-fill" cx="0.32" cy="0.32" r="0.85">
+      <stop offset="0%"   stop-color="#a855f7" stop-opacity="1"/>
+      <stop offset="100%" stop-color="#9234e8" stop-opacity="1"/>
+    </radialGradient>
+  </defs>
 
-  <!-- N — CLI / REPO -->
+  <!-- 8 spokes — all outbound from vault → outer node.
+       cycle dur=6s, begin offsets staggered 0.75s apart so exactly
+       one spoke fires every 0.75s. Particle keyTimes 0.05–0.92 (travel),
+       0.92–0.95 (fade out at node). Ring at outer node bursts 0.92–0.99
+       with peak opacity at 0.95 — exact sync with arrival. Text label
+       flashes brighter purple 0.92–0.96 in tandem. -->
+
+  <!-- N — CLI / REPO (begin 0s) -->
   <line class="spoke" x1="0" y1="0" x2="0" y2="-150"/>
   <circle class="node" cx="0" cy="-150" r="5"/>
-  <text class="node-label" x="0" y="-183" text-anchor="middle">CLI / REPO</text>
-
-  <!-- NE — WEBSITE -->
-  <line class="spoke" x1="0" y1="0" x2="106.07" y2="-106.07"/>
-  <circle class="node" cx="106.07" cy="-106.07" r="5"/>
-  <text class="node-label" x="123.74" y="-119.74" text-anchor="start">WEBSITE</text>
-
-  <!-- E — CLOUD INFRA -->
-  <line class="spoke" x1="0" y1="0" x2="150" y2="0"/>
-  <circle class="node" cx="150" cy="0" r="5"/>
-  <text class="node-label" x="175" y="4" text-anchor="start">CLOUD INFRA</text>
-
-  <!-- SE — SOCIAL MEDIA -->
-  <line class="spoke" x1="0" y1="0" x2="106.07" y2="106.07"/>
-  <circle class="node" cx="106.07" cy="106.07" r="5"/>
-  <text class="node-label" x="123.74" y="127.74" text-anchor="start">SOCIAL MEDIA</text>
-
-  <!-- S — OFFICE DOCS -->
-  <line class="spoke" x1="0" y1="0" x2="0" y2="150"/>
-  <circle class="node" cx="0" cy="150" r="5"/>
-  <text class="node-label" x="0" y="189" text-anchor="middle">OFFICE DOCS</text>
-
-  <!-- SW — PROJECT NOTES -->
-  <line class="spoke" x1="0" y1="0" x2="-106.07" y2="106.07"/>
-  <circle class="node" cx="-106.07" cy="106.07" r="5"/>
-  <text class="node-label" x="-123.74" y="127.74" text-anchor="end">PROJECT NOTES</text>
-
-  <!-- W — RESEARCH -->
-  <line class="spoke" x1="0" y1="0" x2="-150" y2="0"/>
-  <circle class="node" cx="-150" cy="0" r="5"/>
-  <text class="node-label" x="-175" y="4" text-anchor="end">RESEARCH</text>
-
-  <!-- NW — MCP SERVER -->
-  <line class="spoke" x1="0" y1="0" x2="-106.07" y2="-106.07"/>
-  <circle class="node" cx="-106.07" cy="-106.07" r="5"/>
-  <text class="node-label" x="-123.74" y="-119.74" text-anchor="end">MCP SERVER</text>
-
-  <!-- Animated flow: particles travel along spokes, pings flash at the active end -->
-  <!-- N — out to CLI/REPO (8.5s) -->
+  <text class="node-label" x="0" y="-183" text-anchor="middle">CLI / REPO<animate attributeName="fill" values="#a855f7;#a855f7;#f5e9ff;#a855f7" keyTimes="0;0.92;0.95;1" dur="6s" repeatCount="indefinite"/></text>
   <circle class="particle" cx="0" cy="0" r="3" opacity="0">
-    <animateMotion path="M 0,0 L 0,-150" dur="8.5s" repeatCount="indefinite"/>
-    <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.08;0.92;1" dur="8.5s" repeatCount="indefinite"/>
-  </circle>
-  <circle class="particle" cx="0" cy="0" r="3" opacity="0">
-    <animateMotion path="M 0,0 L 0,-150" dur="8.5s" begin="4.25s" repeatCount="indefinite"/>
-    <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.08;0.92;1" dur="8.5s" begin="4.25s" repeatCount="indefinite"/>
+    <animateMotion path="M 0,0 L 0,-150" dur="6s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0;1;1;0;0" keyTimes="0;0.05;0.9;0.95;1" dur="6s" repeatCount="indefinite"/>
   </circle>
   <circle class="ping" cx="0" cy="-150" r="5" opacity="0">
-    <animate attributeName="r" values="5;5;13" keyTimes="0;0.86;1" dur="8.5s" repeatCount="indefinite"/>
-    <animate attributeName="opacity" values="0;0;0.9;0" keyTimes="0;0.86;0.93;1" dur="8.5s" repeatCount="indefinite"/>
+    <animate attributeName="r" values="5;5;14;14" keyTimes="0;0.92;0.99;1" dur="6s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0;0;0.9;0;0" keyTimes="0;0.92;0.95;0.99;1" dur="6s" repeatCount="indefinite"/>
   </circle>
 
-  <!-- NE — in from WEBSITE (7.5s) -->
-  <circle class="particle" cx="0" cy="0" r="3" opacity="0">
-    <animateMotion path="M 106.07,-106.07 L 0,0" dur="7.5s" begin="0.4s" repeatCount="indefinite"/>
-    <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.08;0.92;1" dur="7.5s" begin="0.4s" repeatCount="indefinite"/>
-  </circle>
-  <circle class="particle" cx="0" cy="0" r="3" opacity="0">
-    <animateMotion path="M 106.07,-106.07 L 0,0" dur="7.5s" begin="4.15s" repeatCount="indefinite"/>
-    <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.08;0.92;1" dur="7.5s" begin="4.15s" repeatCount="indefinite"/>
-  </circle>
+  <!-- NE — WEBSITE (inbound, begin 0.75s) — outer pings first, then particle leaves -->
+  <line class="spoke" x1="0" y1="0" x2="106.07" y2="-106.07"/>
+  <circle class="node" cx="106.07" cy="-106.07" r="5"/>
+  <text class="node-label" x="123.74" y="-119.74" text-anchor="start">WEBSITE<animate attributeName="fill" values="#a855f7;#a855f7;#f5e9ff;#a855f7;#a855f7" keyTimes="0;0.02;0.05;0.07;1" dur="6s" begin="0.75s" repeatCount="indefinite"/></text>
   <circle class="ping" cx="106.07" cy="-106.07" r="5" opacity="0">
-    <animate attributeName="r" values="5;13;13" keyTimes="0;0.12;1" dur="7.5s" begin="0.4s" repeatCount="indefinite"/>
-    <animate attributeName="opacity" values="0.9;0;0;0" keyTimes="0;0.12;0.99;1" dur="7.5s" begin="0.4s" repeatCount="indefinite"/>
+    <animate attributeName="r" values="5;5;14;14" keyTimes="0;0.02;0.07;1" dur="6s" begin="0.75s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0;0;0.9;0;0" keyTimes="0;0.02;0.05;0.07;1" dur="6s" begin="0.75s" repeatCount="indefinite"/>
+  </circle>
+  <circle class="particle" cx="0" cy="0" r="3" opacity="0">
+    <animateMotion path="M 106.07,-106.07 L 0,0" dur="6s" calcMode="linear" keyPoints="0;0;1;1" keyTimes="0;0.07;0.92;1" begin="0.75s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0;0;1;1;0;0" keyTimes="0;0.07;0.09;0.9;0.92;1" dur="6s" begin="0.75s" repeatCount="indefinite"/>
   </circle>
 
-  <!-- E — out to CLOUD INFRA (9.5s) -->
+  <!-- E — CLOUD INFRA (begin 1.5s) -->
+  <line class="spoke" x1="0" y1="0" x2="150" y2="0"/>
+  <circle class="node" cx="150" cy="0" r="5"/>
+  <text class="node-label" x="175" y="4" text-anchor="start">CLOUD INFRA<animate attributeName="fill" values="#a855f7;#a855f7;#f5e9ff;#a855f7" keyTimes="0;0.92;0.95;1" dur="6s" begin="1.5s" repeatCount="indefinite"/></text>
   <circle class="particle" cx="0" cy="0" r="3" opacity="0">
-    <animateMotion path="M 0,0 L 150,0" dur="9.5s" begin="0.8s" repeatCount="indefinite"/>
-    <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.08;0.92;1" dur="9.5s" begin="0.8s" repeatCount="indefinite"/>
-  </circle>
-  <circle class="particle" cx="0" cy="0" r="3" opacity="0">
-    <animateMotion path="M 0,0 L 150,0" dur="9.5s" begin="5.55s" repeatCount="indefinite"/>
-    <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.08;0.92;1" dur="9.5s" begin="5.55s" repeatCount="indefinite"/>
+    <animateMotion path="M 0,0 L 150,0" dur="6s" begin="1.5s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0;1;1;0;0" keyTimes="0;0.05;0.9;0.95;1" dur="6s" begin="1.5s" repeatCount="indefinite"/>
   </circle>
   <circle class="ping" cx="150" cy="0" r="5" opacity="0">
-    <animate attributeName="r" values="5;5;13" keyTimes="0;0.86;1" dur="9.5s" begin="0.8s" repeatCount="indefinite"/>
-    <animate attributeName="opacity" values="0;0;0.9;0" keyTimes="0;0.86;0.93;1" dur="9.5s" begin="0.8s" repeatCount="indefinite"/>
+    <animate attributeName="r" values="5;5;14;14" keyTimes="0;0.92;0.99;1" dur="6s" begin="1.5s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0;0;0.9;0;0" keyTimes="0;0.92;0.95;0.99;1" dur="6s" begin="1.5s" repeatCount="indefinite"/>
   </circle>
 
-  <!-- SE — in from SOCIAL MEDIA (10s) -->
-  <circle class="particle" cx="0" cy="0" r="3" opacity="0">
-    <animateMotion path="M 106.07,106.07 L 0,0" dur="10s" begin="1.2s" repeatCount="indefinite"/>
-    <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.08;0.92;1" dur="10s" begin="1.2s" repeatCount="indefinite"/>
-  </circle>
-  <circle class="particle" cx="0" cy="0" r="3" opacity="0">
-    <animateMotion path="M 106.07,106.07 L 0,0" dur="10s" begin="6.2s" repeatCount="indefinite"/>
-    <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.08;0.92;1" dur="10s" begin="6.2s" repeatCount="indefinite"/>
-  </circle>
+  <!-- SE — SOCIAL MEDIA (inbound, begin 2.25s) -->
+  <line class="spoke" x1="0" y1="0" x2="106.07" y2="106.07"/>
+  <circle class="node" cx="106.07" cy="106.07" r="5"/>
+  <text class="node-label" x="123.74" y="127.74" text-anchor="start">SOCIAL MEDIA<animate attributeName="fill" values="#a855f7;#a855f7;#f5e9ff;#a855f7;#a855f7" keyTimes="0;0.02;0.05;0.07;1" dur="6s" begin="2.25s" repeatCount="indefinite"/></text>
   <circle class="ping" cx="106.07" cy="106.07" r="5" opacity="0">
-    <animate attributeName="r" values="5;13;13" keyTimes="0;0.12;1" dur="10s" begin="1.2s" repeatCount="indefinite"/>
-    <animate attributeName="opacity" values="0.9;0;0;0" keyTimes="0;0.12;0.99;1" dur="10s" begin="1.2s" repeatCount="indefinite"/>
+    <animate attributeName="r" values="5;5;14;14" keyTimes="0;0.02;0.07;1" dur="6s" begin="2.25s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0;0;0.9;0;0" keyTimes="0;0.02;0.05;0.07;1" dur="6s" begin="2.25s" repeatCount="indefinite"/>
+  </circle>
+  <circle class="particle" cx="0" cy="0" r="3" opacity="0">
+    <animateMotion path="M 106.07,106.07 L 0,0" dur="6s" calcMode="linear" keyPoints="0;0;1;1" keyTimes="0;0.07;0.92;1" begin="2.25s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0;0;1;1;0;0" keyTimes="0;0.07;0.09;0.9;0.92;1" dur="6s" begin="2.25s" repeatCount="indefinite"/>
   </circle>
 
-  <!-- S — out to OFFICE DOCS (9s) -->
+  <!-- S — OFFICE DOCS (begin 3s) -->
+  <line class="spoke" x1="0" y1="0" x2="0" y2="150"/>
+  <circle class="node" cx="0" cy="150" r="5"/>
+  <text class="node-label" x="0" y="189" text-anchor="middle">OFFICE DOCS<animate attributeName="fill" values="#a855f7;#a855f7;#f5e9ff;#a855f7" keyTimes="0;0.92;0.95;1" dur="6s" begin="3s" repeatCount="indefinite"/></text>
   <circle class="particle" cx="0" cy="0" r="3" opacity="0">
-    <animateMotion path="M 0,0 L 0,150" dur="9s" begin="1.6s" repeatCount="indefinite"/>
-    <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.08;0.92;1" dur="9s" begin="1.6s" repeatCount="indefinite"/>
-  </circle>
-  <circle class="particle" cx="0" cy="0" r="3" opacity="0">
-    <animateMotion path="M 0,0 L 0,150" dur="9s" begin="6.1s" repeatCount="indefinite"/>
-    <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.08;0.92;1" dur="9s" begin="6.1s" repeatCount="indefinite"/>
+    <animateMotion path="M 0,0 L 0,150" dur="6s" begin="3s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0;1;1;0;0" keyTimes="0;0.05;0.9;0.95;1" dur="6s" begin="3s" repeatCount="indefinite"/>
   </circle>
   <circle class="ping" cx="0" cy="150" r="5" opacity="0">
-    <animate attributeName="r" values="5;5;13" keyTimes="0;0.86;1" dur="9s" begin="1.6s" repeatCount="indefinite"/>
-    <animate attributeName="opacity" values="0;0;0.9;0" keyTimes="0;0.86;0.93;1" dur="9s" begin="1.6s" repeatCount="indefinite"/>
+    <animate attributeName="r" values="5;5;14;14" keyTimes="0;0.92;0.99;1" dur="6s" begin="3s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0;0;0.9;0;0" keyTimes="0;0.92;0.95;0.99;1" dur="6s" begin="3s" repeatCount="indefinite"/>
   </circle>
 
-  <!-- SW — in from PROJECT NOTES (7s) -->
-  <circle class="particle" cx="0" cy="0" r="3" opacity="0">
-    <animateMotion path="M -106.07,106.07 L 0,0" dur="7s" begin="2s" repeatCount="indefinite"/>
-    <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.08;0.92;1" dur="7s" begin="2s" repeatCount="indefinite"/>
-  </circle>
-  <circle class="particle" cx="0" cy="0" r="3" opacity="0">
-    <animateMotion path="M -106.07,106.07 L 0,0" dur="7s" begin="5.5s" repeatCount="indefinite"/>
-    <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.08;0.92;1" dur="7s" begin="5.5s" repeatCount="indefinite"/>
-  </circle>
+  <!-- SW — PROJECT NOTES (inbound, begin 3.75s) -->
+  <line class="spoke" x1="0" y1="0" x2="-106.07" y2="106.07"/>
+  <circle class="node" cx="-106.07" cy="106.07" r="5"/>
+  <text class="node-label" x="-123.74" y="127.74" text-anchor="end">PROJECT NOTES<animate attributeName="fill" values="#a855f7;#a855f7;#f5e9ff;#a855f7;#a855f7" keyTimes="0;0.02;0.05;0.07;1" dur="6s" begin="3.75s" repeatCount="indefinite"/></text>
   <circle class="ping" cx="-106.07" cy="106.07" r="5" opacity="0">
-    <animate attributeName="r" values="5;13;13" keyTimes="0;0.12;1" dur="7s" begin="2s" repeatCount="indefinite"/>
-    <animate attributeName="opacity" values="0.9;0;0;0" keyTimes="0;0.12;0.99;1" dur="7s" begin="2s" repeatCount="indefinite"/>
+    <animate attributeName="r" values="5;5;14;14" keyTimes="0;0.02;0.07;1" dur="6s" begin="3.75s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0;0;0.9;0;0" keyTimes="0;0.02;0.05;0.07;1" dur="6s" begin="3.75s" repeatCount="indefinite"/>
+  </circle>
+  <circle class="particle" cx="0" cy="0" r="3" opacity="0">
+    <animateMotion path="M -106.07,106.07 L 0,0" dur="6s" calcMode="linear" keyPoints="0;0;1;1" keyTimes="0;0.07;0.92;1" begin="3.75s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0;0;1;1;0;0" keyTimes="0;0.07;0.09;0.9;0.92;1" dur="6s" begin="3.75s" repeatCount="indefinite"/>
   </circle>
 
-  <!-- W — out to RESEARCH (10.5s) -->
+  <!-- W — RESEARCH (begin 4.5s) -->
+  <line class="spoke" x1="0" y1="0" x2="-150" y2="0"/>
+  <circle class="node" cx="-150" cy="0" r="5"/>
+  <text class="node-label" x="-175" y="4" text-anchor="end">RESEARCH<animate attributeName="fill" values="#a855f7;#a855f7;#f5e9ff;#a855f7" keyTimes="0;0.92;0.95;1" dur="6s" begin="4.5s" repeatCount="indefinite"/></text>
   <circle class="particle" cx="0" cy="0" r="3" opacity="0">
-    <animateMotion path="M 0,0 L -150,0" dur="10.5s" begin="2.4s" repeatCount="indefinite"/>
-    <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.08;0.92;1" dur="10.5s" begin="2.4s" repeatCount="indefinite"/>
-  </circle>
-  <circle class="particle" cx="0" cy="0" r="3" opacity="0">
-    <animateMotion path="M 0,0 L -150,0" dur="10.5s" begin="7.65s" repeatCount="indefinite"/>
-    <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.08;0.92;1" dur="10.5s" begin="7.65s" repeatCount="indefinite"/>
+    <animateMotion path="M 0,0 L -150,0" dur="6s" begin="4.5s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0;1;1;0;0" keyTimes="0;0.05;0.9;0.95;1" dur="6s" begin="4.5s" repeatCount="indefinite"/>
   </circle>
   <circle class="ping" cx="-150" cy="0" r="5" opacity="0">
-    <animate attributeName="r" values="5;5;13" keyTimes="0;0.86;1" dur="10.5s" begin="2.4s" repeatCount="indefinite"/>
-    <animate attributeName="opacity" values="0;0;0.9;0" keyTimes="0;0.86;0.93;1" dur="10.5s" begin="2.4s" repeatCount="indefinite"/>
+    <animate attributeName="r" values="5;5;14;14" keyTimes="0;0.92;0.99;1" dur="6s" begin="4.5s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0;0;0.9;0;0" keyTimes="0;0.92;0.95;0.99;1" dur="6s" begin="4.5s" repeatCount="indefinite"/>
   </circle>
 
-  <!-- NW — in from MCP SERVER (8s) -->
-  <circle class="particle" cx="0" cy="0" r="3" opacity="0">
-    <animateMotion path="M -106.07,-106.07 L 0,0" dur="8s" begin="2.8s" repeatCount="indefinite"/>
-    <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.08;0.92;1" dur="8s" begin="2.8s" repeatCount="indefinite"/>
-  </circle>
-  <circle class="particle" cx="0" cy="0" r="3" opacity="0">
-    <animateMotion path="M -106.07,-106.07 L 0,0" dur="8s" begin="6.8s" repeatCount="indefinite"/>
-    <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.08;0.92;1" dur="8s" begin="6.8s" repeatCount="indefinite"/>
-  </circle>
+  <!-- NW — MCP SERVER (inbound, begin 5.25s) -->
+  <line class="spoke" x1="0" y1="0" x2="-106.07" y2="-106.07"/>
+  <circle class="node" cx="-106.07" cy="-106.07" r="5"/>
+  <text class="node-label" x="-123.74" y="-119.74" text-anchor="end">MCP SERVER<animate attributeName="fill" values="#a855f7;#a855f7;#f5e9ff;#a855f7;#a855f7" keyTimes="0;0.02;0.05;0.07;1" dur="6s" begin="5.25s" repeatCount="indefinite"/></text>
   <circle class="ping" cx="-106.07" cy="-106.07" r="5" opacity="0">
-    <animate attributeName="r" values="5;13;13" keyTimes="0;0.12;1" dur="8s" begin="2.8s" repeatCount="indefinite"/>
-    <animate attributeName="opacity" values="0.9;0;0;0" keyTimes="0;0.12;0.99;1" dur="8s" begin="2.8s" repeatCount="indefinite"/>
+    <animate attributeName="r" values="5;5;14;14" keyTimes="0;0.02;0.07;1" dur="6s" begin="5.25s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0;0;0.9;0;0" keyTimes="0;0.02;0.05;0.07;1" dur="6s" begin="5.25s" repeatCount="indefinite"/>
+  </circle>
+  <circle class="particle" cx="0" cy="0" r="3" opacity="0">
+    <animateMotion path="M -106.07,-106.07 L 0,0" dur="6s" calcMode="linear" keyPoints="0;0;1;1" keyTimes="0;0.07;0.92;1" begin="5.25s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0;0;1;1;0;0" keyTimes="0;0.07;0.09;0.9;0.92;1" dur="6s" begin="5.25s" repeatCount="indefinite"/>
   </circle>
 
   <!-- Center: Obsidian vault as command center -->
-  <circle class="core" cx="0" cy="0" r="52"/>
+  <circle class="core" cx="0" cy="0" r="52" fill="url(#g-core-fill)"/>
   <g transform="translate(0,-23)">
     <path class="core-logo-shell" d="M 0 -9 L 7.79 -4.5 L 7.79 4.5 L 0 9 L -7.79 4.5 L -7.79 -4.5 Z"/>
     <path class="core-logo-cut"   d="M 0 -9 L 0 0 M 0 0 L 7.79 4.5 M 0 0 L -7.79 4.5"/>


### PR DESCRIPTION
## Summary

- **memory-tiers + harness-os-stack** redesigned to gradient-fill stacked rectangles (horizontal linearGradient, white text on saturated bg, dashed bidirectional flow arrows between tiers). Replaces outline/opacity-fade.
- **bidir-flow / coevo-loop / vault-hub** existing `-light` design preserved; `-dark` variants now identical to `-light` (single design works on both bg via white-on-saturated). README's `<picture>` swap pattern unchanged.
- **Accessibility:** SMIL `<animate stroke-dashoffset>` → CSS `@keyframes` so `prefers-reduced-motion` actually suppresses flow-line animation. `vault-hub-{light,dark}.svg <desc>` no longer mislabels itself.

## Why per-file stroke color instead of `@media (prefers-color-scheme: dark)`

`@media (prefers-color-scheme)` inside SVG loaded via `<img>` responds to **user OS theme**, not container background. Unreliable for GitHub README. Each `-light` / `-dark` file now has stroke color baked in.

## Test plan

- [x] Local visual review (5 diagrams × light + dark = 10 panels) via `preview.html` harness
- [x] 3 rounds of parallel sub-agent review (correctness / project conventions / SVG cross-browser)
- [x] Pair integrity: `bidir-flow`, `coevo-loop`, `vault-hub` `-light`/`-dark` byte-identical; `memory-tiers`, `harness-os-stack` differ only on `.flow` stroke + spine accent
- [x] `prefers-reduced-motion` selector includes `.icon-pulse, .flow-down, .flow-up` (CSS animations only — no SMIL left in these 4 files)
- [x] No `prefers-color-scheme` in modified files
- [x] English-only files; no version bump (assets-only refresh)
- [ ] Verify GitHub render of README in light/dark mode after merge

## Files

- `assets/diagrams/{memory-tiers,harness-os-stack,bidir-flow,coevo-loop,vault-hub}-{light,dark}.svg` (10)
- `.gitignore` — exclude local `preview.html` harness

🤖 Generated with [Claude Code](https://claude.com/claude-code)