### PR TITLE
fix(readme): badge top-right + vault overlap + coevo-loop scale

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Obsidian becomes your dispatch hub for everything you do:
 <p align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="assets/diagrams/vault-hub-dark.svg">
-    <img alt="Obsidian as command center — eight spokes radiate from the vault to CLI/repo, website, cloud infra, social media, office docs, project notes, research, and MCP server" src="assets/diagrams/vault-hub-light.svg" width="512">
+    <img alt="Obsidian as command center — eight spokes radiate from the vault to CLI/repo, website, cloud infra, social media, office docs, project notes, research, and MCP server" src="assets/diagrams/vault-hub-light.svg" width="460">
   </picture>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Obsidian becomes your dispatch hub for everything you do:
 <p align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="assets/diagrams/vault-hub-dark.svg">
-    <img alt="Obsidian as command center — eight spokes radiate from the vault to CLI/repo, website, cloud infra, social media, office docs, project notes, research, and MCP server" src="assets/diagrams/vault-hub-light.svg" width="640">
+    <img alt="Obsidian as command center — eight spokes radiate from the vault to CLI/repo, website, cloud infra, social media, office docs, project notes, research, and MCP server" src="assets/diagrams/vault-hub-light.svg" width="512">
   </picture>
 </p>
 
@@ -118,7 +118,7 @@ OneBrain runs as a tight 3-step loop. Each cycle, both sides sharpen.
 <p align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="assets/diagrams/coevo-loop-dark.svg">
-    <img alt="Co-Evolution loop — three nodes (01 CAPTURE at top, 02 EVOLVE at bottom-right, 03 WRAPUP at bottom-left) connected by curved arrows flowing clockwise" src="assets/diagrams/coevo-loop-light.svg" width="270">
+    <img alt="Co-Evolution loop — three nodes (01 CAPTURE at top, 02 EVOLVE at bottom-right, 03 WRAPUP at bottom-left) connected by curved arrows flowing clockwise" src="assets/diagrams/coevo-loop-light.svg" width="350">
   </picture>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ OneBrain runs as a tight 3-step loop. Each cycle, both sides sharpen.
 <p align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="assets/diagrams/coevo-loop-dark.svg">
-    <img alt="Co-Evolution loop — three nodes (01 CAPTURE at top, 02 EVOLVE at bottom-right, 03 WRAPUP at bottom-left) connected by curved arrows flowing clockwise" src="assets/diagrams/coevo-loop-light.svg" width="540">
+    <img alt="Co-Evolution loop — three nodes (01 CAPTURE at top, 02 EVOLVE at bottom-right, 03 WRAPUP at bottom-left) connected by curved arrows flowing clockwise" src="assets/diagrams/coevo-loop-light.svg" width="270">
   </picture>
 </p>
 

--- a/assets/diagrams/coevo-loop-dark.svg
+++ b/assets/diagrams/coevo-loop-dark.svg
@@ -68,7 +68,7 @@
 
   <!-- Node 01 — CAPTURE (top) -->
   <g transform="translate(0,-130)">
-    <circle class="core-1" cx="0" cy="0" r="54" fill="url(#g-capture-fill)"/>
+    <circle class="core-1" cx="0" cy="0" r="48" fill="url(#g-capture-fill)"/>
     <text x="0" y="-12" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-size="11" font-weight="700" fill="rgba(255,255,255,0.85)" letter-spacing="0.18em">01</text>
     <text x="0" y="6" text-anchor="middle" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="14" letter-spacing="0.05em" fill="#ffffff">CAPTURE</text>
     <text x="0" y="22" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-size="8" letter-spacing="0.28em" fill="rgba(255,255,255,0.85)">/braindump</text>
@@ -76,7 +76,7 @@
 
   <!-- Node 02 — EVOLVE (bottom-right) -->
   <g transform="translate(112.6,65)">
-    <circle class="core-2" cx="0" cy="0" r="54" fill="url(#g-evolve-fill)"/>
+    <circle class="core-2" cx="0" cy="0" r="48" fill="url(#g-evolve-fill)"/>
     <text x="0" y="-12" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-size="11" font-weight="700" fill="rgba(255,255,255,0.85)" letter-spacing="0.18em">02</text>
     <text x="0" y="6" text-anchor="middle" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="14" letter-spacing="0.05em" fill="#ffffff">EVOLVE</text>
     <text x="0" y="68" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-size="8" font-weight="600" letter-spacing="0.28em" fill="#9234e8">/distill · /learn</text>
@@ -84,7 +84,7 @@
 
   <!-- Node 03 — WRAPUP (bottom-left) -->
   <g transform="translate(-112.6,65)">
-    <circle class="core-3" cx="0" cy="0" r="54" fill="url(#g-wrapup-fill)"/>
+    <circle class="core-3" cx="0" cy="0" r="48" fill="url(#g-wrapup-fill)"/>
     <text x="0" y="-12" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-size="11" font-weight="700" fill="rgba(255,255,255,0.85)" letter-spacing="0.18em">03</text>
     <text x="0" y="6" text-anchor="middle" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="14" letter-spacing="0.05em" fill="#ffffff">WRAPUP</text>
     <text x="0" y="68" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-size="8" font-weight="600" letter-spacing="0.28em" fill="#00a3bc">/wrapup · /recap</text>
@@ -102,8 +102,8 @@
       <animate attributeName="opacity" values="0;1;1;0;0" keyTimes="0;0.02;0.31;0.333;1" dur="5.4s" repeatCount="indefinite"/>
     </circle>
     <!-- Ring on EVOLVE (purple) — bursts at t=0.333 -->
-    <circle cx="112.6" cy="65" r="54" fill="none" stroke="#9234e8" stroke-width="2" opacity="0">
-      <animate attributeName="r" values="54;54;76;76" keyTimes="0;0.333;0.40;1" dur="5.4s" repeatCount="indefinite"/>
+    <circle cx="112.6" cy="65" r="48" fill="none" stroke="#9234e8" stroke-width="2" opacity="0">
+      <animate attributeName="r" values="48;48;68;68" keyTimes="0;0.333;0.40;1" dur="5.4s" repeatCount="indefinite"/>
       <animate attributeName="opacity" values="0;0;0.9;0;0" keyTimes="0;0.333;0.36;0.40;1" dur="5.4s" repeatCount="indefinite"/>
     </circle>
 
