### PR TITLE
ci(release): auto-trigger website rebuild after npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -256,6 +256,8 @@ jobs:
           fi
 
           echo "Triggering website rebuild for v${VERSION}..."
+          # --retry-connrefused (not --retry-all-errors): retry transient 5xx +
+          # connection-refused; do NOT mask permanent 4xx misconfig errors.
           CURL_EXIT=0
           HTTP_CODE=$(curl -X POST "$DEPLOY_HOOK_URL" \
             -sS \
@@ -263,7 +265,7 @@ jobs:
             -w "%{http_code}" \
             --connect-timeout 10 \
             --max-time 30 \
-            --retry 3 --retry-delay 5 --retry-all-errors) || CURL_EXIT=$?
+            --retry 3 --retry-delay 5 --retry-connrefused) || CURL_EXIT=$?
 
           if [ "$CURL_EXIT" -ne 0 ]; then
             echo "::error::curl failed (exit ${CURL_EXIT}) — network/DNS/TLS issue, not an HTTP error"
@@ -275,12 +277,27 @@ jobs:
             exit 1
           fi
 
-          # Bound body output to avoid huge HTML error pages flooding logs
+          # Bound body output to avoid huge HTML error pages flooding logs.
+          # Use explicit if/elif/else to avoid the `&& ... ||` precedence trap
+          # that prints "(no response body)" when head itself fails.
+          print_response_body() {
+            if [ -s response.txt ]; then
+              echo "--- response body (first 2000 bytes) ---"
+              head -c 2000 response.txt
+              echo
+              echo "--- end response body ---"
+            elif [ -f response.txt ]; then
+              echo "(response body empty)"
+            else
+              echo "(no response body file written)"
+            fi
+          }
+
           if [ "$HTTP_CODE" -ge 200 ] && [ "$HTTP_CODE" -lt 300 ]; then
             echo "Website rebuild triggered (HTTP $HTTP_CODE) — should be live within 1-2 min"
-            [ -f response.txt ] && head -c 2000 response.txt || echo "(no response body)"
+            print_response_body
           else
             echo "::error::Deploy hook returned HTTP $HTTP_CODE"
-            [ -f response.txt ] && head -c 2000 response.txt || echo "(no response body)"
+            print_response_body
             exit 1
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -231,3 +231,30 @@ jobs:
         run: |
           echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> ~/.npmrc
           npm publish --access public
+
+  # ─── Step 6: trigger website rebuild so v{cliVersion} stays in sync ──────
+  trigger-website:
+    needs: [verify-tag, npm-publish]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Cloudflare deploy hook
+        env:
+          DEPLOY_HOOK_URL: ${{ secrets.CF_WEBSITE_DEPLOY_HOOK }}
+          VERSION: ${{ needs.verify-tag.outputs.version }}
+        run: |
+          if [ -z "$DEPLOY_HOOK_URL" ]; then
+            echo "::warning::CF_WEBSITE_DEPLOY_HOOK secret not set — skipping website rebuild"
+            exit 0
+          fi
+
+          echo "Triggering website rebuild for v${VERSION}..."
+          HTTP_CODE=$(curl -X POST "$DEPLOY_HOOK_URL" -s -o response.txt -w "%{http_code}")
+
+          if [ "$HTTP_CODE" -ge 200 ] && [ "$HTTP_CODE" -lt 300 ]; then
+            echo "Website rebuild triggered (HTTP $HTTP_CODE) — should be live within 1-2 min"
+            cat response.txt
+          else
+            echo "::error::Deploy hook returned HTTP $HTTP_CODE"
+            cat response.txt
+            exit 1
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -233,9 +233,13 @@ jobs:
           npm publish --access public
 
   # ─── Step 6: trigger website rebuild so v{cliVersion} stays in sync ──────
+  # Gated on npm-publish.result=='success' because npm-publish has
+  # continue-on-error: true (so `needs:` alone treats a failed publish as success).
   trigger-website:
     needs: [verify-tag, npm-publish]
