### PR TITLE
fix(search): English-only enforcement + remove premature schedulable frontmatter

### DIFF
--- a/.claude/plugins/onebrain/.claude-plugin/plugin.json
+++ b/.claude/plugins/onebrain/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "onebrain",
-  "version": "2.4.4",
+  "version": "2.4.5",
   "description": "OneBrain — Where human and AI thinking become one. A powerful thinking partner powered by AI synergy.",
   "author": {
     "name": "OneBrain Contributors"

--- a/.claude/plugins/onebrain/INSTRUCTIONS.md
+++ b/.claude/plugins/onebrain/INSTRUCTIONS.md
@@ -145,7 +145,7 @@ These workflows are documented in `.claude/plugins/onebrain/skills/`:
 | `/daily` | `daily/SKILL.md` | Daily briefing: surfaces tasks due and open items from last session | user asks for a daily briefing, daily check-in, or what's on for today |
 | `/recap` | `recap/SKILL.md` | Batch-promote session log insights → memory/ files (does NOT write to MEMORY.md) | user asks to recap or synthesize recent sessions |
 | `/distill` | `distill/SKILL.md` | Aggregate notes from multiple sessions on a topic → structured digest note in `[knowledge_folder]/` (does NOT touch MEMORY.md — use `/learn` to promote lessons manually) | user asks to distill, synthesize, or crystallize a completed research thread or topic |
-| `/search` | `search/SKILL.md` | General vault retrieval (what + why) | user asks to find/search content, or asks "why did we" / "ทำไม" questions |
+| `/search` | `search/SKILL.md` | General vault retrieval (what + why) | user asks to find or search content, or asks "why did we / why is" questions (English literal or bilingual equivalent inferred by agent) |
 | `/tasks` | `tasks/SKILL.md` | Create or update live task dashboard (TASKS.md) and open in Obsidian | user asks to view the task dashboard, regenerate TASKS.md, or open it in Obsidian |
 | `/moc` | `moc/SKILL.md` | Create or update vault portal (MOC.md) and open in Obsidian | user asks to update the vault map |
 | `/wrapup` | `wrapup/SKILL.md` | Wrap up session → session log | explicit `/wrapup` command only — end-of-session signals are handled silently by Auto Session Summary |

--- a/.claude/plugins/onebrain/skills/search/SKILL.md
+++ b/.claude/plugins/onebrain/skills/search/SKILL.md
@@ -2,16 +2,9 @@
 name: search
 description: General vault retrieval — answers both "what" and "why" questions across MEMORY.md, memory/, session logs, plan files, decisions logs, and vault notes. Uses qmd (lex+vec+hyde) with grep fallback.
 auto-invoke:
-  - "ค้นหา"
   - "search vault"
-  - "หาเรื่อง"
   - "find in vault"
-  - "ดูว่าเคย"
-  - "ทำไม"
   - "why did"
-schedulable: false
-schedulable_with_args: true
-required_args: [query]
 ---
 
 # /search — General vault retrieval
@@ -39,11 +32,11 @@ Distinct from existing skills:
 
 - **qmd lex+vec+hyde** if `qmd_collection` is configured in vault.yml (preferred)
 - **Glob + Grep fallback** if qmd unavailable
-- **Heuristic question-type detection**: matches `^(why|ทำไม)` → "why mode"; else → "what mode"
+- **Heuristic question-type detection**: matches `^why\b` (or the agent's bilingual intent inference on non-English equivalents) → "why mode"; else → "what mode"
 
 ## Output format — what mode
 
-For "what is X" / "ตอนนี้ X เป็นไง" questions, synthesize a direct answer + cite top 5 sources:
+For "what is X" / "what's the current state of X" questions, synthesize a direct answer + cite top 5 sources:
 
 ```
 📌 Direct answer (1–3 sentences synthesized from sources)
@@ -55,7 +48,7 @@ For "what is X" / "ตอนนี้ X เป็นไง" questions, synthesiz
 
 ## Output format — why mode
 
-For "why did X" / "ทำไม X" questions, reconstruct chronological decision chain:
+For "why did X" / "why is X" questions, reconstruct chronological decision chain:
 
 ```
 🕐 Decision chain (chronological):
@@ -89,7 +82,3 @@ This skill is long-running for large vaults. Emit:
 → [step 3/4] scoring + ranking results...
 → [step 4/4] formatting answer...
 ```
-
-## Schedulable
-
-This skill is schedulable when invoked with a required `query` argument. In headless/scheduled mode, output goes to `[logs_folder]/scheduler/YYYY/MM/YYYY-MM-DD-search.md` instead of an in-session response.

--- a/.claude/plugins/onebrain/skills/search/references/output-formats.md
+++ b/.claude/plugins/onebrain/skills/search/references/output-formats.md
@@ -24,7 +24,8 @@
 
 ## Detection rules
 
-- Input starts with "why " / "ทำไม " → why mode
-- Input starts with "when did" / "เมื่อไหร่" → why mode (timeline ordering)
+- Input starts with "why " → why mode
+- Input starts with "when did" → why mode (timeline ordering)
+- Bilingual user inputs (non-English equivalents of "why" / "when") are routed to why mode via the agent's intent inference, not a literal regex match
 - All other inputs → what mode
 - Override via `--mode=why` or `--mode=what` flag

--- a/PLUGIN-CHANGELOG.md
+++ b/PLUGIN-CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-latest_version: 2.4.4
+latest_version: 2.4.5
 released: 2026-05-12
 ---
 
@@ -11,12 +11,20 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 > **Versioning:** Plugin version is tracked in `plugin.json`. Bump when ANY harness config changes — skills, agents, hooks, INSTRUCTIONS, Gemini settings, slash commands, etc.
 > For CLI binary (`@onebrain-ai/cli`) changes, see [CHANGELOG.md](CHANGELOG.md).
 
+## 2.4.5 — 2026-05-12
+
+- Hot-fix: enforced English-only across /search per `onebrain-repo-english-only` rule
+- Removed non-English auto-invoke triggers; kept 3 English: `search vault`, `find in vault`, `why did`
+- Removed non-English example phrases and regex tokens from SKILL.md body + references + INSTRUCTIONS routing description
+- Removed premature `schedulable` / `schedulable_with_args` / `required_args` frontmatter (defer to E9 scheduler shipping in a later PR)
+- Bilingual user input still routes via agent's intent matching on the English description; non-English literals were redundant
+
 ## 2.4.4 — 2026-05-12
 
 - New skill /search — general vault retrieval (E5)
 - Answers both what + why questions across MEMORY/memory/sessions/plans/decisions logs/notes
 - Uses qmd (lex+vec+hyde) with grep fallback
-- Auto-invoke triggers: "ค้นหา", "search vault", "หาเรื่อง", "ทำไม", "why did"
+- Auto-invoke triggers: `search vault`, `find in vault`, `why did` (initial entry shipped with non-English triggers; hot-fixed in 2.4.5)
 - Registered under 🔍 RECALL tier in /help
 
 ## 2.4.3 — 2026-05-12


### PR DESCRIPTION
## Summary
Hot-fix for PR #167 (E5 /search). The original PR contained non-English content in committed repo files, violating the `onebrain-repo-english-only` rule. Also removes premature `schedulable` frontmatter that should ship with E9 scheduler PR, not here.

## Changes
- **Auto-invoke array** — removed non-English entries; kept 3 English: \`search vault\`, \`find in vault\`, \`why did\`
- **SKILL.md body** — removed non-English example phrases from what-mode + why-mode sections; removed non-English regex token from Heuristic detection rule
- **references/output-formats.md** — removed non-English entries from detection rules
- **INSTRUCTIONS.md** — removed non-English literal from /search routing trigger description
- **PLUGIN-CHANGELOG.md** — 2.4.4 entry rephrased to drop non-English literal; 2.4.5 entry added
- **Frontmatter** — removed \`schedulable\`, \`schedulable_with_args\`, \`required_args\` (defer to E9 scheduler ship)
- **\`## Schedulable\` section** — removed from SKILL.md body (defer to E9)
- Plugin v2.4.4 → 2.4.5

## Bilingual behavior preserved
Thai user inputs still route to /search via the agent's semantic intent inference on the English description; literal Thai triggers were redundant. SKILL.md, references, and INSTRUCTIONS all document this explicitly.

## Test plan
- [x] Strict English-only audit: zero non-Latin characters in 5 modified files (Python re scan in range U+0E00–U+0E7F)
- [x] Schedulable fields fully removed (frontmatter + body section)
- [x] No CLI version touched (package.json stays 2.2.3)
- [x] CHANGELOG.md untouched (plugin-only fix)
- [x] PLUGIN-CHANGELOG entry ≤8 bullets
- [x] 3-round parallel review: all APPROVED, ruthless audit, zero violations
- [x] Tests pass (330), typecheck clean

## Known out-of-scope
\`skills/distill/SKILL.md:179\` has a pre-existing non-English filename example (not introduced by this PR or E5). Track separately as part of distill skill cleanup.

Spec: 01-projects/onebrain/shared/2026-05-11-oracle-borrows-design.md
Plan: 01-projects/onebrain/plans/2026-05-12-oracle-borrows-implementation.md