@@ -113,8 +113,8 @@
       <animate attributeName="opacity" values="0;1;1;0;0" keyTimes="0;0.02;0.31;0.333;1" dur="5.4s" begin="1.8s" repeatCount="indefinite"/>
     </circle>
     <!-- Ring on WRAPUP (teal) — bursts at t=0.333 of leg-2's cycle -->
-    <circle cx="-112.6" cy="65" r="54" fill="none" stroke="#00a3bc" stroke-width="2" opacity="0">
-      <animate attributeName="r" values="54;54;76;76" keyTimes="0;0.333;0.40;1" dur="5.4s" begin="1.8s" repeatCount="indefinite"/>
+    <circle cx="-112.6" cy="65" r="48" fill="none" stroke="#00a3bc" stroke-width="2" opacity="0">
+      <animate attributeName="r" values="48;48;68;68" keyTimes="0;0.333;0.40;1" dur="5.4s" begin="1.8s" repeatCount="indefinite"/>
       <animate attributeName="opacity" values="0;0;0.9;0;0" keyTimes="0;0.333;0.36;0.40;1" dur="5.4s" begin="1.8s" repeatCount="indefinite"/>
     </circle>
 
@@ -124,8 +124,8 @@
       <animate attributeName="opacity" values="0;1;1;0;0" keyTimes="0;0.02;0.31;0.333;1" dur="5.4s" begin="3.6s" repeatCount="indefinite"/>
     </circle>
     <!-- Ring on CAPTURE (pink) — bursts at t=0.333 of leg-3's cycle -->
-    <circle cx="0" cy="-130" r="54" fill="none" stroke="#dc1c89" stroke-width="2" opacity="0">
-      <animate attributeName="r" values="54;54;76;76" keyTimes="0;0.333;0.40;1" dur="5.4s" begin="3.6s" repeatCount="indefinite"/>
+    <circle cx="0" cy="-130" r="48" fill="none" stroke="#dc1c89" stroke-width="2" opacity="0">
+      <animate attributeName="r" values="48;48;68;68" keyTimes="0;0.333;0.40;1" dur="5.4s" begin="3.6s" repeatCount="indefinite"/>
       <animate attributeName="opacity" values="0;0;0.9;0;0" keyTimes="0;0.333;0.36;0.40;1" dur="5.4s" begin="3.6s" repeatCount="indefinite"/>
     </circle>
   </g>

--- a/assets/diagrams/coevo-loop-light.svg
+++ b/assets/diagrams/coevo-loop-light.svg
@@ -68,7 +68,7 @@
 
   <!-- Node 01 — CAPTURE (top) -->
   <g transform="translate(0,-130)">
-    <circle class="core-1" cx="0" cy="0" r="54" fill="url(#g-capture-fill)"/>
+    <circle class="core-1" cx="0" cy="0" r="48" fill="url(#g-capture-fill)"/>
     <text x="0" y="-12" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-size="11" font-weight="700" fill="rgba(255,255,255,0.85)" letter-spacing="0.18em">01</text>
     <text x="0" y="6" text-anchor="middle" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="14" letter-spacing="0.05em" fill="#ffffff">CAPTURE</text>
     <text x="0" y="22" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-size="8" letter-spacing="0.28em" fill="rgba(255,255,255,0.85)">/braindump</text>
@@ -76,7 +76,7 @@
 
   <!-- Node 02 — EVOLVE (bottom-right) -->
   <g transform="translate(112.6,65)">
-    <circle class="core-2" cx="0" cy="0" r="54" fill="url(#g-evolve-fill)"/>
+    <circle class="core-2" cx="0" cy="0" r="48" fill="url(#g-evolve-fill)"/>
     <text x="0" y="-12" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-size="11" font-weight="700" fill="rgba(255,255,255,0.85)" letter-spacing="0.18em">02</text>
     <text x="0" y="6" text-anchor="middle" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="14" letter-spacing="0.05em" fill="#ffffff">EVOLVE</text>
     <text x="0" y="68" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-size="8" font-weight="600" letter-spacing="0.28em" fill="#9234e8">/distill · /learn</text>
@@ -84,7 +84,7 @@
 
   <!-- Node 03 — WRAPUP (bottom-left) -->
   <g transform="translate(-112.6,65)">
-    <circle class="core-3" cx="0" cy="0" r="54" fill="url(#g-wrapup-fill)"/>
+    <circle class="core-3" cx="0" cy="0" r="48" fill="url(#g-wrapup-fill)"/>
     <text x="0" y="-12" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-size="11" font-weight="700" fill="rgba(255,255,255,0.85)" letter-spacing="0.18em">03</text>
     <text x="0" y="6" text-anchor="middle" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="14" letter-spacing="0.05em" fill="#ffffff">WRAPUP</text>
     <text x="0" y="68" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-size="8" font-weight="600" letter-spacing="0.28em" fill="#00a3bc">/wrapup · /recap</text>
@@ -102,8 +102,8 @@
       <animate attributeName="opacity" values="0;1;1;0;0" keyTimes="0;0.02;0.31;0.333;1" dur="5.4s" repeatCount="indefinite"/>
     </circle>
     <!-- Ring on EVOLVE (purple) — bursts at t=0.333 -->
-    <circle cx="112.6" cy="65" r="54" fill="none" stroke="#9234e8" stroke-width="2" opacity="0">
-      <animate attributeName="r" values="54;54;76;76" keyTimes="0;0.333;0.40;1" dur="5.4s" repeatCount="indefinite"/>
+    <circle cx="112.6" cy="65" r="48" fill="none" stroke="#9234e8" stroke-width="2" opacity="0">
+      <animate attributeName="r" values="48;48;68;68" keyTimes="0;0.333;0.40;1" dur="5.4s" repeatCount="indefinite"/>
       <animate attributeName="opacity" values="0;0;0.9;0;0" keyTimes="0;0.333;0.36;0.40;1" dur="5.4s" repeatCount="indefinite"/>
     </circle>
 