+    if: needs.npm-publish.result == 'success'
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Trigger Cloudflare deploy hook
         env:
@@ -243,18 +247,40 @@ jobs:
           VERSION: ${{ needs.verify-tag.outputs.version }}
         run: |
           if [ -z "$DEPLOY_HOOK_URL" ]; then
-            echo "::warning::CF_WEBSITE_DEPLOY_HOOK secret not set — skipping website rebuild"
+            if [ "${GITHUB_REPOSITORY}" = "onebrain-ai/onebrain" ]; then
+              echo "::error::CF_WEBSITE_DEPLOY_HOOK secret is required on the canonical repo"
+              exit 1
+            fi
+            echo "::warning::Skipping website rebuild on fork ${GITHUB_REPOSITORY} — secret not set"
             exit 0
           fi
 
           echo "Triggering website rebuild for v${VERSION}..."
-          HTTP_CODE=$(curl -X POST "$DEPLOY_HOOK_URL" -s -o response.txt -w "%{http_code}")
+          CURL_EXIT=0
+          HTTP_CODE=$(curl -X POST "$DEPLOY_HOOK_URL" \
+            -sS \
+            -o response.txt \
+            -w "%{http_code}" \
+            --connect-timeout 10 \
+            --max-time 30 \
+            --retry 3 --retry-delay 5 --retry-all-errors) || CURL_EXIT=$?
 
+          if [ "$CURL_EXIT" -ne 0 ]; then
+            echo "::error::curl failed (exit ${CURL_EXIT}) — network/DNS/TLS issue, not an HTTP error"
+            exit 1
+          fi
+
+          if ! [[ "$HTTP_CODE" =~ ^[0-9]+$ ]]; then
+            echo "::error::Unexpected HTTP code value: '$HTTP_CODE'"
+            exit 1
+          fi
+
+          # Bound body output to avoid huge HTML error pages flooding logs
           if [ "$HTTP_CODE" -ge 200 ] && [ "$HTTP_CODE" -lt 300 ]; then
             echo "Website rebuild triggered (HTTP $HTTP_CODE) — should be live within 1-2 min"
-            cat response.txt
+            [ -f response.txt ] && head -c 2000 response.txt || echo "(no response body)"
           else
             echo "::error::Deploy hook returned HTTP $HTTP_CODE"
-            cat response.txt
+            [ -f response.txt ] && head -c 2000 response.txt || echo "(no response body)"
             exit 1
           fi


### PR DESCRIPTION
## Summary

- Add `trigger-website` job to `.github/workflows/release.yml` that fires after `npm-publish` succeeds
- POSTs to the Cloudflare deploy hook stored in `CF_WEBSITE_DEPLOY_HOOK` repo secret → onebrain.run rebuilds within 1–2 min, picking up the new CLI version baked at build time
- Closes the version-staleness gap between `@onebrain-ai/cli` on npm and the `v{cliVersion}` / `buildDate` rendered on the website (both currently bake at website-build time, so a fresh CLI release without a website rebuild leaves stale numbers visible)

## Behavior

| Scenario | Result |
|---|---|
| Secret unset (e.g. on forks) | Skip with `::warning::`, exit 0 — release pipeline succeeds |
| Hook returns 2xx | Log success + response body, exit 0 |
| Hook returns non-2xx | Log error + response body, exit 1 — release tag stays, only this job fails (visible on the Actions UI) |

## Test plan

- [x] `actionlint .github/workflows/release.yml` passes
- [x] No CLI source touched, no version bump (CI infra change only)
- [x] Pre-merge: verify `CF_WEBSITE_DEPLOY_HOOK` secret is set in repo settings (Settings → Secrets and variables → Actions)
- [ ] Pre-merge: 3-round review (per OneBrain convention)
- [ ] Post-merge: verify on next CLI release tag — Cloudflare Deployments tab should show a new build triggered within seconds of the npm-publish job finishing