### PR TITLE
fix(qmd): drop stale --qmd/--remove-qmd flags + strip canonical hook on uninstall

### DIFF
--- a/.claude/plugins/onebrain/.claude-plugin/plugin.json
+++ b/.claude/plugins/onebrain/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "onebrain",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "OneBrain — Where human and AI thinking become one. A powerful thinking partner powered by AI synergy.",
   "author": {
     "name": "OneBrain Contributors"

--- a/.claude/plugins/onebrain/skills/qmd/SKILL.md
+++ b/.claude/plugins/onebrain/skills/qmd/SKILL.md
@@ -118,8 +118,10 @@ onebrain qmd-reindex
 Then register the PostToolUse hook so the index stays in sync automatically (run from vault root):
 
 ```bash
-onebrain register-hooks --qmd
+onebrain register-hooks
 ```
+
+`register-hooks` reads `qmd_collection` from `vault.yml` (written in Step 7) and registers the PostToolUse hook automatically. No flag needed.
 
 If the reindex fails, show the error : the collection is created but not indexed. User can run `/qmd reindex` to retry.
 

--- a/.claude/plugins/onebrain/skills/qmd/SKILL.md
+++ b/.claude/plugins/onebrain/skills/qmd/SKILL.md
@@ -121,7 +121,7 @@ Then register the PostToolUse hook so the index stays in sync automatically (run
 onebrain register-hooks
 ```
 
-`register-hooks` reads `qmd_collection` from `vault.yml` (written in Step 7) and registers the PostToolUse hook automatically. No flag needed.
+`register-hooks` reads `qmd_collection` from `vault.yml` (written in the previous step) and registers the PostToolUse hook automatically. No flag needed.
 
 If the reindex fails, show the error : the collection is created but not indexed. User can run `/qmd reindex` to retry.
 
@@ -347,10 +347,10 @@ If the write fails, show the error. Tell the user to manually remove the `qmd_co
 ### Step 4b: Remove PostToolUse hook from settings.json
 
 ```bash
-onebrain register-hooks --remove-qmd
+onebrain register-hooks
 ```
 
-Run from vault root. This removes the `onebrain qmd-reindex` PostToolUse hook that was registered during `/qmd setup`. If the hook is not present, the script exits cleanly.
+Run from vault root. After Step 4 removed `qmd_collection` from `vault.yml`, `register-hooks` strips the `onebrain qmd-reindex` PostToolUse hook automatically. If the hook is not present, the command exits cleanly.
 
 ### Step 5: Confirm
 

--- a/.claude/plugins/onebrain/skills/update/references/migration-steps.md
+++ b/.claude/plugins/onebrain/skills/update/references/migration-steps.md
@@ -95,13 +95,8 @@ Always: update `updated:` frontmatter to today.
 
 Runs every /update — idempotent. Ensures all hooks point to the correct script.
 
-- Run `onebrain register-hooks` — registers Stop hook; removes stale onebrain entries from any other hook event (PreCompact, PostCompact, UserPromptSubmit, etc.); preserves user-added non-onebrain hooks under the same events
+- Run `onebrain register-hooks` — registers Stop hook; auto-registers PostToolUse qmd hook when `qmd_collection` is set in vault.yml; removes stale onebrain entries from any other hook event (PreCompact, PostCompact, UserPromptSubmit, etc.); preserves user-added non-onebrain hooks under the same events
 - Check output: "all hooks already registered" → ✅ done; "added X" → ✅ registered
-
-**PostToolUse qmd hook (only when `qmd_collection` is set in vault.yml):**
-- If `qmd_collection` is absent in vault.yml: skip
-- If `qmd_collection` is present: run `onebrain register-hooks --qmd`
-  - Check output: "all hooks already registered" → ✅ done; "added PostToolUse" → ✅ registered
 
 **Bash permission for onebrain CLI:**
 - Read `[vault]/.claude/settings.json` fresh (after `onebrain register-hooks` has written to it); check `permissions.allow` contains `"Bash(onebrain *)"` — if missing, add it using an inline Python snippet or targeted JSON edit. Never rewrite the entire file. Example:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Companion to plugin v2.4.1's `/qmd uninstall` doc fix. `migrateLegacyQmdEntries(groups, false)` previously stripped only legacy `qmd update …` entries, preserving the canonical `onebrain qmd-reindex` entry on the assumption that a hand-registered hook should survive. In practice no realistic user setup separates the two — `/qmd setup` always writes both, `/qmd uninstall` always removes both — and the preservation made the post-uninstall hook fire forever against a deleted collection.
 
 - fix(register-hooks): when `qmd_collection` is absent from `vault.yml`, strip both legacy `qmd update …` AND canonical `onebrain qmd-reindex` PostToolUse entries. `qmd_collection`'s absence is now the authoritative signal that qmd is not in use.
-- test(register-hooks): flip the "mixed legacy + canonical → strips legacy, keeps canonical" assertion to "strips both"; add a new "canonical-only entry → strips it" test pinning the `/qmd uninstall` path explicitly.
+- test(register-hooks): flip the "mixed legacy + canonical → strips legacy, keeps canonical" assertion to "strips both"; add "canonical-only entry → strips it" test pinning the `/qmd uninstall` path; add "canonical + user hook co-resident → strips canonical, keeps user" test pinning the strip-by-command-value invariant.
 
 ## v2.2.2 — fix(checkpoint, orphan-scan, migrate): read from new 07-logs layout
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-latest_version: 2.2.2
+latest_version: 2.2.3
 released: 2026-05-10
 ---
 
@@ -12,6 +12,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 > For plugin changes (skills, agents, hooks, INSTRUCTIONS), see [PLUGIN-CHANGELOG.md](PLUGIN-CHANGELOG.md).
 
 ## [Unreleased]
+
+## v2.2.3 — fix(register-hooks): strip canonical qmd hook when qmd_collection absent
+
+Companion to plugin v2.4.1's `/qmd uninstall` doc fix. `migrateLegacyQmdEntries(groups, false)` previously stripped only legacy `qmd update …` entries, preserving the canonical `onebrain qmd-reindex` entry on the assumption that a hand-registered hook should survive. In practice no realistic user setup separates the two — `/qmd setup` always writes both, `/qmd uninstall` always removes both — and the preservation made the post-uninstall hook fire forever against a deleted collection.
+
+- fix(register-hooks): when `qmd_collection` is absent from `vault.yml`, strip both legacy `qmd update …` AND canonical `onebrain qmd-reindex` PostToolUse entries. `qmd_collection`'s absence is now the authoritative signal that qmd is not in use.
+- test(register-hooks): flip the "mixed legacy + canonical → strips legacy, keeps canonical" assertion to "strips both"; add a new "canonical-only entry → strips it" test pinning the `/qmd uninstall` path explicitly.
 
 ## v2.2.2 — fix(checkpoint, orphan-scan, migrate): read from new 07-logs layout
 

--- a/PLUGIN-CHANGELOG.md
+++ b/PLUGIN-CHANGELOG.md
@@ -13,12 +13,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
-## v2.4.1 — fix(qmd, /update): drop stale `--qmd` flag from docs
+## v2.4.1 — fix(qmd, /update): drop stale `--qmd` / `--remove-qmd` flags from docs
 
-CLI dropped the `--qmd` option from `onebrain register-hooks` in v2.1.0 (auto-detects from `vault.yml`'s `qmd_collection` instead), but two plugin docs still told users and `/update` to pass it. On Windows running `/update` after upgrading to CLI v2.2.1+ surfaced this as an "unknown option" error from commander.
+CLI dropped both `--qmd` and `--remove-qmd` from `onebrain register-hooks` in v2.1.0 (auto-detects from `vault.yml`'s `qmd_collection` instead — present registers the hook, absent strips it). Three plugin docs still told users and `/update` to pass these flags. On Windows after upgrading to CLI v2.2.1+, both `/update` and `/qmd uninstall` surfaced this as `unknown option` errors from commander.
 
-- fix(skills/qmd/SKILL.md): Step 8 now runs `onebrain register-hooks` (no flag); auto-detects qmd from vault.yml.
-- fix(skills/update/references/migration-steps.md): Step 6 merges the qmd hook bullet into the unconditional `register-hooks` call — no separate `--qmd` invocation.
+- fix(skills/qmd/SKILL.md): Step 8 (`/qmd setup`) and Step 4b (`/qmd uninstall`) now run `onebrain register-hooks` (no flag); auto-detects from vault.yml.
+- fix(skills/update/references/migration-steps.md): Step 6 merges the qmd-hook bullet into the unconditional `register-hooks` call — no separate `--qmd` invocation.
 
 ## v2.4.0 — feat(07-logs): subfolder restructure + per-skill log entries
 

--- a/PLUGIN-CHANGELOG.md
+++ b/PLUGIN-CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-latest_version: 2.4.0
+latest_version: 2.4.1
 released: 2026-05-10
 ---
 
@@ -12,6 +12,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 > For CLI binary (`@onebrain-ai/cli`) changes, see [CHANGELOG.md](CHANGELOG.md).
 
 ## [Unreleased]
+
+## v2.4.1 — fix(qmd, /update): drop stale `--qmd` flag from docs
+
+CLI dropped the `--qmd` option from `onebrain register-hooks` in v2.1.0 (auto-detects from `vault.yml`'s `qmd_collection` instead), but two plugin docs still told users and `/update` to pass it. On Windows running `/update` after upgrading to CLI v2.2.1+ surfaced this as an "unknown option" error from commander.
+
+- fix(skills/qmd/SKILL.md): Step 8 now runs `onebrain register-hooks` (no flag); auto-detects qmd from vault.yml.
+- fix(skills/update/references/migration-steps.md): Step 6 merges the qmd hook bullet into the unconditional `register-hooks` call — no separate `--qmd` invocation.
 
 ## v2.4.0 — feat(07-logs): subfolder restructure + per-skill log entries
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onebrain-ai/cli",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "CLI for OneBrain — personal AI OS for Obsidian with persistent memory, 24+ skills, and Claude Code integration",
   "keywords": [
     "onebrain",

--- a/src/commands/internal/register-hooks.test.ts
+++ b/src/commands/internal/register-hooks.test.ts
@@ -633,6 +633,35 @@ describe('qmd PostToolUse hook via vault.yml qmd_collection', () => {
     expect(cmds).toEqual(['echo user-custom-hook']);
   });
 
+  test('qmd disabled with mixed canonical + user hooks → strips canonical, keeps user entry', async () => {
+    // Pin the invariant: canonical-stripping must filter by command value,
+    // never by matcher or group membership. A future refactor that swept by
+    // matcher would silently nuke the user's hook — this test catches that.
+    await writeFile(join(vaultDir, 'vault.yml'), 'method: onebrain\n', 'utf8');
+    await writeFile(
+      join(vaultDir, '.claude', 'settings.json'),
+      JSON.stringify({
+        hooks: {
+          PostToolUse: [
+            {
+              matcher: 'Write|Edit',
+              hooks: [
+                { type: 'command', command: 'onebrain qmd-reindex' },
+                { type: 'command', command: 'echo user-custom-hook' },
+              ],
+            },
+          ],
+        },
+      }),
+      'utf8',
+    );
+
+    await runRegisterHooks({ vaultDir });
+
+    const cmds = await readPostToolUseCommands(vaultDir);
+    expect(cmds).toEqual(['echo user-custom-hook']);
+  });
+
   test('two pre-existing canonical entries (no legacy) → dedupes to one', async () => {
     // Pathological state from a hand-edit or partial prior run. Even when
     // there's nothing legacy to migrate, the dedup pass must keep a single

--- a/src/commands/internal/register-hooks.test.ts
+++ b/src/commands/internal/register-hooks.test.ts
@@ -577,6 +577,36 @@ describe('qmd PostToolUse hook via vault.yml qmd_collection', () => {
     expect(hooks?.['PostToolUse']).toBeUndefined();
   });
 
+  test('qmd disabled with canonical-only entry → strips it (the /qmd uninstall path)', async () => {
+    // The common /qmd uninstall flow: vault.yml has qmd_collection removed,
+    // and settings.json still has the canonical `onebrain qmd-reindex`
+    // PostToolUse hook from a prior /qmd setup. Running register-hooks must
+    // strip the hook — leaving it in fires forever against a deleted
+    // collection.
+    await writeFile(join(vaultDir, 'vault.yml'), 'method: onebrain\n', 'utf8');
+    await writeFile(
+      join(vaultDir, '.claude', 'settings.json'),
+      JSON.stringify({
+        hooks: {
+          PostToolUse: [
+            {
+              matcher: 'Write|Edit',
+              hooks: [{ type: 'command', command: 'onebrain qmd-reindex' }],
+            },
+          ],
+        },
+      }),
+      'utf8',
+    );
+
+    await runRegisterHooks({ vaultDir });
+
+    const text = await readFile(join(vaultDir, '.claude', 'settings.json'), 'utf8');
+    const settings = JSON.parse(text) as Record<string, unknown>;
+    const hooks = settings['hooks'] as Record<string, unknown> | undefined;
+    expect(hooks?.['PostToolUse']).toBeUndefined();
+  });
+
   test('qmd disabled with mixed legacy + user hooks → strips legacy, keeps user entry', async () => {
     await writeFile(join(vaultDir, 'vault.yml'), 'method: onebrain\n', 'utf8');
     await writeFile(
@@ -637,10 +667,13 @@ describe('qmd PostToolUse hook via vault.yml qmd_collection', () => {
     expect(cmds.filter((c) => c === 'onebrain qmd-reindex').length).toBe(1);
   });
 
-  test('qmd disabled with mixed legacy + canonical → strips legacy, keeps canonical', async () => {
-    // The user disabled qmd in vault.yml but had previously registered the
-    // canonical hook by hand. We must strip only the broken legacy entry —
-    // never silently delete the user's manually-kept canonical one.
+  test('qmd disabled with mixed legacy + canonical → strips both', async () => {
+    // /qmd uninstall removes `qmd_collection` from vault.yml and then runs
+    // `onebrain register-hooks` to clean up. Absence of `qmd_collection` is
+    // the authoritative signal that qmd is not in use, so neither legacy
+    // `qmd update …` nor canonical `onebrain qmd-reindex` entries should
+    // survive — both would fire forever against a collection that no longer
+    // exists.
     await writeFile(join(vaultDir, 'vault.yml'), 'method: onebrain\n', 'utf8');
     await writeFile(
       join(vaultDir, '.claude', 'settings.json'),
@@ -662,8 +695,10 @@ describe('qmd PostToolUse hook via vault.yml qmd_collection', () => {
 
     await runRegisterHooks({ vaultDir });
 
-    const cmds = await readPostToolUseCommands(vaultDir);
-    expect(cmds).toEqual(['onebrain qmd-reindex']);
+    const text = await readFile(join(vaultDir, '.claude', 'settings.json'), 'utf8');
+    const settings = JSON.parse(text) as Record<string, unknown>;
+    const hooks = settings['hooks'] as Record<string, unknown> | undefined;
+    expect(hooks?.['PostToolUse']).toBeUndefined();
   });
 
   test('idempotence: re-introducing a legacy entry after migration → migrates again on next run', async () => {

--- a/src/commands/internal/register-hooks.ts
+++ b/src/commands/internal/register-hooks.ts
@@ -212,10 +212,14 @@ function isLegacyQmdCmd(cmd: string): boolean {
  *   is normalized to `QMD_MATCHER` so a fresh install and a migrated install
  *   converge to the same shape.
  * - When `keepCanonical` is false (no `qmd_collection` in vault.yml — the user
- *   no longer uses qmd), legacy entries are dropped from their groups, and any
+ *   no longer uses qmd), both legacy `qmd update …` entries and canonical
+ *   `onebrain qmd-reindex` entries are dropped from their groups, and any
  *   group that becomes empty is removed. Without this, deleting `qmd_collection`
- *   from vault.yml would leave the legacy hook firing forever against a
- *   collection that no longer exists.
+ *   from vault.yml (or running `/qmd uninstall`) would leave the hook firing
+ *   forever against a collection that no longer exists. `qmd_collection`'s
+ *   absence is the authoritative signal that qmd is not in use — so the
+ *   PostToolUse hook should not survive it, even if the user previously
+ *   registered the canonical entry by hand.
  *
  * After in-place rewriting, duplicate canonical entries are deduped to one,
  * so a vault that already had a canonical entry plus a legacy entry doesn't
@@ -249,7 +253,10 @@ function migrateLegacyQmdEntries(groups: HookGroup[], keepCanonical: boolean): b
       }
     } else {
       const before = group.hooks.length;
-      group.hooks = group.hooks.filter((h) => !isLegacyQmdCmd(h.command ?? ''));
+      group.hooks = group.hooks.filter((h) => {
+        const cmd = h.command ?? '';
+        return !isLegacyQmdCmd(cmd) && cmd !== QMD_CMD;
+      });
       if (group.hooks.length !== before) touched = true;
     }
   }


### PR DESCRIPTION
## Summary

Two coupled bugs around the qmd PostToolUse hook lifecycle, both surfacing on Windows after CLI v2.2.1+.

**Plugin (docs) — v2.4.1:**
The CLI dropped `--qmd` and `--remove-qmd` from `onebrain register-hooks` in v2.1.0 (auto-detects from `vault.yml`'s `qmd_collection` instead). Three plugin docs still told users and `/update` to pass these flags. On Windows, `/update` and `/qmd uninstall` hit `unknown option` errors from commander.

**CLI — v2.2.3:**
Even after the doc fix, `/qmd uninstall` Step 4b still didn't actually strip the hook. `migrateLegacyQmdEntries(groups, false)` only stripped legacy `qmd update …` entries, preserving the canonical `onebrain qmd-reindex` on the (defensive but unrealistic) assumption that the user manually registered it. In practice `/qmd setup` always writes `vault.yml` AND `settings.json` together — there's no real path where a canonical hook exists without `qmd_collection`. So absence of `qmd_collection` is now treated as the authoritative "qmd not in use" signal, and both legacy and canonical entries get stripped.

## Root cause trace

- CLI v2.0.9 (`75e8324`) — added `--qmd` / `--remove-qmd` flags
- CLI v2.1.0 (`2552a3a`) — removed both flags; introduced auto-detection from `vault.yml`
- Plugin docs missed the sync
- The auto-detection's strip path under `keepCanonical=false` was scoped narrowly to legacy entries only — leaving canonical entries dangling on `/qmd uninstall`

## Changes

**Plugin v2.4.0 → v2.4.1:**
- `skills/qmd/SKILL.md` — Step 8 (`/qmd setup`) and Step 4b (`/qmd uninstall`) drop both flags; reworded paragraphs explain auto-detection; softened "Step 7" cross-reference to "the previous step"
- `skills/update/references/migration-steps.md` — Step 6 merges qmd-hook bullet into single `register-hooks` call
- `.claude-plugin/plugin.json` — bump `2.4.0` → `2.4.1`
- `PLUGIN-CHANGELOG.md` — v2.4.1 entry

**CLI v2.2.2 → v2.2.3:**
- `src/commands/internal/register-hooks.ts` — `migrateLegacyQmdEntries(groups, false)` strips canonical entries too; updated function-level rationale
- `src/commands/internal/register-hooks.test.ts` — flipped existing "mixed legacy + canonical → keeps canonical" assertion to "strips both"; added "canonical-only entry → strips it" test pinning the `/qmd uninstall` path; added "canonical + user hook co-resident → strips canonical, keeps user" test pinning the strip-by-command-value invariant
- `package.json` — bump `2.2.2` → `2.2.3`
- `CHANGELOG.md` — v2.2.3 entry

All 330 tests pass (was 329 + 1 new canonical+user-hook test).

## Review history

- **Round 1** (3 parallel reviewers) — caught that `--remove-qmd` was missed in the initial fix
- **Round 2** (verifier) — caught that the CLI auto-strip didn't actually cover canonical entries; doc claim was a lie until CLI fix landed
- **Round 3** (final reviewer) — explicit "safe to merge"; flagged missing test for canonical+user-hook co-resident invariant (now added)

Plus a post-review sweep across all `onebrain <subcommand>` and `--<flag>` references in plugin/Gemini docs against `src/index.ts` — no other stale subcommands or flags found.

## Test plan

- [ ] On Windows: re-run `/update` against a vault with `qmd_collection` set — Step 6 completes without `unknown option` error
- [ ] On Windows: run `/qmd setup` end-to-end — Step 8 registers PostToolUse hook successfully
- [ ] On Windows: run `/qmd uninstall` end-to-end — Step 4b strips the canonical PostToolUse hook from `.claude/settings.json`
- [ ] `grep -rn -- "--qmd\|--remove-qmd" .claude/ .gemini/` returns no doc hits
- [ ] `bun test` — 330 pass