@@ -113,8 +113,8 @@
       <animate attributeName="opacity" values="0;1;1;0;0" keyTimes="0;0.02;0.31;0.333;1" dur="5.4s" begin="1.8s" repeatCount="indefinite"/>
     </circle>
     <!-- Ring on WRAPUP (teal) — bursts at t=0.333 of leg-2's cycle -->
-    <circle cx="-112.6" cy="65" r="54" fill="none" stroke="#00a3bc" stroke-width="2" opacity="0">
-      <animate attributeName="r" values="54;54;76;76" keyTimes="0;0.333;0.40;1" dur="5.4s" begin="1.8s" repeatCount="indefinite"/>
+    <circle cx="-112.6" cy="65" r="48" fill="none" stroke="#00a3bc" stroke-width="2" opacity="0">
+      <animate attributeName="r" values="48;48;68;68" keyTimes="0;0.333;0.40;1" dur="5.4s" begin="1.8s" repeatCount="indefinite"/>
       <animate attributeName="opacity" values="0;0;0.9;0;0" keyTimes="0;0.333;0.36;0.40;1" dur="5.4s" begin="1.8s" repeatCount="indefinite"/>
     </circle>
 
@@ -124,8 +124,8 @@
       <animate attributeName="opacity" values="0;1;1;0;0" keyTimes="0;0.02;0.31;0.333;1" dur="5.4s" begin="3.6s" repeatCount="indefinite"/>
     </circle>
     <!-- Ring on CAPTURE (pink) — bursts at t=0.333 of leg-3's cycle -->
-    <circle cx="0" cy="-130" r="54" fill="none" stroke="#dc1c89" stroke-width="2" opacity="0">
-      <animate attributeName="r" values="54;54;76;76" keyTimes="0;0.333;0.40;1" dur="5.4s" begin="3.6s" repeatCount="indefinite"/>
+    <circle cx="0" cy="-130" r="48" fill="none" stroke="#dc1c89" stroke-width="2" opacity="0">
+      <animate attributeName="r" values="48;48;68;68" keyTimes="0;0.333;0.40;1" dur="5.4s" begin="3.6s" repeatCount="indefinite"/>
       <animate attributeName="opacity" values="0;0;0.9;0;0" keyTimes="0;0.333;0.36;0.40;1" dur="5.4s" begin="3.6s" repeatCount="indefinite"/>
     </circle>
   </g>

--- a/assets/diagrams/harness-os-stack-dark.svg
+++ b/assets/diagrams/harness-os-stack-dark.svg
@@ -57,11 +57,11 @@
     <rect width="780" height="130" fill="url(#g-onebrain)"/>
     <text class="icon-pulse" x="38" y="78" font-size="32" text-anchor="middle" dominant-baseline="central" aria-hidden="true">🧠</text>
     <text x="74" y="42" font-family="'JetBrains Mono', monospace" font-size="13" font-weight="700" fill="rgba(255,255,255,0.85)" letter-spacing="0.08em">LAYER_01</text>
-    <text x="74" y="82" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="28" fill="#ffffff" letter-spacing="0.04em">ONEBRAIN</text>
+    <text x="74" y="82" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="24" fill="#ffffff" letter-spacing="0.04em">ONEBRAIN</text>
     <text x="74" y="112" font-family="'JetBrains Mono', monospace" font-size="11" fill="rgba(255,255,255,0.85)" letter-spacing="0.30em">PLUGIN · CLI · ORCHESTRATOR</text>
-    <text x="290" y="68" font-family="'JetBrains Mono', monospace" font-size="13" fill="#ffffff">The OS layer driving every harness consistently.</text>
-    <text x="290" y="98" font-family="'JetBrains Mono', monospace" font-size="13" fill="rgba(255,255,255,0.78)">skills · hooks · sync · indexing · checkpoints</text>
-    <g transform="translate(668, 53)">
+    <text x="320" y="68" font-family="'JetBrains Mono', monospace" font-size="13" fill="#ffffff">The OS layer driving every harness consistently.</text>
+    <text x="320" y="98" font-family="'JetBrains Mono', monospace" font-size="13" fill="rgba(255,255,255,0.78)">skills · hooks · sync · indexing · checkpoints</text>
+    <g transform="translate(668, 14)">
       <rect width="100" height="24" fill="#ffffff"/>
       <text x="50" y="16" font-family="'JetBrains Mono', monospace" font-size="10" fill="#c91075" font-weight="700" letter-spacing="0.14em" text-anchor="middle">OS_LAYER</text>
     </g>
@@ -78,11 +78,11 @@
     <rect width="780" height="130" fill="url(#g-harness)"/>
     <text class="icon-pulse" x="38" y="78" font-size="32" text-anchor="middle" dominant-baseline="central" aria-hidden="true" style="animation-delay: 0.65s;">🤖</text>
     <text x="74" y="42" font-family="'JetBrains Mono', monospace" font-size="13" font-weight="700" fill="rgba(255,255,255,0.85)" letter-spacing="0.08em">LAYER_02</text>
-    <text x="74" y="82" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="28" fill="#ffffff" letter-spacing="0.04em">HARNESS</text>
+    <text x="74" y="82" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="24" fill="#ffffff" letter-spacing="0.04em">HARNESS</text>
     <text x="74" y="112" font-family="'JetBrains Mono', monospace" font-size="11" fill="rgba(255,255,255,0.85)" letter-spacing="0.30em">AGENTIC_RUNTIME</text>
-    <text x="290" y="68" font-family="'JetBrains Mono', monospace" font-size="13" fill="#ffffff">Bring your own. Switch any time.</text>
-    <text x="290" y="98" font-family="'JetBrains Mono', monospace" font-size="13" fill="rgba(255,255,255,0.78)">claude code · gemini cli · codex · qwen</text>
-    <g transform="translate(668, 53)">
+    <text x="320" y="68" font-family="'JetBrains Mono', monospace" font-size="13" fill="#ffffff">Bring your own. Switch any time.</text>
+    <text x="320" y="98" font-family="'JetBrains Mono', monospace" font-size="13" fill="rgba(255,255,255,0.78)">claude code · gemini cli · codex · qwen</text>
+    <g transform="translate(668, 14)">
       <rect width="100" height="24" fill="#ffffff"/>
       <text x="50" y="16" font-family="'JetBrains Mono', monospace" font-size="10" fill="#7c1ade" font-weight="700" letter-spacing="0.14em" text-anchor="middle">BYO_HARNESS</text>
     </g>
