### PR TITLE
feat(hooks): emit exec-form Stop + qmd hooks (Claude Code 2.1.139)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ---
-latest_version: 2.2.3
-released: 2026-05-10
+latest_version: 2.2.4
+released: 2026-05-12
 ---
 
 # CLI Changelog
@@ -12,6 +12,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 > For plugin changes (skills, agents, hooks, INSTRUCTIONS), see [PLUGIN-CHANGELOG.md](PLUGIN-CHANGELOG.md).
 
 ## [Unreleased]
+
+## v2.2.4 — feat(register-hooks): emit exec-form hooks (Claude Code 2.1.139)
+
+Hooks emitted by `onebrain register-hooks` now use Claude Code 2.1.139's exec form (`command: "onebrain", args: [...]`) instead of shell form. Exec form spawns the binary directly without a shell, eliminating path-quoting issues for vault paths containing spaces (e.g. Obsidian-on-iCloud).
+
+- feat(register-hooks): Stop and PostToolUse qmd hooks emit `{ command: "onebrain", args: [...] }` exec form
+- fix(register-hooks): idempotent shell→exec migration — legacy shell-form entries (`command: "onebrain checkpoint stop"`) are rewritten in place on next register-hooks run, no duplicates
+- fix(register-hooks): legacy `qmd update -c <col>` entries now migrate directly to exec form, skipping the intermediate shell-form state
+- test(register-hooks): new tests for fresh exec-form emission, shell→exec Stop migration, shell→exec qmd migration, and direct-to-exec legacy qmd migration
 
 ## v2.2.3 — fix(register-hooks): strip canonical qmd hook when qmd_collection absent
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onebrain-ai/cli",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "CLI for OneBrain — personal AI OS for Obsidian with persistent memory, 24+ skills, and Claude Code integration",
   "keywords": [
     "onebrain",

--- a/src/commands/internal/register-hooks.test.ts
+++ b/src/commands/internal/register-hooks.test.ts
@@ -184,13 +184,93 @@ describe('runRegisterHooks', () => {
     const settings = await readSettingsFile(tempDir);
     const hooks = settings['hooks'] as Record<
       string,
-      Array<{ matcher: string; hooks: Array<{ type: string; command: string }> }>
+      Array<{
+        matcher: string;
+        hooks: Array<{ type: string; command: string; args?: string[] }>;
+      }>
     >;
 
     const group = hooks['Stop']?.[0];
     expect(group).toBeDefined();
     expect(group?.matcher).toBe('');
     expect(group?.hooks?.[0]?.type).toBe('command');
+  });
+
+  test('fresh Stop hook is emitted in exec form (command + args, no shell string)', async () => {
+    // Claude Code 2.1.139+: exec form avoids shell quoting issues for vault
+    // paths containing spaces (Obsidian-on-iCloud).
+    await runRegisterHooks({ vaultDir: tempDir });
+
+    const settings = await readSettingsFile(tempDir);
+    const hooks = settings['hooks'] as Record<
+      string,
+      Array<{ hooks: Array<{ command: string; args?: string[] }> }>
+    >;
+    const entry = hooks['Stop']?.[0]?.hooks?.[0];
+    expect(entry?.command).toBe('onebrain');
+    expect(entry?.args).toEqual(['checkpoint', 'stop']);
+  });
+
+  test('rewrites legacy shell-form Stop hook to exec form on register', async () => {
+    // Pre-existing settings.json from a CLI older than 2.2.4 — single shell-
+    // form command string. Running register-hooks must rewrite it in place to
+    // exec form rather than seeing it as missing-and-then-re-added.
+    const settingsPath = join(tempDir, '.claude', 'settings.json');
+    await writeFile(
+      settingsPath,
+      JSON.stringify({
+        hooks: {
+          Stop: [
+            {
+              matcher: '',
+              hooks: [{ type: 'command', command: 'onebrain checkpoint stop' }],
+            },
+          ],
+        },
+      }),
+      'utf8',
+    );
+
+    const result = await runRegisterHooks({ vaultDir: tempDir });
+    expect(result.ok).toBe(true);
+    expect(result.hooks['Stop']).toBe('migrated');
+
+    const settings = await readSettingsFile(tempDir);
+    const stopGroups = (
+      settings['hooks'] as Record<
+        string,
+        Array<{ matcher: string; hooks: Array<{ command: string; args?: string[] }> }>
+      >
+    )['Stop'];
+    // Single entry — no duplicate appended; rewritten in place.
+    const entries = (stopGroups ?? []).flatMap((g) => g.hooks);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.command).toBe('onebrain');
+    expect(entries[0]?.args).toEqual(['checkpoint', 'stop']);
+  });
+
+  test('shell→exec migration is idempotent — second run reports ok', async () => {
+    const settingsPath = join(tempDir, '.claude', 'settings.json');
+    await writeFile(
+      settingsPath,
+      JSON.stringify({
+        hooks: {
+          Stop: [
+            {
+              matcher: '',
+              hooks: [{ type: 'command', command: 'onebrain checkpoint stop' }],
+            },
+          ],
+        },
+      }),
+      'utf8',
+    );
+
+    const first = await runRegisterHooks({ vaultDir: tempDir });
+    expect(first.hooks['Stop']).toBe('migrated');
+
+    const second = await runRegisterHooks({ vaultDir: tempDir });
+    expect(second.hooks['Stop']).toBe('ok');
   });
 
   test('idempotent re-run — nothing changes', async () => {
@@ -231,12 +311,18 @@ describe('runRegisterHooks', () => {
     const stopGroups = (
       settings['hooks'] as Record<
         string,
-        { matcher: string; hooks: { type: string; command: string }[] }[]
+        { matcher: string; hooks: { type: string; command: string; args?: string[] }[] }[]
       >
     )['Stop'];
-    const commands = (stopGroups ?? []).flatMap((g) => g.hooks.map((h) => h.command));
-    expect(commands).toContain('onebrain checkpoint stop');
-    expect(commands.some((c) => c.includes('checkpoint-hook.sh'))).toBe(false);
+    const entries = (stopGroups ?? []).flatMap((g) => g.hooks);
+    // Migrated to exec form (Claude Code ≥2.1.139).
+    expect(entries.some((e) => e.command === 'onebrain' && Array.isArray(e.args))).toBe(true);
+    expect(
+      entries.some(
+        (e) => e.command === 'onebrain' && e.args?.[0] === 'checkpoint' && e.args?.[1] === 'stop',
+      ),
+    ).toBe(true);
+    expect(entries.some((e) => (e.command ?? '').includes('checkpoint-hook.sh'))).toBe(false);
     // Migrated entries must also have type and matcher (same requirement as new entries)
     for (const group of stopGroups ?? []) {
       expect(group.matcher).toBe('');
@@ -315,17 +401,38 @@ describe('qmd PostToolUse hook via vault.yml qmd_collection', () => {
   // ---- legacy `qmd update -c <collection>` migration (issue #127) ----------
 
   /**
-   * Read the PostToolUse hook commands from the vault's settings.json.
-   * Helper keeps the migration assertions readable.
+   * Read PostToolUse commands as joined `command + args` strings for readable
+   * assertions. Exec-form entries (`command: "onebrain", args: ["qmd-reindex"]`)
+   * surface as `"onebrain qmd-reindex"` so legacy assertions still hold.
    */
   async function readPostToolUseCommands(vault: string): Promise<string[]> {
     const text = await readFile(join(vault, '.claude', 'settings.json'), 'utf8');
     const settings = JSON.parse(text) as Record<string, unknown>;
     const hooks = settings['hooks'] as Record<string, unknown[]> | undefined;
     const groups = (hooks?.['PostToolUse'] ?? []) as Array<{
-      hooks?: Array<{ command?: string }>;
+      hooks?: Array<{ command?: string; args?: string[] }>;
     }>;
-    return groups.flatMap((g) => (g.hooks ?? []).map((h) => h.command ?? ''));
+    return groups.flatMap((g) =>
+      (g.hooks ?? []).map((h) => {
+        const args = h.args ?? [];
+        return args.length > 0 ? [h.command ?? '', ...args].join(' ') : (h.command ?? '');
+      }),
+    );
+  }
+
+  /**
+   * Read the raw PostToolUse hook entries (preserves exec-form `args`).
+   */
+  async function readPostToolUseEntries(
+    vault: string,
+  ): Promise<Array<{ command?: string; args?: string[] }>> {
+    const text = await readFile(join(vault, '.claude', 'settings.json'), 'utf8');
+    const settings = JSON.parse(text) as Record<string, unknown>;
+    const hooks = settings['hooks'] as Record<string, unknown[]> | undefined;
+    const groups = (hooks?.['PostToolUse'] ?? []) as Array<{
+      hooks?: Array<{ command?: string; args?: string[] }>;
+    }>;
+    return groups.flatMap((g) => g.hooks ?? []);
   }
 
   test('legacy `qmd update -c …` PostToolUse entry → migrated to `onebrain qmd-reindex`', async () => {
@@ -543,10 +650,76 @@ describe('qmd PostToolUse hook via vault.yml qmd_collection', () => {
     const settings = JSON.parse(text) as Record<string, unknown>;
     const groups = (settings['hooks'] as Record<string, unknown[]>)['PostToolUse'] as Array<{
       matcher: string;
-      hooks: Array<{ command: string }>;
+      hooks: Array<{ command: string; args?: string[] }>;
     }>;
-    const canonical = groups.find((g) => g.hooks.some((h) => h.command === 'onebrain qmd-reindex'));
+    // Exec-form match: `command: "onebrain", args: ["qmd-reindex"]`.
+    const canonical = groups.find((g) =>
+      g.hooks.some((h) => h.command === 'onebrain' && h.args?.[0] === 'qmd-reindex'),
+    );
     expect(canonical?.matcher).toBe('Write|Edit');
+  });
+
+  test('legacy `qmd update -c …` migrates directly to exec form (not shell-form intermediate)', async () => {
+    // Issue #127 + 2.2.4: legacy `qmd update <args>` shell-form entries must
+    // land in exec form on first run, skipping the intermediate shell-form
+    // `onebrain qmd-reindex` state.
+    await writeFile(
+      join(vaultDir, 'vault.yml'),
+      'method: onebrain\nqmd_collection: ob-1-test\n',
+      'utf8',
+    );
+    await writeFile(
+      join(vaultDir, '.claude', 'settings.json'),
+      JSON.stringify({
+        hooks: {
+          PostToolUse: [
+            {
+              matcher: 'Write|Edit',
+              hooks: [{ type: 'command', command: 'qmd update -c ob-1-test' }],
+            },
+          ],
+        },
+      }),
+      'utf8',
+    );
+
+    await runRegisterHooks({ vaultDir });
+
+    const entries = await readPostToolUseEntries(vaultDir);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.command).toBe('onebrain');
+    expect(entries[0]?.args).toEqual(['qmd-reindex']);
+  });
+
+  test('rewrites legacy shell-form qmd hook to exec form on register', async () => {
+    // Pre-existing canonical shell-form entry from a CLI older than 2.2.4 —
+    // must be rewritten in place to exec form, not duplicated.
+    await writeFile(
+      join(vaultDir, 'vault.yml'),
+      'method: onebrain\nqmd_collection: ob-1-test\n',
+      'utf8',
+    );
+    await writeFile(
+      join(vaultDir, '.claude', 'settings.json'),
+      JSON.stringify({
+        hooks: {
+          PostToolUse: [
+            {
+              matcher: 'Write|Edit',
+              hooks: [{ type: 'command', command: 'onebrain qmd-reindex' }],
+            },
+          ],
+        },
+      }),
+      'utf8',
+    );
+
+    await runRegisterHooks({ vaultDir });
+
+    const entries = await readPostToolUseEntries(vaultDir);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.command).toBe('onebrain');
+    expect(entries[0]?.args).toEqual(['qmd-reindex']);
   });
 
   test('qmd disabled (no qmd_collection) → legacy entry is stripped, not left dangling', async () => {

--- a/src/commands/internal/register-hooks.ts
+++ b/src/commands/internal/register-hooks.ts
@@ -24,7 +24,20 @@ import { detectHarness } from './harness.js';
 interface HookEntry {
   type?: string;
   command?: string;
+  args?: string[];
   [key: string]: unknown;
+}
+
+/**
+ * Exec-form hook spec — split command + args so settings.json emits
+ * `{ command: "onebrain", args: [...] }` (Claude Code ≥2.1.139).
+ *
+ * Exec form spawns the binary directly without a shell, so vault paths
+ * containing spaces (e.g. Obsidian-on-iCloud) never need quoting.
+ */
+interface HookSpec {
+  command: string;
+  args: string[];
 }
 
 interface HookGroup {
@@ -48,8 +61,8 @@ interface SettingsJson {
 // Constants
 // ---------------------------------------------------------------------------
 
-const HOOK_COMMANDS: Record<string, string> = {
-  Stop: 'onebrain checkpoint stop',
+const HOOK_SPECS: Record<string, HookSpec> = {
+  Stop: { command: 'onebrain', args: ['checkpoint', 'stop'] },
 };
 
 const HOOK_EVENTS = ['Stop'] as const;
@@ -102,17 +115,57 @@ async function writeSettings(settingsPath: string, settings: SettingsJson): Prom
 type HookStatus = 'added' | 'migrated' | 'ok';
 
 /**
- * Check whether a command is already registered under an event.
+ * Match a hook entry against an exec-form spec, accepting both:
+ * - new exec form: `{ command: "onebrain", args: ["checkpoint", "stop"] }`
+ * - legacy shell form: `{ command: "onebrain checkpoint stop" }` (no args)
  */
-function checkHookPresence(
-  groups: HookGroup[],
-  targetCmd: string,
-): 'found' | 'migrate' | 'missing' {
+function matchesSpec(entry: HookEntry, spec: HookSpec): boolean {
+  const fullCmd = [spec.command, ...spec.args].join(' ');
+  if (
+    entry.command === spec.command &&
+    JSON.stringify(entry.args ?? []) === JSON.stringify(spec.args)
+  ) {
+    return true;
+  }
+  if (entry.command === fullCmd && !entry.args) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * If `entry` is the legacy shell form of `spec`, rewrite it in place to
+ * exec form. Returns true when a rewrite happened.
+ */
+function rewriteIfShellForm(entry: HookEntry, spec: HookSpec): boolean {
+  const fullCmd = [spec.command, ...spec.args].join(' ');
+  if (entry.command === fullCmd && !entry.args) {
+    entry.command = spec.command;
+    entry.args = [...spec.args];
+    if (!entry.type) entry.type = 'command';
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Check whether a hook matching `spec` is already registered under an event.
+ *
+ * Returns:
+ * - `found`: an entry already matches `spec` (in either exec or shell form).
+ *   Callers should still run `rewriteIfShellForm` first so legacy entries
+ *   converge to exec form on the same pass.
+ * - `migrate`: an old `checkpoint-hook.sh` entry was found — caller should
+ *   rewrite it to exec form rather than appending a new entry.
+ * - `missing`: no matching or migratable entry — caller should push a new
+ *   exec-form entry.
+ */
+function checkHookPresence(groups: HookGroup[], spec: HookSpec): 'found' | 'migrate' | 'missing' {
   let foundMigrate = false;
   for (const group of groups) {
     for (const entry of group.hooks ?? []) {
+      if (matchesSpec(entry, spec)) return 'found';
       const cmd = entry.command ?? '';
-      if (cmd === targetCmd) return 'found';
       if (cmd.includes('checkpoint-hook.sh')) foundMigrate = true;
     }
   }
@@ -155,27 +208,42 @@ function applyHooks(settings: SettingsJson): Record<string, HookStatus> {
   }
 
   for (const event of HOOK_EVENTS) {
-    const cmd = HOOK_COMMANDS[event];
-    if (!cmd) continue; // HOOK_COMMANDS covers all HOOK_EVENTS — this is a safety guard
+    const spec = HOOK_SPECS[event];
+    if (!spec) continue; // HOOK_SPECS covers all HOOK_EVENTS — this is a safety guard
     if (!hooks[event]) hooks[event] = [];
     const groups = hooks[event];
-    const presence = checkHookPresence(groups, cmd);
+
+    // Pass 1: rewrite any legacy shell-form entries (`command: "onebrain
+    // checkpoint stop"`) to exec form in place. This converts old entries on
+    // the same run that registers new ones, without producing duplicates.
+    let rewroteShellForm = false;
+    for (const group of groups) {
+      for (const entry of group.hooks ?? []) {
+        if (rewriteIfShellForm(entry, spec)) rewroteShellForm = true;
+      }
+    }
+
+    const presence = checkHookPresence(groups, spec);
 
     if (presence === 'found') {
-      result[event] = 'ok';
+      result[event] = rewroteShellForm ? 'migrated' : 'ok';
     } else if (presence === 'migrate') {
       for (const group of groups) {
         if (group.matcher === undefined) group.matcher = '';
         for (const entry of group.hooks ?? []) {
           if ((entry.command ?? '').includes('checkpoint-hook.sh')) {
-            entry.command = cmd;
+            entry.command = spec.command;
+            entry.args = [...spec.args];
             if (!entry.type) entry.type = 'command';
           }
         }
       }
       result[event] = 'migrated';
     } else {
-      groups.push({ matcher: '', hooks: [{ type: 'command', command: cmd }] });
+      groups.push({
+        matcher: '',
+        hooks: [{ type: 'command', command: spec.command, args: [...spec.args] }],
+      });
       result[event] = 'added';
     }
   }
@@ -187,8 +255,17 @@ function applyHooks(settings: SettingsJson): Record<string, HookStatus> {
 // Step 2: Register PostToolUse qmd hook (optional, --qmd / --remove-qmd)
 // ---------------------------------------------------------------------------
 
-const QMD_CMD = 'onebrain qmd-reindex';
+const QMD_SPEC: HookSpec = { command: 'onebrain', args: ['qmd-reindex'] };
 const QMD_MATCHER = 'Write|Edit';
+
+/**
+ * True for any entry that represents the canonical qmd-reindex hook in
+ * either exec or legacy shell form. Used by the strip-on-uninstall path
+ * (`keepCanonical=false`) so /qmd uninstall removes both forms.
+ */
+function isCanonicalQmdEntry(entry: HookEntry): boolean {
+  return matchesSpec(entry, QMD_SPEC);
+}
 
 /**
  * Match legacy templates that registered `qmd update <args>` as the PostToolUse
@@ -226,13 +303,16 @@ function isLegacyQmdCmd(cmd: string): boolean {
  * end up calling the hook twice on each Write.
  */
 function migrateLegacyQmdEntries(groups: HookGroup[], keepCanonical: boolean): boolean {
-  // Three sequential passes over `groups`:
-  //   1. Rewrite-or-strip any `qmd update …` entries (rewrite keeps canonical,
-  //      strip removes them entirely).
-  //   2. Dedupe `onebrain qmd-reindex` entries — runs on every keepCanonical=true
-  //      call so a settings.json that already had two canonical entries (Pass 1
-  //      saw nothing to do) still ends up with one.
-  //   3. Splice out groups whose hooks array became empty (reverse iteration —
+  // Four sequential passes over `groups`:
+  //   1. Rewrite-or-strip any `qmd update …` entries (rewrite directly to
+  //      exec form; strip removes them entirely).
+  //   2. (keepCanonical only) Rewrite legacy shell-form `onebrain qmd-reindex`
+  //      entries to exec form in place, so both Pass-1 migrations and
+  //      hand-edited shell-form entries converge to the same shape.
+  //   3. Dedupe canonical entries (matched by spec, so both forms count as
+  //      one) — runs on every keepCanonical=true call so a settings.json
+  //      that already had two canonical entries still ends up with one.
+  //   4. Splice out groups whose hooks array became empty (reverse iteration —
   //      forward indices stay valid as we splice from the tail).
   let touched = false;
 
@@ -242,7 +322,8 @@ function migrateLegacyQmdEntries(groups: HookGroup[], keepCanonical: boolean): b
       let groupTouched = false;
       for (const entry of group.hooks) {
         if (isLegacyQmdCmd(entry.command ?? '')) {
-          entry.command = QMD_CMD;
+          entry.command = QMD_SPEC.command;
+          entry.args = [...QMD_SPEC.args];
           if (!entry.type) entry.type = 'command';
           groupTouched = true;
         }
@@ -255,19 +336,28 @@ function migrateLegacyQmdEntries(groups: HookGroup[], keepCanonical: boolean): b
       const before = group.hooks.length;
       group.hooks = group.hooks.filter((h) => {
         const cmd = h.command ?? '';
-        return !isLegacyQmdCmd(cmd) && cmd !== QMD_CMD;
+        // Drop legacy `qmd update …` and canonical qmd-reindex (either form).
+        return !isLegacyQmdCmd(cmd) && !isCanonicalQmdEntry(h);
       });
       if (group.hooks.length !== before) touched = true;
     }
   }
 
   if (keepCanonical) {
+    // Pass 2: rewrite shell-form canonical entries to exec form in place.
+    for (const group of groups) {
+      for (const entry of group.hooks ?? []) {
+        if (rewriteIfShellForm(entry, QMD_SPEC)) touched = true;
+      }
+    }
+
+    // Pass 3: dedupe — keep first canonical (now always exec form), drop rest.
     let seenCanonical = false;
     for (const group of groups) {
       if (!group.hooks) continue;
       const before = group.hooks.length;
       group.hooks = group.hooks.filter((h) => {
-        if (h.command !== QMD_CMD) return true;
+        if (!isCanonicalQmdEntry(h)) return true;
         if (seenCanonical) return false;
         seenCanonical = true;
         return true;
@@ -291,12 +381,16 @@ function applyQmdHook(settings: SettingsJson): HookStatus {
 
   // Migrate before the canonical-presence check so a settings.json containing
   // only legacy entries reports `migrated` and produces a single canonical
-  // entry — never `added` plus a stale duplicate.
+  // entry — never `added` plus a stale duplicate. Migration also rewrites
+  // legacy shell-form `onebrain qmd-reindex` entries to exec form.
   const migrated = migrateLegacyQmdEntries(groups, true);
 
-  const already = groups.some((g) => g.hooks?.some((h) => h.command === QMD_CMD));
+  const already = groups.some((g) => g.hooks?.some((h) => isCanonicalQmdEntry(h)));
   if (already) return migrated ? 'migrated' : 'ok';
-  groups.push({ matcher: QMD_MATCHER, hooks: [{ type: 'command', command: QMD_CMD }] });
+  groups.push({
+    matcher: QMD_MATCHER,
+    hooks: [{ type: 'command', command: QMD_SPEC.command, args: [...QMD_SPEC.args] }],
+  });
   return 'added';
 }
 


### PR DESCRIPTION
## Summary
Claude Code 2.1.139 added `args: string[]` field on hook entries (exec form) — spawns the command directly without a shell, so path placeholders never need quoting. This matters for OneBrain users whose vault path contains spaces (Obsidian-on-iCloud).

## Changes
- `HookEntry` interface: added `args?: string[]`
- `HOOK_SPECS` (Stop) + `QMD_SPEC` (PostToolUse) split command + args
- New helpers: `matchesSpec`, `rewriteIfShellForm`, `isCanonicalQmdEntry`
- Legacy shell-form entries rewritten in-place on next `onebrain register-hooks` run
- Legacy `qmd update <args>` migration lands directly at exec form (skipping intermediate shell form)
- Legacy `checkpoint-hook.sh` migration lands at exec form
- CLI v2.2.3 → 2.2.4

## Test plan
- [x] 5 new tests: fresh exec-form Stop + qmd emission, shell→exec Stop rewrite, shell→exec qmd rewrite, legacy `qmd update` direct-to-exec
- [x] Idempotence: running register-hooks twice yields status `ok` on second run
- [x] 335 tests pass (was 330; +5 new)
- [x] typecheck clean, biome clean
- [x] 3-round parallel review: all APPROVED, zero non-English audit clean, conventions respected
- [x] Vault-side: next `onebrain register-hooks` (or `onebrain update`) migrates existing entries idempotently

## Why now
Pre-PR 4 ship — independent of the E9 scheduler work. Quick win for path-quoting bugs.

## Reference
Claude Code 2.1.139 changelog: "Added hook \`args: string[]\` field (exec form) that spawns the command directly without a shell, so path placeholders never need quoting"