### PR TITLE
refactor(update): delegate CLI bump to `onebrain update`

### DIFF
--- a/.claude/plugins/onebrain/.claude-plugin/plugin.json
+++ b/.claude/plugins/onebrain/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "onebrain",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "OneBrain — Where human and AI thinking become one. A powerful thinking partner powered by AI synergy.",
   "author": {
     "name": "OneBrain Contributors"

--- a/.claude/plugins/onebrain/skills/update/SKILL.md
+++ b/.claude/plugins/onebrain/skills/update/SKILL.md
@@ -47,36 +47,20 @@ Minor/patch bumps (1.10.0 → 1.10.1, 1.10.0 → 1.11.0): proceed without major 
 
 ## CLI Version Check
 
-After confirming the vault update (step 7 above), also check if the installed `onebrain` CLI is up to date.
+After confirming the vault update (step 7 above), also bring the installed `onebrain` CLI up to date by delegating to the CLI's own update path.
 
-1. Run `onebrain --version 2>/dev/null` → parse installed version (e.g. `2.0.4`). If command not found → skip this section entirely.
-2. Fetch latest from npm: `npm view @onebrain-ai/cli version 2>/dev/null` → parse version string. If npm unavailable or fetch fails → skip.
-3. If installed = latest → skip (no output needed).
-4. If newer version available:
-   a. Detect available package managers. Use the form matching the active shell — PowerShell 5.1 (Win10/Server 2019 default) does not parse `||` as a control operator, so do not chain `which || where` in a single command:
-      - **Bash / zsh / Git Bash:**
-        ```bash
-        which bun 2>/dev/null
-        which npm 2>/dev/null
-        ```
-      - **PowerShell:** `Get-Command` always exits 0 — interpret presence by whether the command emitted a `CommandInfo` line (non-empty stdout) rather than by exit code:
-        ```powershell
-        Get-Command bun -ErrorAction SilentlyContinue
-        Get-Command npm -ErrorAction SilentlyContinue
-        ```
-      - **cmd:**
-        ```
-        where bun 2>nul
-        where npm 2>nul
-        ```
-   b. AskUserQuestion: "Update onebrain CLI from v{installed} to v{latest}?"
-      - Both bun and npm available: options `npm / bun / skip` (npm as default)
-      - Only bun: options `bun / skip`
-      - Only npm: options `npm / skip`
-      - Neither available: output `⚠️ CLI v{installed} is outdated (latest: v{latest}) — install npm or bun to update.` and skip
-   c. If `npm` selected: run `npm install -g @onebrain-ai/cli`
-   d. If `bun` selected: run `bun install -g @onebrain-ai/cli`
-   e. Verify: run `onebrain --version` → confirm output matches `{latest}`
+1. **Probe whether `onebrain` is on PATH.** Use the form matching the active shell. `Get-Command` always exits 0, so on PowerShell interpret presence by stdout content (a non-empty `CommandInfo` line = present), not by exit code:
+   - **Bash / zsh / Git Bash:** `onebrain --version 2>/dev/null` — non-zero exit = not installed.
+   - **PowerShell:** `Get-Command onebrain -ErrorAction SilentlyContinue` — empty stdout = not installed.
+   - **cmd:** `where onebrain 2>nul` — non-zero exit = not installed.
+
+   If not installed, skip this section entirely — the CLI cannot self-update if it isn't installed; first-time CLI install lives in the README, not here.
+
+2. Run `onebrain update`. The CLI handles everything: version comparison against the GitHub releases API, package-manager choice (`bun` on macOS/Linux, `npm` via PowerShell on Windows), install, and post-install binary validation. If already current it prints `Already up to date — @onebrain-ai/cli vX.Y.Z` and exits 0; no further action.
+
+3. If `onebrain update` exits non-zero, surface its captured output (both stdout and stderr) verbatim to the user — `runUpdate` writes the human-readable step lines to stdout and the final error tag to stderr, so showing only stderr would hide the diagnostic context. Then continue with the rest of `/update` — CLI failure does not block the vault sync that already completed (and re-running `/update` retries the CLI bump idempotently).
+
+> **Why one command instead of a prompt.** `onebrain update` is the canonical CLI-update path. Duplicating its logic here (raw `npm view` + AskUserQuestion + `npm install -g`) would drift from the CLI's own version check and validation gates. The user already confirmed `/update` at step 6; the CLI bump rides on that confirmation.
 
 ## Self-Update Bootstrap (Read-New, Execute-In-Place)
 
@@ -186,3 +170,5 @@ Dry run complete — {N} files would be created, {M} modified, {P} deleted.
 - **Root files live at the repo root, not the plugin folder.** `onebrain vault-sync` handles all seven root-level files: README.md, CONTRIBUTING.md, CHANGELOG.md, PLUGIN-CHANGELOG.md (simple overwrite) and CLAUDE.md, GEMINI.md, AGENTS.md (merge — preserves user `@` imports). Never copy any of these into the plugin folder.
 
 - **Failure recovery path:** If interrupted before step 3d (plugin.json bump), re-running /update will retry from step 1. The early bootstrap (download SKILL.md) is idempotent — safe to repeat.
+
+- **CLI update delegates to `onebrain update`.** Do not call `npm install -g @onebrain-ai/cli` or `bun install -g @onebrain-ai/cli` from this skill — `onebrain update` is the single source of truth for the CLI bump (version check, package-manager choice, validation). Raw npm/bun is reserved for first-time CLI bootstrap, which is a README/install-script concern, not a `/update` concern.

--- a/PLUGIN-CHANGELOG.md
+++ b/PLUGIN-CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-latest_version: 2.3.1
+latest_version: 2.3.2
 released: 2026-05-07
 ---
 
@@ -12,6 +12,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 > For CLI binary (`@onebrain-ai/cli`) changes, see [CHANGELOG.md](CHANGELOG.md).
 
 ## [Unreleased]
+
+## v2.3.2 — refactor(update): delegate CLI bump to `onebrain update`
+
+`/update`'s "CLI Version Check" section was duplicating logic that the `onebrain update` CLI already owns: GitHub release lookup, package-manager detection, install, and binary validation. The skill now defers to the CLI as the single source of truth for the CLI bump.
+
+- refactor(update/SKILL.md): replace 30-line "CLI Version Check" block (raw `npm view` + AskUserQuestion + per-shell bun/npm detection + `npm install -g` / `bun install -g`) with a 3-step delegation: probe `onebrain --version`, run `onebrain update`, surface non-zero exits.
+- refactor(update/SKILL.md): drop the npm/bun selection prompt — `onebrain update` already picks `bun` on macOS/Linux and `npm` on Windows; user already consented to `/update` upstream, so a second AskUserQuestion is noise.
+- docs(update/SKILL.md): add Known Gotcha — raw `npm install -g` / `bun install -g` calls are reserved for first-time CLI bootstrap (README/install scripts), never `/update`.
+- note: pure SKILL.md change, no CLI/binary change. CLI version unchanged at 2.2.0.
 
 ## v2.3.1 — fix(wrapup): active-session guard prevents cross-harness checkpoint loss
 


### PR DESCRIPTION
## Summary

- `/update`'s **CLI Version Check** section was duplicating logic that the `onebrain update` CLI already owns: GitHub release lookup, package-manager detection (bun/npm), install, post-install validation. The skill now defers to the CLI as the single source of truth for the CLI bump.
- 3-step delegation replaces the old 30-line block: shell-specific PATH probe → `onebrain update` → surface output on non-zero exit.
- Drops the second AskUserQuestion (`npm / bun / skip`); user already consented at the `/update` confirmation upstream, and `onebrain update` already picks the right package manager per platform.
- Cross-platform PATH probe preserved with explicit per-shell forms (Bash `2>/dev/null` · PowerShell `Get-Command` with stdout-presence rule · cmd `2>nul`).
- Step 3 surfaces both stdout and stderr — `runUpdate` writes step lines via `writeLine`/`close()` (stdout) and the final error tag to stderr, so stderr alone would lose diagnostic context.
- Plugin bump `2.3.1` → `2.3.2`; CLI version unchanged at `2.2.0`.

## Why

User feedback memory: *"use `onebrain update`, not raw npm/bun install (except CLI bootstrap)"*. This PR removes the last `/update`-internal copy of that raw npm/bun path. New Known Gotcha makes the boundary explicit: `npm install -g` / `bun install -g` are reserved for first-time CLI bootstrap (README), never `/update`.

## Review

3 parallel sub-agent rounds + 1 confirmation round.

- Round 1 (correctness) — flagged: stderr-only surfacing missed stdout diagnostics; PowerShell detection had no presence-by-stdout rule.
- Round 2 (conventions) — clean: plugin track ✓, ≤ 8 changelog bullets ✓, English-only ✓, sequential bump ✓.
- Round 3 (cross-platform) — flagged: same PowerShell detection issue (consensus with Round 1); `2>/dev/null` is bash-only.
- Round 4 (confirmation) — all three flagged issues RESOLVED, no regressions.

## Test plan

- [x] `git diff main --stat` confirms 3 files changed, 27/-32 lines
- [x] `plugin.json` bumped to `2.3.2` (single sequential bump from `2.3.1`)
- [x] `PLUGIN-CHANGELOG.md` `latest_version` synced; new entry under 8 bullets
- [x] `references/migration-steps.md` has no stale npm/bun references (verified by Round 1 reviewer)
- [x] `onebrain update` CLI behavior matches skill claims (`bun` on Unix, `npm` via PowerShell on Windows; idempotent already-current branch) — confirmed against `src/commands/update.ts:109-170, 250-260`
- [ ] CI green
- [ ] Run `/update` end-to-end on next vault sync to validate the new flow