@@ -99,11 +99,11 @@
     <rect width="780" height="130" fill="url(#g-llm)"/>
     <text class="icon-pulse" x="38" y="78" font-size="32" text-anchor="middle" dominant-baseline="central" aria-hidden="true" style="animation-delay: 1.3s;">✨</text>
     <text x="74" y="42" font-family="'JetBrains Mono', monospace" font-size="13" font-weight="700" fill="rgba(255,255,255,0.85)" letter-spacing="0.08em">LAYER_03</text>
-    <text x="74" y="82" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="28" fill="#ffffff" letter-spacing="0.04em">LLM</text>
+    <text x="74" y="82" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="24" fill="#ffffff" letter-spacing="0.04em">LLM</text>
     <text x="74" y="112" font-family="'JetBrains Mono', monospace" font-size="11" fill="rgba(255,255,255,0.85)" letter-spacing="0.30em">INTELLIGENCE_SOURCE</text>
-    <text x="290" y="68" font-family="'JetBrains Mono', monospace" font-size="13" fill="#ffffff">Powered by anything. OneBrain stays the same.</text>
-    <text x="290" y="98" font-family="'JetBrains Mono', monospace" font-size="13" fill="rgba(255,255,255,0.78)">local: mlx, ollama · cloud: claude, gemini, gpt</text>
-    <g transform="translate(668, 53)">
+    <text x="320" y="68" font-family="'JetBrains Mono', monospace" font-size="13" fill="#ffffff">Powered by anything. OneBrain stays the same.</text>
+    <text x="320" y="98" font-family="'JetBrains Mono', monospace" font-size="13" fill="rgba(255,255,255,0.78)">local: mlx, ollama · cloud: claude, gemini, gpt</text>
+    <g transform="translate(668, 14)">
       <rect width="100" height="24" fill="#ffffff"/>
       <text x="50" y="16" font-family="'JetBrains Mono', monospace" font-size="10" fill="#4d6d00" font-weight="700" letter-spacing="0.14em" text-anchor="middle">RAW_TOKENS</text>
     </g>
@@ -120,11 +120,11 @@
     <rect width="780" height="130" fill="url(#g-vault)"/>
     <text class="icon-pulse" x="38" y="78" font-size="32" text-anchor="middle" dominant-baseline="central" aria-hidden="true" style="animation-delay: 1.95s;">💎</text>
     <text x="74" y="42" font-family="'JetBrains Mono', monospace" font-size="13" font-weight="700" fill="rgba(255,255,255,0.85)" letter-spacing="0.08em">LAYER_04</text>
-    <text x="74" y="82" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="28" fill="#ffffff" letter-spacing="0.04em">OBSIDIAN VAULT</text>
+    <text x="74" y="82" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="24" fill="#ffffff" letter-spacing="0.04em">OBSIDIAN VAULT</text>
     <text x="74" y="112" font-family="'JetBrains Mono', monospace" font-size="11" fill="rgba(255,255,255,0.85)" letter-spacing="0.30em">SOURCE_OF_TRUTH</text>
-    <text x="290" y="68" font-family="'JetBrains Mono', monospace" font-size="13" fill="#ffffff">Plain Markdown · durable state for every layer.</text>
-    <text x="290" y="98" font-family="'JetBrains Mono', monospace" font-size="13" fill="rgba(255,255,255,0.78)">notes · memory · decisions · knowledge graph</text>
-    <g transform="translate(668, 53)">
+    <text x="320" y="68" font-family="'JetBrains Mono', monospace" font-size="13" fill="#ffffff">Plain Markdown · durable state for every layer.</text>
+    <text x="320" y="98" font-family="'JetBrains Mono', monospace" font-size="13" fill="rgba(255,255,255,0.78)">notes · memory · decisions · knowledge graph</text>
+    <g transform="translate(668, 14)">
       <rect width="100" height="24" fill="#ffffff"/>
       <text x="50" y="16" font-family="'JetBrains Mono', monospace" font-size="10" fill="#00788c" font-weight="700" letter-spacing="0.14em" text-anchor="middle">BASE_LAYER</text>
     </g>

--- a/assets/diagrams/harness-os-stack-light.svg
+++ b/assets/diagrams/harness-os-stack-light.svg
@@ -57,11 +57,11 @@
     <rect width="780" height="130" fill="url(#g-onebrain)"/>
     <text class="icon-pulse" x="38" y="78" font-size="32" text-anchor="middle" dominant-baseline="central" aria-hidden="true">🧠</text>
     <text x="74" y="42" font-family="'JetBrains Mono', monospace" font-size="13" font-weight="700" fill="rgba(255,255,255,0.85)" letter-spacing="0.08em">LAYER_01</text>
-    <text x="74" y="82" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="28" fill="#ffffff" letter-spacing="0.04em">ONEBRAIN</text>
+    <text x="74" y="82" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="24" fill="#ffffff" letter-spacing="0.04em">ONEBRAIN</text>
     <text x="74" y="112" font-family="'JetBrains Mono', monospace" font-size="11" fill="rgba(255,255,255,0.85)" letter-spacing="0.30em">PLUGIN · CLI · ORCHESTRATOR</text>
-    <text x="290" y="68" font-family="'JetBrains Mono', monospace" font-size="13" fill="#ffffff">The OS layer driving every harness consistently.</text>
-    <text x="290" y="98" font-family="'JetBrains Mono', monospace" font-size="13" fill="rgba(255,255,255,0.78)">skills · hooks · sync · indexing · checkpoints</text>
-    <g transform="translate(668, 53)">
+    <text x="320" y="68" font-family="'JetBrains Mono', monospace" font-size="13" fill="#ffffff">The OS layer driving every harness consistently.</text>
+    <text x="320" y="98" font-family="'JetBrains Mono', monospace" font-size="13" fill="rgba(255,255,255,0.78)">skills · hooks · sync · indexing · checkpoints</text>
+    <g transform="translate(668, 14)">
       <rect width="100" height="24" fill="#ffffff"/>
       <text x="50" y="16" font-family="'JetBrains Mono', monospace" font-size="10" fill="#c91075" font-weight="700" letter-spacing="0.14em" text-anchor="middle">OS_LAYER</text>
     </g>
