### PR TITLE
feat(help): reorganize /help into 4 Workflow tiers (E6)

### DIFF
--- a/.claude/plugins/onebrain/.claude-plugin/plugin.json
+++ b/.claude/plugins/onebrain/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "onebrain",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "OneBrain — Where human and AI thinking become one. A powerful thinking partner powered by AI synergy.",
   "author": {
     "name": "OneBrain Contributors"

--- a/.claude/plugins/onebrain/skills/help/SKILL.md
+++ b/.claude/plugins/onebrain/skills/help/SKILL.md
@@ -5,69 +5,49 @@ description: "List all available OneBrain commands with descriptions and use cas
 
 # Available Commands
 
-When this skill is invoked, present all available OneBrain commands to the user.
+Skills are organized by workflow phase — Input → Process → Recall → Maintain.
 
-## Step 0: Show Plugin Version and Install Location
+## 📥 INPUT — Capture & ingest
 
-1. Determine install location: use Glob to check if `.claude/plugins/onebrain/.claude-plugin/plugin.json` exists relative to the vault root
-   - If it exists → this is a **project plugin**
-   - If it does not exist → this is a **global plugin** (installed at `$HOME/.claude/plugins/` on Unix or `$env:USERPROFILE/.claude/plugins/` on Windows PowerShell)
-2. Read the version from the correct path:
-   - If project plugin: read from `.claude/plugins/onebrain/.claude-plugin/plugin.json`
-   - If global plugin: use Glob on `$HOME/.claude/plugins/cache/onebrain/onebrain/*/.claude-plugin/plugin.json` (Unix) or `$env:USERPROFILE/.claude/plugins/cache/onebrain/onebrain/*/.claude-plugin/plugin.json` (Windows PowerShell) to find all cached versions. The Glob tool does not expand `~`, so use the env var that resolves to the user's home directory. If multiple matches are returned, use the one with the highest version number (compare the version directory name as semver). If no matches are found, skip the version display.
-3. Display as the first line of your response:
-   - If project plugin: OneBrain v{version} (project plugin)
-   - If global plugin: OneBrain v{version} (global plugin)
-   - If version could not be determined: OneBrain
+| Command | Purpose |
+|---------|---------|
+| `/onboarding` | First-run setup (capture identity + preferences) · *first run only* |
+| `/capture` | Quick titled note with auto-links |
+| `/braindump` | Stream-of-consciousness multi-thread dump |
+| `/bookmark` | Save URL with AI-generated metadata |
+| `/summarize` | Fetch URL → deep summary note |
+| `/import` | Local file (PDF/docs/images) → vault note |
+| `/reading-notes` | Book/article → structured notes |
+| `/research` | Web research → resources/ note |
 
-## Step 1: Present the Command List
+## ⚙️ PROCESS — Synthesize & organize
 
-Display a grouped plain text output:
+| Command | Purpose |
+|---------|---------|
+| `/consolidate` | Inbox → knowledge base |
+| `/distill` | Multi-session notes → digest |
+| `/connect` | Find note-to-note links |
+| `/recap` | Session insights → memory/ |
+| `/weekly` | Weekly reflection |
+| `/daily` | Daily briefing |
+| `/learn` | Teach agent a fact / preference |
 
-```
-──────────────────────────────────────────────────────────────
-📖 OneBrain Commands — v{version}
-──────────────────────────────────────────────────────────────
-Capture & Organize
-  /capture        Quick note capture with wikilinks
-  /braindump      Dump raw thoughts, ideas, tasks
-  /bookmark       Save a URL to Bookmarks.md
-  /consolidate    Process inbox into knowledge base
+## 🔍 RECALL — Retrieve & navigate
 
-Research & Recall
-  /research       Web research → structured knowledge note
-  /summarize      URL → deep summary note
-  /reading-notes  Book or article → structured notes
-  /connect        Find connections between notes
+| Command | Purpose |
+|---------|---------|
+| `/tasks` | Live task dashboard |
+| `/moc` | Vault portal map |
+| `/memory-review` | Audit memory/ files |
 
-Review & Reflect
-  /daily          Daily briefing — tasks + last session
-  /weekly         Weekly reflection and planning
-  /recap          Promote session insights to memory
-  /distill        Compress a research thread into knowledge
+## 🔧 MAINTAIN — System housekeeping
 
-System
-  /tasks          Open live task dashboard
-  /moc            Refresh vault portal (MOC.md)
-  /doctor         Vault health check
-  /update         Update OneBrain to latest version
-  /learn          Teach the agent something to remember
-  /wrapup         Save session summary to log
-  /memory-review  Interactive memory pruning
-  /clone          Package agent context for vault transfer
-  /reorganize     Migrate flat notes into subfolders
-  /qmd            Manage search index
-  /onboarding     First-run vault setup
-  /help           Show this list
-──────────────────────────────────────────────────────────────
-/help [command] for details on any command
-```
-
-## Step 2: Add a Usage Note
-
-After the command list, add:
-
-Tips:
-  • Commands use the `/` prefix — for example, `/braindump`, `/tasks`, `/research`
-  • You can also describe what you want in plain language
-  • New to OneBrain? Start with `/onboarding`
+| Command | Purpose |
+|---------|---------|
+| `/update` | Pull latest from GitHub |
+| `/doctor` | Vault + plugin health check |
+| `/reorganize` | Migrate vault structure |
+| `/clone` | Package agent context for transfer |
+| `/qmd` | qmd search index management |
+| `/help` | This catalog |
+| `/wrapup` | Session log |

--- a/PLUGIN-CHANGELOG.md
+++ b/PLUGIN-CHANGELOG.md
@@ -11,6 +11,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 > **Versioning:** Plugin version is tracked in `plugin.json`. Bump when ANY harness config changes — skills, agents, hooks, INSTRUCTIONS, Gemini settings, slash commands, etc.
 > For CLI binary (`@onebrain-ai/cli`) changes, see [CHANGELOG.md](CHANGELOG.md).
 
+## 2.4.2 — 2026-05-12
+
+- /help reorganized into 4 Workflow tiers: 📥 INPUT · ⚙️ PROCESS · 🔍 RECALL · 🔧 MAINTAIN
+- /onboarding moved from Maintain → Input (first run only)
+- README skill list reordered to mirror tier structure
+- Discoverability win for new users; existing users now see skills by phase
+
 ## [Unreleased]
 
 ## v2.4.1 — fix(qmd, /update): drop stale `--qmd` / `--remove-qmd` flags from docs

--- a/README.md
+++ b/README.md
@@ -342,35 +342,52 @@ Same vault. Same skills. Same memory. The LLM swaps; OneBrain doesn't notice.
 
 ## 📋 24+ Commands
 
-The full skill surface, alphabetized by workflow. **Gemini CLI users:** prepend the `onebrain:` namespace, e.g. `/onebrain:braindump` instead of `/braindump` (avoids collisions with Gemini built-in commands like `/help` and `/tasks`).
+Skills are organized by workflow phase. **Gemini CLI users:** prepend the `onebrain:` namespace, e.g. `/onebrain:braindump` instead of `/braindump` (avoids collisions with Gemini built-in commands like `/help` and `/tasks`).
+
+### 📥 INPUT — Capture & ingest
 
 | Command | What it does |
 |---------|-------------|
-| `/onboarding` | First-run setup — run this first |
+| `/onboarding` | First-run setup — run this first · *first run only* |
 | `/braindump` | Dump everything on your mind — it gets classified and filed |
 | `/capture` | Quick note with auto-linking to related notes |
 | `/bookmark [url]` | Save a URL with AI-generated name, description, and category to Bookmarks.md |
-| `/consolidate` | Process inbox into permanent knowledge |
-| `/connect` | Find connections between notes, suggest wikilinks |
-| `/research [topic]` | Web research → structured note in your vault |
 | `/summarize [url]` | Fetch a URL and save a deep summary note |
 | `/import [path]` | Import local files (PDF, Word, images, scripts) into vault notes |
 | `/reading-notes` | Turn a book or article into structured notes |
+| `/research [topic]` | Web research → structured note in your vault |
+
+### ⚙️ PROCESS — Synthesize & organize
+
+| Command | What it does |
+|---------|-------------|
+| `/consolidate` | Process inbox into permanent knowledge |
+| `/distill [topic]` | Crystallize a completed topic thread into a permanent knowledge note in `03-knowledge/` |
+| `/connect` | Find connections between notes, suggest wikilinks |
+| `/recap` | Cross-session synthesis — batch-promote recurring insights from session logs into `memory/` files (does NOT write to MEMORY.md) |
 | `/weekly` | Review the week, surface patterns, set intentions |
 | `/daily` | Daily briefing — surfaces tasks and last session context, then saves your focus as a daily note |
-| `/recap` | Cross-session synthesis — batch-promote recurring insights from session logs into `memory/` files (does NOT write to MEMORY.md) |
-| `/distill [topic]` | Crystallize a completed topic thread into a permanent knowledge note in `03-knowledge/` |
+| `/learn` | Teach the agent something — facts about your world or behavioral preferences |
+
+### 🔍 RECALL — Retrieve & navigate
+
+| Command | What it does |
+|---------|-------------|
 | `/tasks` | Live task dashboard in Obsidian — creates/updates `TASKS.md` with always-current query sections |
 | `/moc` | Vault portal in Obsidian — creates/updates `MOC.md` with projects, areas, knowledge, tasks, and pinned links |
-| `/wrapup` | Wrap up session — merges any auto-checkpoints and saves full summary to session log |
-| `/learn` | Teach the agent something — facts about your world or behavioral preferences |
 | `/memory-review` | Interactive review of memory files — keep, update, deprecate, or delete entries |
-| `/clone` | Package your agent context for transfer to a new vault |
-| `/reorganize` | Migrate flat notes into organized subfolders |
-| `/qmd` | Set up fast vault search index — enables semantic search across all notes |
-| `/doctor` | Vault + config health check — broken links, orphan notes, stale memory entries, inbox backlog |
+
+### 🔧 MAINTAIN — System housekeeping
+
+| Command | What it does |
+|---------|-------------|
 | `/update` | Update skills, config, and plugins from GitHub |
+| `/doctor` | Vault + config health check — broken links, orphan notes, stale memory entries, inbox backlog |
+| `/reorganize` | Migrate flat notes into organized subfolders |
+| `/clone` | Package your agent context for transfer to a new vault |
+| `/qmd` | Set up fast vault search index — enables semantic search across all notes |
 | `/help` | List all available commands with descriptions |
+| `/wrapup` | Wrap up session — merges any auto-checkpoints and saves full summary to session log |
 
 <details>
 <summary><strong>📁 Vault Structure</strong></summary>


### PR DESCRIPTION
## Summary
- /help skill restructured from flat list → 4 Workflow tiers (📥 INPUT · ⚙️ PROCESS · 🔍 RECALL · 🔧 MAINTAIN)
- /onboarding moved from Maintain → Input (annotated *first run only*)
- README skill list reorganized to mirror tier structure
- Plugin v2.4.1 → 2.4.2

## Test plan
- [x] /help SKILL.md renders 4 tier sections with correct emoji + 25 skills total
- [x] /onboarding under INPUT with "first run only" annotation (consistent in SKILL.md + README)
- [x] No new slash commands referenced (E5 /search, E8 /squad, E9 /schedule-* skills come in later PRs)
- [x] 3-round parallel review: 2 ✅ APPROVED · 1 CHANGES REQUESTED (annotation parity — fixed inline)

Spec: \`01-projects/onebrain/shared/2026-05-11-oracle-borrows-design.md\` · E6
Plan: \`01-projects/onebrain/plans/2026-05-12-oracle-borrows-implementation.md\` · PR 1