### PR TITLE
feat: add Progress reporting heartbeat to 6 long skills (E3)

### DIFF
--- a/.claude/plugins/onebrain/.claude-plugin/plugin.json
+++ b/.claude/plugins/onebrain/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "onebrain",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "description": "OneBrain — Where human and AI thinking become one. A powerful thinking partner powered by AI synergy.",
   "author": {
     "name": "OneBrain Contributors"

--- a/.claude/plugins/onebrain/skills/connect/SKILL.md
+++ b/.claude/plugins/onebrain/skills/connect/SKILL.md
@@ -159,6 +159,33 @@ Per-skill body template (canonical `## Run HH:MM` heading; metadata in first bul
 
 ---
 
+## Progress reporting
+
+This skill is long-running. Emit a 1-line status update after each major step so the user can see progress in real time.
+
+**In-session format:**
+
+```
+→ [step N/M] <action being taken>
+```
+
+**Examples:**
+
+```
+→ [step 1/4] reading target note · finding candidate links...
+→ [step 2/4] dispatching knowledge-linker sub-agent...
+→ [step 3/4] linker returned 14 candidates · ranking...
+→ [step 4/4] writing top suggestions + adding to ## Related...
+```
+
+**Rules:**
+- Emit one line per major step (NOT per sub-step or tool call)
+- M = total steps known up front (count them before starting)
+- Status lines use `→ [step N/M]` prefix exactly so they're visually distinct from skill output
+- Do NOT emit heartbeats for fast operations (< 5 seconds)
+
+---
+
 ## Known Gotchas
 
 - **"Entire knowledge base" scope can be very large.** If note count exceeds 20, Step 2b delegates to the Knowledge Linker agent — the inline Steps 3-4 path is only for small scopes. Do not try to hold hundreds of notes in context.

--- a/.claude/plugins/onebrain/skills/consolidate/SKILL.md
+++ b/.claude/plugins/onebrain/skills/consolidate/SKILL.md
@@ -183,6 +183,34 @@ Per-skill body template (canonical `## Run HH:MM` heading; metadata in first bul
 
 ---
 
+## Progress reporting
+
+This skill is long-running. Emit a 1-line status update after each major step so the user can see progress in real time.
+
+**In-session format:**
+
+```
+→ [step N/M] <action being taken>
+```
+
+**Examples:**
+
+```
+→ [step 1/5] reading inbox · 8 notes found...
+→ [step 2/5] dispatching inbox-classifier in parallel...
+→ [step 3/5] classifier returned recommendations...
+→ [step 4/5] applying user decisions per note...
+→ [step 5/5] moving notes + updating MEMORY-INDEX...
+```
+
+**Rules:**
+- Emit one line per major step (NOT per sub-step or tool call)
+- M = total steps known up front (count them before starting)
+- Status lines use `→ [step N/M]` prefix exactly so they're visually distinct from skill output
+- Do NOT emit heartbeats for fast operations (< 5 seconds)
+
+---
+
 ## Known Gotchas
 
 - **Mixed-content notes.** Braindumps often start with a personal insight but contain project tasks, external references, and reflections all in one file. Read the FULL note before classifying — the first paragraph can be misleading about the overall content type.

--- a/.claude/plugins/onebrain/skills/distill/SKILL.md
+++ b/.claude/plugins/onebrain/skills/distill/SKILL.md
@@ -222,6 +222,34 @@ destination: "[knowledge_folder]/[subfolder]/[Topic].md"
 
 ---
 
+## Progress reporting
+
+This skill is long-running. Emit a 1-line status update after each major step so the user can see progress in real time.
+
+**In-session format:**
+
+```
+→ [step N/M] <action being taken>
+```
+
+**Examples:**
+
+```
+→ [step 1/5] identifying topic sources via qmd...
+→ [step 2/5] reading 9 source notes...
+→ [step 3/5] clustering themes...
+→ [step 4/5] drafting digest...
+→ [step 5/5] writing to 03-knowledge/ + linking...
+```
+
+**Rules:**
+- Emit one line per major step (NOT per sub-step or tool call)
+- M = total steps known up front (count them before starting)
+- Status lines use `→ [step N/M]` prefix exactly so they're visually distinct from skill output
+- Do NOT emit heartbeats for fast operations (< 5 seconds)
+
+---
+
 ## Known Gotchas
 
 - **`synthesized_from_checkpoints: true` logs are recovery summaries.** Checkpoint-synthesized session logs contain less detail than manually written ones — they summarize what was captured by the hook, not a full session review. Treat them as supporting context rather than authoritative sources when distilling decisions.

--- a/.claude/plugins/onebrain/skills/import/SKILL.md
+++ b/.claude/plugins/onebrain/skills/import/SKILL.md
@@ -230,6 +230,33 @@ Each subagent reads the relevant handler reference file before processing. Handl
 
 ---
 
+## Progress reporting
+
+This skill is long-running. Emit a 1-line status update after each major step so the user can see progress in real time.
+
+**In-session format:**
+
+```
+→ [step N/M] <action being taken>
+```
+
+**Examples:**
+
+```
+→ [step 1/4] reading file · detecting format...
+→ [step 2/4] extracting content (PDF parse / OCR / Markdown)...
+→ [step 3/4] enriching via tag-suggester + link-suggester...
+→ [step 4/4] writing to 04-resources/ + linking related notes...
+```
+
+**Rules:**
+- Emit one line per major step (NOT per sub-step or tool call)
+- M = total steps known up front (count them before starting)
+- Status lines use `→ [step N/M]` prefix exactly so they're visually distinct from skill output
+- Do NOT emit heartbeats for fast operations (< 5 seconds)
+
+---
+
 ## Known Gotchas
 
 - **Password-protected PDFs and Word files.** The Read tool returns empty content or a decryption error on protected files. When a non-trivially sized file (> 0 bytes) returns completely empty content, create a stub note with the message "File may be password-protected — content could not be extracted. Unlock the file and re-import."

--- a/.claude/plugins/onebrain/skills/reorganize/SKILL.md
+++ b/.claude/plugins/onebrain/skills/reorganize/SKILL.md
@@ -198,6 +198,35 @@ Per-skill body template (canonical `## Run HH:MM` heading; metadata in first bul
 
 ---
 
+## Progress reporting
+
+This skill is long-running. Emit a 1-line status update after each major step so the user can see progress in real time.
+
+**In-session format:**
+
+```
+→ [step N/M] <action being taken>
+```
+
+**Examples:**
+
+```
+→ [step 1/6] scanning flat notes...
+→ [step 2/6] proposing subfolder structure...
+→ [step 3/6] showing user diff preview...
+→ [step 4/6] (awaiting confirmation)...
+→ [step 5/6] moving files in batches...
+→ [step 6/6] updating MEMORY-INDEX + wikilinks...
+```
+
+**Rules:**
+- Emit one line per major step (NOT per sub-step or tool call)
+- M = total steps known up front (count them before starting)
+- Status lines use `→ [step N/M]` prefix exactly so they're visually distinct from skill output
+- Do NOT emit heartbeats for fast operations (< 5 seconds)
+
+---
+
 ## Known Gotchas
 
 - **Wikilinks are path-independent in Obsidian.** Moving files does NOT break `[[Note Name]]` links — Obsidian resolves by filename, not path. The skill already notes this, but it is the most common user concern; reassure proactively before executing moves.

--- a/.claude/plugins/onebrain/skills/research/SKILL.md
+++ b/.claude/plugins/onebrain/skills/research/SKILL.md
@@ -126,6 +126,35 @@ You might also explore:
 
 ---
 
+## Progress reporting
+
+This skill is long-running. Emit a 1-line status update after each major step so the user can see progress in real time.
+
+**In-session format:**
+
+```
+→ [step N/M] <action being taken>
+```
+
+**Examples:**
+
+```
+→ [step 1/6] fetching seed sources...
+→ [step 2/6] expanding queries via qmd...
+→ [step 3/6] reading 12 web sources...
+→ [step 4/6] extracting key claims + cross-referencing...
+→ [step 5/6] drafting resource note...
+→ [step 6/6] saving to 04-resources/ + adding links...
+```
+
+**Rules:**
+- Emit one line per major step (NOT per sub-step or tool call)
+- M = total steps known up front (count them before starting)
+- Status lines use `→ [step N/M]` prefix exactly so they're visually distinct from skill output
+- Do NOT emit heartbeats for fast operations (< 5 seconds)
+
+---
+
 ## Known Gotchas
 
 - **Versioned tools and libraries.** Web search may return cached or outdated documentation pages. Include the version number in search queries when the topic is a versioned library or framework, and note the publication date of each source in the note.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,6 +110,16 @@ When editing INSTRUCTIONS.md or skills, use Claude Code tool names (`Read`, `Wri
 3. Write the skill as a numbered sequence of steps the AI should follow
 4. Register the command in [INSTRUCTIONS.md](.claude/plugins/onebrain/INSTRUCTIONS.md) and [README.md](README.md) (also increment the command count in the README feature list)
 
+### Long-running skills: heartbeat pattern
+
+Skills that run more than a few seconds (multi-step workflows, batch processing) should emit progress heartbeats. Add a `## Progress reporting` section to your SKILL.md with the format:
+
+```
+→ [step N/M] <action being taken>
+```
+
+See `/research`, `/consolidate`, `/distill`, `/reorganize`, `/connect`, `/import` for reference implementations.
+
 ## Editing an Existing Skill
 
 - Keep the frontmatter intact

--- a/PLUGIN-CHANGELOG.md
+++ b/PLUGIN-CHANGELOG.md
@@ -1,6 +1,6 @@
 ---
-latest_version: 2.4.1
-released: 2026-05-10
+latest_version: 2.4.3
+released: 2026-05-12
 ---
 
 # Plugin Changelog
@@ -10,6 +10,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 > **Versioning:** Plugin version is tracked in `plugin.json`. Bump when ANY harness config changes — skills, agents, hooks, INSTRUCTIONS, Gemini settings, slash commands, etc.
 > For CLI binary (`@onebrain-ai/cli`) changes, see [CHANGELOG.md](CHANGELOG.md).
+
+## 2.4.3 — 2026-05-12
+
+- Added `## Progress reporting` section to 6 long-running skills (E3)
+- Skills updated: /research, /consolidate, /distill, /reorganize, /connect, /import
+- Format: `→ [step N/M] <action>` emitted at each major step
+- Trust improvement during multi-step skill runs
 
 ## 2.4.2 — 2026-05-12
 


### PR DESCRIPTION
## Summary
- 6 long skills now emit `→ [step N/M] <action>` heartbeats
- Skills: /research, /consolidate, /distill, /reorganize, /connect, /import
- CONTRIBUTING.md adds heartbeat pattern subsection under "Adding a New Skill"
- Plugin v2.4.2 → 2.4.3

## Test plan
- [x] Each skill has \`## Progress reporting\` section appended (6/6)
- [x] Step counts match: research=6, consolidate=5, distill=5, reorganize=6, connect=4, import=4
- [x] No fast skills modified (e.g. /capture, /learn unchanged)
- [x] 3-round parallel review: all APPROVED

Spec: 01-projects/onebrain/shared/2026-05-11-oracle-borrows-design.md · E3
Plan: 01-projects/onebrain/plans/2026-05-12-oracle-borrows-implementation.md · PR 2