@@ -78,11 +78,11 @@
     <rect width="780" height="130" fill="url(#g-harness)"/>
     <text class="icon-pulse" x="38" y="78" font-size="32" text-anchor="middle" dominant-baseline="central" aria-hidden="true" style="animation-delay: 0.65s;">🤖</text>
     <text x="74" y="42" font-family="'JetBrains Mono', monospace" font-size="13" font-weight="700" fill="rgba(255,255,255,0.85)" letter-spacing="0.08em">LAYER_02</text>
-    <text x="74" y="82" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="28" fill="#ffffff" letter-spacing="0.04em">HARNESS</text>
+    <text x="74" y="82" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="24" fill="#ffffff" letter-spacing="0.04em">HARNESS</text>
     <text x="74" y="112" font-family="'JetBrains Mono', monospace" font-size="11" fill="rgba(255,255,255,0.85)" letter-spacing="0.30em">AGENTIC_RUNTIME</text>
-    <text x="290" y="68" font-family="'JetBrains Mono', monospace" font-size="13" fill="#ffffff">Bring your own. Switch any time.</text>
-    <text x="290" y="98" font-family="'JetBrains Mono', monospace" font-size="13" fill="rgba(255,255,255,0.78)">claude code · gemini cli · codex · qwen</text>
-    <g transform="translate(668, 53)">
+    <text x="320" y="68" font-family="'JetBrains Mono', monospace" font-size="13" fill="#ffffff">Bring your own. Switch any time.</text>
+    <text x="320" y="98" font-family="'JetBrains Mono', monospace" font-size="13" fill="rgba(255,255,255,0.78)">claude code · gemini cli · codex · qwen</text>
+    <g transform="translate(668, 14)">
       <rect width="100" height="24" fill="#ffffff"/>
       <text x="50" y="16" font-family="'JetBrains Mono', monospace" font-size="10" fill="#7c1ade" font-weight="700" letter-spacing="0.14em" text-anchor="middle">BYO_HARNESS</text>
     </g>
@@ -99,11 +99,11 @@
     <rect width="780" height="130" fill="url(#g-llm)"/>
     <text class="icon-pulse" x="38" y="78" font-size="32" text-anchor="middle" dominant-baseline="central" aria-hidden="true" style="animation-delay: 1.3s;">✨</text>
     <text x="74" y="42" font-family="'JetBrains Mono', monospace" font-size="13" font-weight="700" fill="rgba(255,255,255,0.85)" letter-spacing="0.08em">LAYER_03</text>
-    <text x="74" y="82" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="28" fill="#ffffff" letter-spacing="0.04em">LLM</text>
+    <text x="74" y="82" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="24" fill="#ffffff" letter-spacing="0.04em">LLM</text>
     <text x="74" y="112" font-family="'JetBrains Mono', monospace" font-size="11" fill="rgba(255,255,255,0.85)" letter-spacing="0.30em">INTELLIGENCE_SOURCE</text>
-    <text x="290" y="68" font-family="'JetBrains Mono', monospace" font-size="13" fill="#ffffff">Powered by anything. OneBrain stays the same.</text>
-    <text x="290" y="98" font-family="'JetBrains Mono', monospace" font-size="13" fill="rgba(255,255,255,0.78)">local: mlx, ollama · cloud: claude, gemini, gpt</text>
-    <g transform="translate(668, 53)">
+    <text x="320" y="68" font-family="'JetBrains Mono', monospace" font-size="13" fill="#ffffff">Powered by anything. OneBrain stays the same.</text>
+    <text x="320" y="98" font-family="'JetBrains Mono', monospace" font-size="13" fill="rgba(255,255,255,0.78)">local: mlx, ollama · cloud: claude, gemini, gpt</text>
+    <g transform="translate(668, 14)">
       <rect width="100" height="24" fill="#ffffff"/>
       <text x="50" y="16" font-family="'JetBrains Mono', monospace" font-size="10" fill="#4d6d00" font-weight="700" letter-spacing="0.14em" text-anchor="middle">RAW_TOKENS</text>
     </g>
@@ -120,11 +120,11 @@
     <rect width="780" height="130" fill="url(#g-vault)"/>
     <text class="icon-pulse" x="38" y="78" font-size="32" text-anchor="middle" dominant-baseline="central" aria-hidden="true" style="animation-delay: 1.95s;">💎</text>
     <text x="74" y="42" font-family="'JetBrains Mono', monospace" font-size="13" font-weight="700" fill="rgba(255,255,255,0.85)" letter-spacing="0.08em">LAYER_04</text>
-    <text x="74" y="82" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="28" fill="#ffffff" letter-spacing="0.04em">OBSIDIAN VAULT</text>
+    <text x="74" y="82" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="24" fill="#ffffff" letter-spacing="0.04em">OBSIDIAN VAULT</text>
     <text x="74" y="112" font-family="'JetBrains Mono', monospace" font-size="11" fill="rgba(255,255,255,0.85)" letter-spacing="0.30em">SOURCE_OF_TRUTH</text>
-    <text x="290" y="68" font-family="'JetBrains Mono', monospace" font-size="13" fill="#ffffff">Plain Markdown · durable state for every layer.</text>
-    <text x="290" y="98" font-family="'JetBrains Mono', monospace" font-size="13" fill="rgba(255,255,255,0.78)">notes · memory · decisions · knowledge graph</text>
-    <g transform="translate(668, 53)">
+    <text x="320" y="68" font-family="'JetBrains Mono', monospace" font-size="13" fill="#ffffff">Plain Markdown · durable state for every layer.</text>
+    <text x="320" y="98" font-family="'JetBrains Mono', monospace" font-size="13" fill="rgba(255,255,255,0.78)">notes · memory · decisions · knowledge graph</text>
+    <g transform="translate(668, 14)">
       <rect width="100" height="24" fill="#ffffff"/>
       <text x="50" y="16" font-family="'JetBrains Mono', monospace" font-size="10" fill="#00788c" font-weight="700" letter-spacing="0.14em" text-anchor="middle">BASE_LAYER</text>
     </g>

