### PR TITLE
feat(search): new /search skill — general vault retrieval (E5)

### DIFF
--- a/.claude/plugins/onebrain/.claude-plugin/plugin.json
+++ b/.claude/plugins/onebrain/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "onebrain",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "description": "OneBrain — Where human and AI thinking become one. A powerful thinking partner powered by AI synergy.",
   "author": {
     "name": "OneBrain Contributors"

--- a/.claude/plugins/onebrain/INSTRUCTIONS.md
+++ b/.claude/plugins/onebrain/INSTRUCTIONS.md
@@ -145,6 +145,7 @@ These workflows are documented in `.claude/plugins/onebrain/skills/`:
 | `/daily` | `daily/SKILL.md` | Daily briefing: surfaces tasks due and open items from last session | user asks for a daily briefing, daily check-in, or what's on for today |
 | `/recap` | `recap/SKILL.md` | Batch-promote session log insights → memory/ files (does NOT write to MEMORY.md) | user asks to recap or synthesize recent sessions |
 | `/distill` | `distill/SKILL.md` | Aggregate notes from multiple sessions on a topic → structured digest note in `[knowledge_folder]/` (does NOT touch MEMORY.md — use `/learn` to promote lessons manually) | user asks to distill, synthesize, or crystallize a completed research thread or topic |
+| `/search` | `search/SKILL.md` | General vault retrieval (what + why) | user asks to find/search content, or asks "why did we" / "ทำไม" questions |
 | `/tasks` | `tasks/SKILL.md` | Create or update live task dashboard (TASKS.md) and open in Obsidian | user asks to view the task dashboard, regenerate TASKS.md, or open it in Obsidian |
 | `/moc` | `moc/SKILL.md` | Create or update vault portal (MOC.md) and open in Obsidian | user asks to update the vault map |
 | `/wrapup` | `wrapup/SKILL.md` | Wrap up session → session log | explicit `/wrapup` command only — end-of-session signals are handled silently by Auto Session Summary |

--- a/.claude/plugins/onebrain/skills/help/SKILL.md
+++ b/.claude/plugins/onebrain/skills/help/SKILL.md
@@ -36,6 +36,7 @@ Skills are organized by workflow phase — Input → Process → Recall → Main
 
 | Command | Purpose |
 |---------|---------|
+| `/search` | General vault retrieval — answers what + why questions |
 | `/tasks` | Live task dashboard |
 | `/moc` | Vault portal map |
 | `/memory-review` | Audit memory/ files |

--- a/.claude/plugins/onebrain/skills/search/SKILL.md
+++ b/.claude/plugins/onebrain/skills/search/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: search
+description: General vault retrieval — answers both "what" and "why" questions across MEMORY.md, memory/, session logs, plan files, decisions logs, and vault notes. Uses qmd (lex+vec+hyde) with grep fallback.
+auto-invoke:
+  - "ค้นหา"
+  - "search vault"
+  - "หาเรื่อง"
+  - "find in vault"
+  - "ดูว่าเคย"
+  - "ทำไม"
+  - "why did"
+schedulable: false
+schedulable_with_args: true
+required_args: [query]
+---
+
+# /search — General vault retrieval
+
+## Purpose
+
+First-class retrieval skill that answers both **what** and **why** questions across all knowledge layers in the OneBrain vault.
+
+Distinct from existing skills:
+- `/distill` synthesizes a topic into a *new persisted note* (write); /search is read-only
+- `/recap` promotes session insights to *memory/* (write); /search is read-only
+- Direct qmd query gives content matches; /search ranks by question type and surfaces decision chains
+
+## Sources searched (in order of relevance)
+
+1. `[agent_folder]/MEMORY.md` — always-loaded persona/active-projects
+2. `[agent_folder]/memory/*.md` — match via MEMORY-INDEX topics
+3. `[logs_folder]/session/**/*-session-*.md` — past session logs
+4. `[projects_folder]/onebrain/plans/*.md` — implementation plans
+5. Project tracker decisions log tables (e.g. `OneBrain CLI.md`, `OneBrain Cloud.md`)
+6. Vault notes (`03-knowledge/`, `01-projects/`, `04-resources/`, `02-areas/`)
+7. `[logs_folder]/checkpoint/*.md` — in-session-state recovery (for current-day questions)
+
+## Tools used
+
+- **qmd lex+vec+hyde** if `qmd_collection` is configured in vault.yml (preferred)
+- **Glob + Grep fallback** if qmd unavailable
+- **Heuristic question-type detection**: matches `^(why|ทำไม)` → "why mode"; else → "what mode"
+
+## Output format — what mode
+
+For "what is X" / "ตอนนี้ X เป็นไง" questions, synthesize a direct answer + cite top 5 sources:
+
+```
+📌 Direct answer (1–3 sentences synthesized from sources)
+
+📚 Sources (top 5 by relevance):
+  1. <file path>:<heading> — <1-line excerpt>
+  2. ...
+```
+
+## Output format — why mode
+
+For "why did X" / "ทำไม X" questions, reconstruct chronological decision chain:
+
+```
+🕐 Decision chain (chronological):
+  YYYY-MM-DD · <event/decision> · "<key quote or rationale>"
+  YYYY-MM-DD · <next event> · "<rationale>"
+  ...
+
+📚 Sources: <list of files referenced in chain>
+```
+
+## Skill flow
+
+1. Detect question type from input (`why` keyword or default to `what`)
+2. Run qmd query (lex+vec+hyde) OR grep fallback
+3. Score results by question type (why → emphasize sessions + decisions logs; what → emphasize knowledge + project notes)
+4. Top-K cap: 5 results by default; `--all` flag returns full ranked list
+5. Format per mode above
+
+## Known limitations
+
+- Search quality depends on qmd index freshness — run `/qmd embed` if recent vault changes not reflected
+- Why mode requires chronological events to exist; if no decision history found, falls back to what-mode output with a note
+
+## Progress reporting
+
+This skill is long-running for large vaults. Emit:
+
+```
+→ [step 1/4] detecting question type · routing to qmd...
+→ [step 2/4] running qmd lex+vec+hyde across 7 sources...
+→ [step 3/4] scoring + ranking results...
+→ [step 4/4] formatting answer...
+```
+
+## Schedulable
+
+This skill is schedulable when invoked with a required `query` argument. In headless/scheduled mode, output goes to `[logs_folder]/scheduler/YYYY/MM/YYYY-MM-DD-search.md` instead of an in-session response.

--- a/.claude/plugins/onebrain/skills/search/references/output-formats.md
+++ b/.claude/plugins/onebrain/skills/search/references/output-formats.md
@@ -1,0 +1,30 @@
+# /search Output Format Reference
+
+## What mode template
+
+```
+📌 **Answer:** <synthesis>
+
+📚 **Sources:**
+1. `<path>:<heading>` — <excerpt under 80 chars>
+2. ...
+```
+
+## Why mode template
+
+```
+🕐 **Decision chain:**
+
+| Date | Event | Rationale |
+|------|-------|-----------|
+| YYYY-MM-DD | <event> | <key quote> |
+
+📚 **Sources:** <list>
+```
+
+## Detection rules
+
+- Input starts with "why " / "ทำไม " → why mode
+- Input starts with "when did" / "เมื่อไหร่" → why mode (timeline ordering)
+- All other inputs → what mode
+- Override via `--mode=why` or `--mode=what` flag

--- a/PLUGIN-CHANGELOG.md
+++ b/PLUGIN-CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-latest_version: 2.4.3
+latest_version: 2.4.4
 released: 2026-05-12
 ---
 
@@ -10,6 +10,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 > **Versioning:** Plugin version is tracked in `plugin.json`. Bump when ANY harness config changes — skills, agents, hooks, INSTRUCTIONS, Gemini settings, slash commands, etc.
 > For CLI binary (`@onebrain-ai/cli`) changes, see [CHANGELOG.md](CHANGELOG.md).
+
+## 2.4.4 — 2026-05-12
+
+- New skill /search — general vault retrieval (E5)
+- Answers both what + why questions across MEMORY/memory/sessions/plans/decisions logs/notes
+- Uses qmd (lex+vec+hyde) with grep fallback
+- Auto-invoke triggers: "ค้นหา", "search vault", "หาเรื่อง", "ทำไม", "why did"
+- Registered under 🔍 RECALL tier in /help
 
 ## 2.4.3 — 2026-05-12
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 </p>
 
 <p align="center">
-  <strong>Your personal AI OS</strong> — persistent memory, 24+ skills, and a full local stack<br>
+  <strong>Your personal AI OS</strong> — persistent memory, 25+ skills, and a full local stack<br>
   (Claude Code + Obsidian + tmux + Telegram), entirely on your own machine.
 </p>
 
@@ -35,7 +35,7 @@
 
 ## What is OneBrain?
 
-OneBrain is an AI operating system layer built on top of Obsidian. It gives your AI agent persistent memory, a structured knowledge vault, and 24+ pre-built skills — so every session picks up exactly where the last one left off.
+OneBrain is an AI operating system layer built on top of Obsidian. It gives your AI agent persistent memory, a structured knowledge vault, and 25+ pre-built skills — so every session picks up exactly where the last one left off.
 
 Unlike chat-based AI tools, OneBrain lives in plain Markdown files you own forever. No cloud sync required. No proprietary format. Just your agent, your vault, your data.
 
@@ -70,7 +70,7 @@ OneBrain doesn't compete with Claude Code, Gemini CLI, or any other AI harness �
 
 | # | Layer | Role | What lives here |
 |---|---|---|---|
-| 01 | **OneBrain** | OS layer (plugin + CLI) | 24+ skills · lifecycle hooks · vault sync · indexing · checkpoints · harness routing |
+| 01 | **OneBrain** | OS layer (plugin + CLI) | 25+ skills · lifecycle hooks · vault sync · indexing · checkpoints · harness routing |
 | 02 | **Harness** | Agentic runtime | Bring your own — Claude Code · Gemini CLI · Codex · Qwen · ... |
 | 03 | **LLM** | Intelligence source | Local (mlx, ollama) · cloud (claude, gemini, gpt) · raw API |
 | 04 | **Obsidian Vault** | Source of truth | Plain Markdown — notes, memory, decisions, knowledge graph |
@@ -84,7 +84,7 @@ A great harness already knows how to talk to an LLM, edit files, and run shell c
 | | What OneBrain adds | Why it matters |
 |---|---|---|
 | 🧠 | **Memory** — Identity, preferences, decisions, project state — promoted across four tiers as it earns trust | The harness alone starts every session from zero. OneBrain doesn't. |
-| ⚡ | **Skills** — 24+ vault-aware verbs (`/braindump`, `/research`, `/distill`, `/learn`, `/wrapup`, …) | Pre-built workflows the harness would otherwise need you to script every time. |
+| ⚡ | **Skills** — 25+ vault-aware verbs (`/braindump`, `/research`, `/distill`, `/learn`, `/wrapup`, …) | Pre-built workflows the harness would otherwise need you to script every time. |
 | 🎯 | **Calibration** — Every correction, every preference, every learned habit tunes the agent to *you* | The longer you use it, the sharper it gets — your vault is the training data. |
 | 🔀 | **Continuity** — Context lives in the vault, not the harness | Switch from Claude Code to Gemini CLI to Codex. Same memory. Same skills. Same agent. |
 
@@ -210,7 +210,7 @@ OneBrain doesn't just store markdown. Every feature exists to make you and the a
 |---|---|---|
 | 🧠 | **Persistent Memory** | Remembers your name, goals, preferences, and decisions across every session |
 | 🖥️ | **Personal AI OS** | Full local stack: Claude Code + Obsidian + tmux + Telegram — no cloud infra needed |
-| ⚡ | **24+ Skills** | Braindump, research, consolidate, bookmark, import files, daily briefing, and more |
+| ⚡ | **25+ Skills** | Braindump, research, consolidate, bookmark, import files, daily briefing, and more |
 | 📂 | **Vault-native Markdown** | Plain Markdown, no lock-in. Your data stays yours forever |
 | 🔀 | **Multi-Harness OS** | Switch between Claude Code, Gemini CLI, Codex, Qwen, or BYO LLM — context never breaks. [See architecture ↑](#the-harness-os-architecture) |
 | 🔌 | **Zero Config** | Clone, open in Obsidian, run `/onboarding`. Ready in under 2 minutes |
@@ -340,7 +340,7 @@ Same vault. Same skills. Same memory. The LLM swaps; OneBrain doesn't notice.
 
 <a id="commands"></a>
 
-## 📋 24+ Commands
+## 📋 25+ Commands
 
 Skills are organized by workflow phase. **Gemini CLI users:** prepend the `onebrain:` namespace, e.g. `/onebrain:braindump` instead of `/braindump` (avoids collisions with Gemini built-in commands like `/help` and `/tasks`).
 
@@ -373,6 +373,7 @@ Skills are organized by workflow phase. **Gemini CLI users:** prepend the `onebr
 
 | Command | What it does |
 |---------|-------------|
+| `/search` | General vault retrieval — answers what + why questions across MEMORY, sessions, plans, decisions logs, notes |
 | `/tasks` | Live task dashboard in Obsidian — creates/updates `TASKS.md` with always-current query sections |
 | `/moc` | Vault portal in Obsidian — creates/updates `MOC.md` with projects, areas, knowledge, tasks, and pinned links |
 | `/memory-review` | Interactive review of memory files — keep, update, deprecate, or delete entries |


### PR DESCRIPTION
## Summary
- New skill /search for vault-wide retrieval answering what + why questions
- Sources: MEMORY.md, memory/, session logs, plan files, decisions logs, vault notes, checkpoints
- Uses qmd (lex+vec+hyde) with grep fallback
- 7 auto-invoke triggers (ค้นหา, search vault, หาเรื่อง, find in vault, ดูว่าเคย, ทำไม, why did)
- Registered under 🔍 RECALL tier in /help; INSTRUCTIONS.md routing added
- README skill count bumped 24+ → 25+
- Plugin v2.4.3 → 2.4.4

## Test plan
- [x] /search "OneBrain Pro tier pricing" returns synthesized answer + top 5 sources (what mode)
- [x] /search "why Cloudflare Workers" returns chronological decision chain (why mode)
- [x] Auto-invoke triggers detected on "ทำไม" + "search vault" phrasing
- [x] Falls back to grep if qmd_collection not configured
- [x] 3-round parallel review: all APPROVED, zero changes requested

Spec: 01-projects/onebrain/shared/2026-05-11-oracle-borrows-design.md · E5
Plan: 01-projects/onebrain/plans/2026-05-12-oracle-borrows-implementation.md · PR 3