--- a/assets/diagrams/memory-tiers-dark.svg
+++ b/assets/diagrams/memory-tiers-dark.svg
@@ -57,11 +57,11 @@
     <rect width="780" height="130" fill="url(#g-t1-fill)"/>
     <text class="icon-pulse" x="38" y="78" font-size="32" text-anchor="middle" dominant-baseline="central" aria-hidden="true">📥</text>
     <text x="74" y="42" font-family="'JetBrains Mono', monospace" font-size="13" font-weight="700" fill="rgba(255,255,255,0.85)" letter-spacing="0.08em">TIER_01</text>
-    <text x="74" y="82" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="28" fill="#ffffff" letter-spacing="0.04em">WORKING</text>
+    <text x="74" y="82" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="24" fill="#ffffff" letter-spacing="0.04em">WORKING</text>
     <text x="74" y="112" font-family="'JetBrains Mono', monospace" font-size="11" fill="rgba(255,255,255,0.85)" letter-spacing="0.30em">00-inbox · current session</text>
-    <text x="290" y="68" font-family="'JetBrains Mono', monospace" font-size="13" fill="#ffffff">Raw captures, unprocessed thoughts.</text>
-    <text x="290" y="98" font-family="'JetBrains Mono', monospace" font-size="13" fill="rgba(255,255,255,0.78)">/braindump · /capture · /bookmark</text>
-    <g transform="translate(668, 53)">
+    <text x="320" y="68" font-family="'JetBrains Mono', monospace" font-size="13" fill="#ffffff">Raw captures, unprocessed thoughts.</text>
+    <text x="320" y="98" font-family="'JetBrains Mono', monospace" font-size="13" fill="rgba(255,255,255,0.78)">/braindump · /capture · /bookmark</text>
+    <g transform="translate(668, 14)">
       <rect width="100" height="24" fill="#ffffff"/>
       <text x="50" y="16" font-family="'JetBrains Mono', monospace" font-size="10" fill="#c91075" font-weight="700" letter-spacing="0.14em" text-anchor="middle">EPHEMERAL</text>
     </g>
@@ -78,11 +78,11 @@
     <rect width="780" height="130" fill="url(#g-t2-fill)"/>
     <text class="icon-pulse" x="38" y="78" font-size="32" text-anchor="middle" dominant-baseline="central" aria-hidden="true" style="animation-delay: 0.65s;">📜</text>
     <text x="74" y="42" font-family="'JetBrains Mono', monospace" font-size="13" font-weight="700" fill="rgba(255,255,255,0.85)" letter-spacing="0.08em">TIER_02</text>
-    <text x="74" y="82" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="28" fill="#ffffff" letter-spacing="0.04em">EPISODIC</text>
+    <text x="74" y="82" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="24" fill="#ffffff" letter-spacing="0.04em">EPISODIC</text>
     <text x="74" y="112" font-family="'JetBrains Mono', monospace" font-size="11" fill="rgba(255,255,255,0.85)" letter-spacing="0.30em">07-logs · session + checkpoint</text>
-    <text x="290" y="68" font-family="'JetBrains Mono', monospace" font-size="13" fill="#ffffff">What happened — sessions, decisions, narrative.</text>
-    <text x="290" y="98" font-family="'JetBrains Mono', monospace" font-size="13" fill="rgba(255,255,255,0.78)">/wrapup · auto-checkpoints</text>
-    <g transform="translate(668, 53)">
+    <text x="320" y="68" font-family="'JetBrains Mono', monospace" font-size="13" fill="#ffffff">What happened — sessions, decisions, narrative.</text>
+    <text x="320" y="98" font-family="'JetBrains Mono', monospace" font-size="13" fill="rgba(255,255,255,0.78)">/wrapup · auto-checkpoints</text>
+    <g transform="translate(668, 14)">
       <rect width="100" height="24" fill="#ffffff"/>
       <text x="50" y="16" font-family="'JetBrains Mono', monospace" font-size="10" fill="#7c1ade" font-weight="700" letter-spacing="0.14em" text-anchor="middle">PER_SESSION</text>
     </g>
@@ -99,11 +99,11 @@
     <rect width="780" height="130" fill="url(#g-t3-fill)"/>
     <text class="icon-pulse" x="38" y="78" font-size="32" text-anchor="middle" dominant-baseline="central" aria-hidden="true" style="animation-delay: 1.3s;">🧬</text>
     <text x="74" y="42" font-family="'JetBrains Mono', monospace" font-size="13" font-weight="700" fill="rgba(255,255,255,0.85)" letter-spacing="0.08em">TIER_03</text>
-    <text x="74" y="82" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="28" fill="#ffffff" letter-spacing="0.04em">SEMANTIC</text>
+    <text x="74" y="82" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="24" fill="#ffffff" letter-spacing="0.04em">SEMANTIC</text>
     <text x="74" y="112" font-family="'JetBrains Mono', monospace" font-size="11" fill="rgba(255,255,255,0.85)" letter-spacing="0.30em">05-agent · MEMORY.md + memory/</text>
-    <text x="290" y="68" font-family="'JetBrains Mono', monospace" font-size="13" fill="#ffffff">Identity, preferences, recurring patterns.</text>
-    <text x="290" y="98" font-family="'JetBrains Mono', monospace" font-size="13" fill="rgba(255,255,255,0.78)">/learn · /recap · /memory-review</text>
-    <g transform="translate(668, 53)">
+    <text x="320" y="68" font-family="'JetBrains Mono', monospace" font-size="13" fill="#ffffff">Identity, preferences, recurring patterns.</text>
+    <text x="320" y="98" font-family="'JetBrains Mono', monospace" font-size="13" fill="rgba(255,255,255,0.78)">/learn · /recap · /memory-review</text>
+    <g transform="translate(668, 14)">
       <rect width="100" height="24" fill="#ffffff"/>
       <text x="50" y="16" font-family="'JetBrains Mono', monospace" font-size="10" fill="#4d6d00" font-weight="700" letter-spacing="0.14em" text-anchor="middle">CROSS_SESSION</text>
     </g>
@@ -120,11 +120,11 @@
     <rect width="780" height="130" fill="url(#g-t4-fill)"/>
     <text class="icon-pulse" x="38" y="78" font-size="32" text-anchor="middle" dominant-baseline="central" aria-hidden="true" style="animation-delay: 1.95s;">💎</text>
     <text x="74" y="42" font-family="'JetBrains Mono', monospace" font-size="13" font-weight="700" fill="rgba(255,255,255,0.85)" letter-spacing="0.08em">TIER_04</text>
-    <text x="74" y="82" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="28" fill="#ffffff" letter-spacing="0.04em">KNOWLEDGE</text>
+    <text x="74" y="82" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="24" fill="#ffffff" letter-spacing="0.04em">KNOWLEDGE</text>
     <text x="74" y="112" font-family="'JetBrains Mono', monospace" font-size="11" fill="rgba(255,255,255,0.85)" letter-spacing="0.30em">03-knowledge · distilled notes</text>
-    <text x="290" y="68" font-family="'JetBrains Mono', monospace" font-size="13" fill="#ffffff">Crystallized insights — what you know forever.</text>
-    <text x="290" y="98" font-family="'JetBrains Mono', monospace" font-size="13" fill="rgba(255,255,255,0.78)">/distill · /connect · /weekly</text>
-    <g transform="translate(668, 53)">
+    <text x="320" y="68" font-family="'JetBrains Mono', monospace" font-size="13" fill="#ffffff">Crystallized insights — what you know forever.</text>
+    <text x="320" y="98" font-family="'JetBrains Mono', monospace" font-size="13" fill="rgba(255,255,255,0.78)">/distill · /connect · /weekly</text>
+    <g transform="translate(668, 14)">
       <rect width="100" height="24" fill="#ffffff"/>
       <text x="50" y="16" font-family="'JetBrains Mono', monospace" font-size="10" fill="#00788c" font-weight="700" letter-spacing="0.14em" text-anchor="middle">FOREVER</text>
     </g>

--- a/assets/diagrams/memory-tiers-light.svg
+++ b/assets/diagrams/memory-tiers-light.svg
@@ -57,11 +57,11 @@
     <rect width="780" height="130" fill="url(#g-t1-fill)"/>
     <text class="icon-pulse" x="38" y="78" font-size="32" text-anchor="middle" dominant-baseline="central" aria-hidden="true">📥</text>
     <text x="74" y="42" font-family="'JetBrains Mono', monospace" font-size="13" font-weight="700" fill="rgba(255,255,255,0.85)" letter-spacing="0.08em">TIER_01</text>
-    <text x="74" y="82" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="28" fill="#ffffff" letter-spacing="0.04em">WORKING</text>
+    <text x="74" y="82" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="24" fill="#ffffff" letter-spacing="0.04em">WORKING</text>
     <text x="74" y="112" font-family="'JetBrains Mono', monospace" font-size="11" fill="rgba(255,255,255,0.85)" letter-spacing="0.30em">00-inbox · current session</text>
-    <text x="290" y="68" font-family="'JetBrains Mono', monospace" font-size="13" fill="#ffffff">Raw captures, unprocessed thoughts.</text>
-    <text x="290" y="98" font-family="'JetBrains Mono', monospace" font-size="13" fill="rgba(255,255,255,0.78)">/braindump · /capture · /bookmark</text>
-    <g transform="translate(668, 53)">
+    <text x="320" y="68" font-family="'JetBrains Mono', monospace" font-size="13" fill="#ffffff">Raw captures, unprocessed thoughts.</text>
+    <text x="320" y="98" font-family="'JetBrains Mono', monospace" font-size="13" fill="rgba(255,255,255,0.78)">/braindump · /capture · /bookmark</text>
+    <g transform="translate(668, 14)">
       <rect width="100" height="24" fill="#ffffff"/>
       <text x="50" y="16" font-family="'JetBrains Mono', monospace" font-size="10" fill="#c91075" font-weight="700" letter-spacing="0.14em" text-anchor="middle">EPHEMERAL</text>
     </g>
@@ -78,11 +78,11 @@
     <rect width="780" height="130" fill="url(#g-t2-fill)"/>
     <text class="icon-pulse" x="38" y="78" font-size="32" text-anchor="middle" dominant-baseline="central" aria-hidden="true" style="animation-delay: 0.65s;">📜</text>
     <text x="74" y="42" font-family="'JetBrains Mono', monospace" font-size="13" font-weight="700" fill="rgba(255,255,255,0.85)" letter-spacing="0.08em">TIER_02</text>
-    <text x="74" y="82" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="28" fill="#ffffff" letter-spacing="0.04em">EPISODIC</text>
+    <text x="74" y="82" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="24" fill="#ffffff" letter-spacing="0.04em">EPISODIC</text>
     <text x="74" y="112" font-family="'JetBrains Mono', monospace" font-size="11" fill="rgba(255,255,255,0.85)" letter-spacing="0.30em">07-logs · session + checkpoint</text>
-    <text x="290" y="68" font-family="'JetBrains Mono', monospace" font-size="13" fill="#ffffff">What happened — sessions, decisions, narrative.</text>
-    <text x="290" y="98" font-family="'JetBrains Mono', monospace" font-size="13" fill="rgba(255,255,255,0.78)">/wrapup · auto-checkpoints</text>
-    <g transform="translate(668, 53)">
+    <text x="320" y="68" font-family="'JetBrains Mono', monospace" font-size="13" fill="#ffffff">What happened — sessions, decisions, narrative.</text>
+    <text x="320" y="98" font-family="'JetBrains Mono', monospace" font-size="13" fill="rgba(255,255,255,0.78)">/wrapup · auto-checkpoints</text>
+    <g transform="translate(668, 14)">
       <rect width="100" height="24" fill="#ffffff"/>
       <text x="50" y="16" font-family="'JetBrains Mono', monospace" font-size="10" fill="#7c1ade" font-weight="700" letter-spacing="0.14em" text-anchor="middle">PER_SESSION</text>
     </g>
@@ -99,11 +99,11 @@
     <rect width="780" height="130" fill="url(#g-t3-fill)"/>
     <text class="icon-pulse" x="38" y="78" font-size="32" text-anchor="middle" dominant-baseline="central" aria-hidden="true" style="animation-delay: 1.3s;">🧬</text>
     <text x="74" y="42" font-family="'JetBrains Mono', monospace" font-size="13" font-weight="700" fill="rgba(255,255,255,0.85)" letter-spacing="0.08em">TIER_03</text>
-    <text x="74" y="82" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="28" fill="#ffffff" letter-spacing="0.04em">SEMANTIC</text>
+    <text x="74" y="82" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="24" fill="#ffffff" letter-spacing="0.04em">SEMANTIC</text>
     <text x="74" y="112" font-family="'JetBrains Mono', monospace" font-size="11" fill="rgba(255,255,255,0.85)" letter-spacing="0.30em">05-agent · MEMORY.md + memory/</text>
-    <text x="290" y="68" font-family="'JetBrains Mono', monospace" font-size="13" fill="#ffffff">Identity, preferences, recurring patterns.</text>
-    <text x="290" y="98" font-family="'JetBrains Mono', monospace" font-size="13" fill="rgba(255,255,255,0.78)">/learn · /recap · /memory-review</text>
-    <g transform="translate(668, 53)">
+    <text x="320" y="68" font-family="'JetBrains Mono', monospace" font-size="13" fill="#ffffff">Identity, preferences, recurring patterns.</text>
+    <text x="320" y="98" font-family="'JetBrains Mono', monospace" font-size="13" fill="rgba(255,255,255,0.78)">/learn · /recap · /memory-review</text>
+    <g transform="translate(668, 14)">
       <rect width="100" height="24" fill="#ffffff"/>
       <text x="50" y="16" font-family="'JetBrains Mono', monospace" font-size="10" fill="#4d6d00" font-weight="700" letter-spacing="0.14em" text-anchor="middle">CROSS_SESSION</text>
     </g>
@@ -120,11 +120,11 @@
     <rect width="780" height="130" fill="url(#g-t4-fill)"/>
     <text class="icon-pulse" x="38" y="78" font-size="32" text-anchor="middle" dominant-baseline="central" aria-hidden="true" style="animation-delay: 1.95s;">💎</text>
     <text x="74" y="42" font-family="'JetBrains Mono', monospace" font-size="13" font-weight="700" fill="rgba(255,255,255,0.85)" letter-spacing="0.08em">TIER_04</text>
-    <text x="74" y="82" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="28" fill="#ffffff" letter-spacing="0.04em">KNOWLEDGE</text>
+    <text x="74" y="82" font-family="'Chakra Petch', sans-serif" font-style="italic" font-weight="700" font-size="24" fill="#ffffff" letter-spacing="0.04em">KNOWLEDGE</text>
     <text x="74" y="112" font-family="'JetBrains Mono', monospace" font-size="11" fill="rgba(255,255,255,0.85)" letter-spacing="0.30em">03-knowledge · distilled notes</text>
-    <text x="290" y="68" font-family="'JetBrains Mono', monospace" font-size="13" fill="#ffffff">Crystallized insights — what you know forever.</text>
-    <text x="290" y="98" font-family="'JetBrains Mono', monospace" font-size="13" fill="rgba(255,255,255,0.78)">/distill · /connect · /weekly</text>
-    <g transform="translate(668, 53)">
+    <text x="320" y="68" font-family="'JetBrains Mono', monospace" font-size="13" fill="#ffffff">Crystallized insights — what you know forever.</text>
+    <text x="320" y="98" font-family="'JetBrains Mono', monospace" font-size="13" fill="rgba(255,255,255,0.78)">/distill · /connect · /weekly</text>
+    <g transform="translate(668, 14)">
       <rect width="100" height="24" fill="#ffffff"/>
       <text x="50" y="16" font-family="'JetBrains Mono', monospace" font-size="10" fill="#00788c" font-weight="700" letter-spacing="0.14em" text-anchor="middle">FOREVER</text>
     </g>


### PR DESCRIPTION
## Summary

Two small README diagram fixes:

### 1. Badge position + vault overlap (4 SVGs)

The white badge (OS_LAYER / BYO_HARNESS / etc.) in each layer card sat at middle-right (translate(668, 53)) and collided with the description text on the longest layer name — \`LAYER_04 OBSIDIAN VAULT\` in harness-os-stack and \`TIER_04 KNOWLEDGE\` in memory-tiers — at GitHub render scale. Same overlap was discovered + fixed on the website earlier today (onebrain-ai/website#12); this carries the fix back to the README source.

Three surgical attribute tweaks per file, applied to all four SVGs:

| Attribute | Before | After | Why |
|---|---|---|---|
| Layer name \`font-size\` | 28 | 24 | "OBSIDIAN VAULT" / "KNOWLEDGE" used to push past x=290 |
| Description col \`x\` | 290 | 320 | extra breathing room from layer name |
| Badge \`translate y\` | 53 | 14 | top-right corner instead of middle-right |

No color or structural changes — README palette stays exactly as ccc8d55 shipped.

### 2. coevo-loop scale 540 → 270 (50%)

The 540px render was visually dominating the surrounding numbered list. Halving to 270px lets the prose-and-list cadence breathe while keeping the three-node triangle legible. SVG unchanged — only the README \`<img width>\` attribute drops.

## Files

- \`assets/diagrams/harness-os-stack-light.svg\`
- \`assets/diagrams/harness-os-stack-dark.svg\`
- \`assets/diagrams/memory-tiers-light.svg\`
- \`assets/diagrams/memory-tiers-dark.svg\`
- \`README.md\`

## Verification

- Rendered both light variants via \`rsvg-convert\` at 880×600 — no overlap, badge in top-right corner of every layer.
- Reviewer pass (code-reviewer agent): substitution unambiguity verified across all 4 files (no collateral hits — \`font-size="28"\`, \`x="290"\`, \`translate(668, 53)\` are unique to the target elements). Y=14 badge band vs y=42 LAYER_NN label — clears by 514px horizontally (badge at x=668, label at x=74), no collision.

## Test plan

- [x] rsvg-convert preview clean
- [x] Single-round code-reviewer pass
- [ ] GitHub render check on PR diff after merge (README \`<img>\` tags reload from the new SVGs at the new scale)