### PR TITLE
fix(hooks): iterate all detected harnesses + raw status label in non-TTY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-latest_version: 2.2.4
+latest_version: 2.2.5
 released: 2026-05-12
 ---
 
@@ -12,6 +12,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 > For plugin changes (skills, agents, hooks, INSTRUCTIONS), see [PLUGIN-CHANGELOG.md](PLUGIN-CHANGELOG.md).
 
 ## [Unreleased]
+
+## v2.2.5 — fix(hooks): iterate all detected harnesses + raw status label in non-TTY
+
+- Fix: `register-hooks` now updates ALL configured harnesses (.claude AND .gemini) instead of exiting on the first match
+- Multi-harness vaults previously had `.claude/settings.json` silently skipped when `.gemini/` was also present
+- `detectHarnesses()` returns `Harness[]`; `detectHarness()` kept as thin single-value wrapper for backward compat
+- Fix: non-TTY hook status report now shows raw status (`Stop migrated`) instead of collapsing all to `ok`
+- Workaround for affected vaults (pre-2.2.5): `ONEBRAIN_HARNESS=claude onebrain register-hooks`
 
 ## v2.2.4 — feat(register-hooks): emit exec-form hooks (Claude Code 2.1.139)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onebrain-ai/cli",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "description": "CLI for OneBrain — personal AI OS for Obsidian with persistent memory, 24+ skills, and Claude Code integration",
   "keywords": [
     "onebrain",

--- a/src/commands/internal/harness.test.ts
+++ b/src/commands/internal/harness.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Tests for harness detection.
+ *
+ * `detectHarnesses()` returns ALL detected harnesses (multi-harness vaults
+ * matter — a vault with both .claude/ and .gemini/ wants OneBrain configured
+ * for both). `detectHarness()` is a thin wrapper that returns the first.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdir, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { detectHarness, detectHarnesses } from './harness.js';
+
+let vaultDir: string;
+
+beforeEach(async () => {
+  vaultDir = join(tmpdir(), `ob-harness-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  await mkdir(vaultDir, { recursive: true });
+  // biome-ignore lint/performance/noDelete: env cleanup requires delete to unset
+  delete process.env['ONEBRAIN_HARNESS'];
+});
+
+afterEach(async () => {
+  await rm(vaultDir, { recursive: true, force: true });
+  // biome-ignore lint/performance/noDelete: env cleanup requires delete to unset
+  delete process.env['ONEBRAIN_HARNESS'];
+});
+
+// ---------------------------------------------------------------------------
+// detectHarnesses
+// ---------------------------------------------------------------------------
+
+describe('detectHarnesses', () => {
+  test('both .claude/ and .gemini/ present → ["claude", "gemini"] (claude first)', async () => {
+    await mkdir(join(vaultDir, '.claude'), { recursive: true });
+    await mkdir(join(vaultDir, '.gemini'), { recursive: true });
+
+    const result = await detectHarnesses(vaultDir);
+    expect(result).toEqual(['claude', 'gemini']);
+  });
+
+  test('only .claude/ present → ["claude"]', async () => {
+    await mkdir(join(vaultDir, '.claude'), { recursive: true });
+
+    const result = await detectHarnesses(vaultDir);
+    expect(result).toEqual(['claude']);
+  });
+
+  test('only .gemini/ present → ["gemini"]', async () => {
+    await mkdir(join(vaultDir, '.gemini'), { recursive: true });
+
+    const result = await detectHarnesses(vaultDir);
+    expect(result).toEqual(['gemini']);
+  });
+
+  test('neither directory present → ["direct"]', async () => {
+    const result = await detectHarnesses(vaultDir);
+    expect(result).toEqual(['direct']);
+  });
+
+  test('ONEBRAIN_HARNESS=claude → ["claude"] (overrides directory detection)', async () => {
+    process.env['ONEBRAIN_HARNESS'] = 'claude';
+    // .gemini/ present should be ignored when env is set
+    await mkdir(join(vaultDir, '.gemini'), { recursive: true });
+
+    const result = await detectHarnesses(vaultDir);
+    expect(result).toEqual(['claude']);
+  });
+
+  test('ONEBRAIN_HARNESS=claude-code → ["claude"] (alias)', async () => {
+    process.env['ONEBRAIN_HARNESS'] = 'claude-code';
+    const result = await detectHarnesses(vaultDir);
+    expect(result).toEqual(['claude']);
+  });
+
+  test('ONEBRAIN_HARNESS=gemini → ["gemini"]', async () => {
+    process.env['ONEBRAIN_HARNESS'] = 'gemini';
+    // .claude/ present should be ignored when env is set
+    await mkdir(join(vaultDir, '.claude'), { recursive: true });
+
+    const result = await detectHarnesses(vaultDir);
+    expect(result).toEqual(['gemini']);
+  });
+
+  test('ONEBRAIN_HARNESS=direct → ["direct"]', async () => {
+    process.env['ONEBRAIN_HARNESS'] = 'direct';
+    const result = await detectHarnesses(vaultDir);
+    expect(result).toEqual(['direct']);
+  });
+
+  test('ONEBRAIN_HARNESS=garbage → falls back to directory detection', async () => {
+    process.env['ONEBRAIN_HARNESS'] = 'not-a-harness';
+    await mkdir(join(vaultDir, '.claude'), { recursive: true });
+
+    const result = await detectHarnesses(vaultDir);
+    expect(result).toEqual(['claude']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// detectHarness — backward-compat wrapper
+// ---------------------------------------------------------------------------
+
+describe('detectHarness (legacy single-value wrapper)', () => {
+  test('both .claude/ and .gemini/ → "claude" (first detected)', async () => {
+    await mkdir(join(vaultDir, '.claude'), { recursive: true });
+    await mkdir(join(vaultDir, '.gemini'), { recursive: true });
+
+    const result = await detectHarness(vaultDir);
+    expect(result).toBe('claude');
+  });
+
+  test('only .claude/ → "claude"', async () => {
+    await mkdir(join(vaultDir, '.claude'), { recursive: true });
+    const result = await detectHarness(vaultDir);
+    expect(result).toBe('claude');
+  });
+
+  test('only .gemini/ → "gemini"', async () => {
+    await mkdir(join(vaultDir, '.gemini'), { recursive: true });
+    const result = await detectHarness(vaultDir);
+    expect(result).toBe('gemini');
+  });
+
+  test('neither → "direct"', async () => {
+    const result = await detectHarness(vaultDir);
+    expect(result).toBe('direct');
+  });
+
+  test('ONEBRAIN_HARNESS=gemini → "gemini"', async () => {
+    process.env['ONEBRAIN_HARNESS'] = 'gemini';
+    const result = await detectHarness(vaultDir);
+    expect(result).toBe('gemini');
+  });
+});

--- a/src/commands/internal/harness.ts
+++ b/src/commands/internal/harness.ts
@@ -13,27 +13,49 @@ async function pathExists(p: string): Promise<boolean> {
 }
 
 /**
- * Detect which AI runtime harness is in use.
+ * Detect which AI runtime harness(es) are in use.
+ *
+ * A vault may configure multiple harnesses (e.g. both .claude/ and .gemini/
+ * present means the user wants OneBrain hooks installed for BOTH). Return all
+ * detected; caller decides what to do with each.
  *
  * Priority:
- *   1. ONEBRAIN_HARNESS env var (explicit override)
- *   2. .gemini/ directory present → gemini
- *   3. .claude/ directory present → claude
- *   4. fallback → direct
+ *   1. ONEBRAIN_HARNESS env var (explicit override — single value, returned as
+ *      a one-element array; honors backward compat with the single-harness API).
+ *   2. .claude/ and .gemini/ directory presence — independent checks; either or
+ *      both can be returned.
+ *   3. fallback → ['direct']
  */
-export async function detectHarness(vaultRoot: string): Promise<Harness> {
+export async function detectHarnesses(vaultRoot: string): Promise<Harness[]> {
   const env = process.env['ONEBRAIN_HARNESS'];
   if (env) {
-    if (env === 'claude' || env === 'claude-code') return 'claude';
-    if (env === 'gemini') return 'gemini';
-    if (env === 'direct') return 'direct';
+    if (env === 'claude' || env === 'claude-code') return ['claude'];
+    if (env === 'gemini') return ['gemini'];
+    if (env === 'direct') return ['direct'];
     process.stderr.write(
       `harness: unknown ONEBRAIN_HARNESS value "${env}" — ignoring, falling back to directory detection\n`,
     );
   }
 
-  if (await pathExists(join(vaultRoot, '.gemini'))) return 'gemini';
-  if (await pathExists(join(vaultRoot, '.claude'))) return 'claude';
+  const detected: Harness[] = [];
+  if (await pathExists(join(vaultRoot, '.claude'))) detected.push('claude');
+  if (await pathExists(join(vaultRoot, '.gemini'))) detected.push('gemini');
 
-  return 'direct';
+  if (detected.length === 0) return ['direct'];
+  return detected;
+}
+
+/**
+ * Backward-compat shim: keep the old `detectHarness` signature for any callers
+ * outside register-hooks that consume a single value. Returns the FIRST
+ * detected harness, mirroring the new priority (claude before gemini).
+ *
+ * `detectHarnesses` always returns at least one element (`['direct']` as
+ * fallback), so the destructured value is non-undefined — the explicit
+ * `?? 'direct'` is a defense-in-depth guard that lets us avoid a non-null
+ * assertion without changing observable behavior.
+ */
+export async function detectHarness(vaultRoot: string): Promise<Harness> {
+  const [first] = await detectHarnesses(vaultRoot);
+  return first ?? 'direct';
 }

--- a/src/commands/internal/register-hooks.test.ts
+++ b/src/commands/internal/register-hooks.test.ts
@@ -1058,3 +1058,134 @@ describe('registerDirectPath', () => {
     expect(result.ok).toBe(true);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Multi-harness vault — both .claude/ and .gemini/ present
+// ---------------------------------------------------------------------------
+//
+// Bug found 2026-05-12: detectHarness returned a SINGLE harness, so vaults
+// with BOTH .claude/ and .gemini/ had the .claude block skipped (gemini won
+// the priority race) — register-hooks silently never wrote .claude/settings.json.
+// The fix is detectHarnesses → Harness[] + runRegisterHooks loops every
+// detected harness. This test would have caught the regression.
+
+describe('runRegisterHooks with multi-harness vault', () => {
+  let vaultDir: string;
+
+  beforeEach(async () => {
+    vaultDir = join(tmpdir(), `ob-multi-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    await mkdir(join(vaultDir, '.claude'), { recursive: true });
+    await mkdir(join(vaultDir, '.gemini'), { recursive: true });
+    await writeFile(join(vaultDir, 'vault.yml'), 'update_channel: stable\n', 'utf8');
+  });
+
+  afterEach(async () => {
+    await rm(vaultDir, { recursive: true, force: true });
+  });
+
+  test('vault with BOTH .claude/ and .gemini/ → .claude/settings.json IS updated', async () => {
+    const result = await runRegisterHooks({ vaultDir });
+    expect(result.ok).toBe(true);
+    // Stop hook registered into .claude/settings.json — the bug was that the
+    // claude branch never ran when .gemini/ was also present.
+    expect(result.hooks['Stop']).toBe('added');
+
+    const settings = JSON.parse(
+      await readFile(join(vaultDir, '.claude', 'settings.json'), 'utf8'),
+    ) as Record<string, unknown>;
+    expect(settings['hooks']).toBeDefined();
+    expect((settings['hooks'] as Record<string, unknown>)['Stop']).toBeDefined();
+    expect((settings['permissions'] as { allow: string[] }).allow).toContain('Bash(onebrain *)');
+  });
+
+  test('vault with BOTH .claude/ and .gemini/ → .gemini/settings.json untouched', async () => {
+    const geminiSettings = join(vaultDir, '.gemini', 'settings.json');
+    const userSettings = { theme: 'my-theme', model: 'gemini-2.5-pro' };
+    await writeFile(geminiSettings, JSON.stringify(userSettings), 'utf8');
+
+    const result = await runRegisterHooks({ vaultDir });
+    expect(result.ok).toBe(true);
+
+    // Gemini config is owned by the user / installed via extension link — we
+    // must never mutate it, even when iterating it as one of the detected
+    // harnesses.
+    const after = JSON.parse(await readFile(geminiSettings, 'utf8')) as Record<string, unknown>;
+    expect(after).toEqual(userSettings);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Non-TTY status label — must show RAW status (Bug 2 fix, 2026-05-12)
+// ---------------------------------------------------------------------------
+//
+// Before the fix, the non-TTY branch collapsed `ok`, `added`, and `migrated`
+// all to the literal string `'ok'`, which hid migration events from CI users
+// and made the Stop line inconsistent with the qmd line (which already used
+// raw status). The fix: drop the relabel and print raw status.
+
+describe('runRegisterHooks non-TTY status output', () => {
+  let captured: string[];
+  let originalWrite: typeof process.stdout.write;
+
+  beforeEach(() => {
+    captured = [];
+    originalWrite = process.stdout.write.bind(process.stdout);
+    // biome-ignore lint/suspicious/noExplicitAny: monkey-patching stdout for capture
+    process.stdout.write = ((chunk: any) => {
+      captured.push(typeof chunk === 'string' ? chunk : String(chunk));
+      return true;
+      // biome-ignore lint/suspicious/noExplicitAny: same as above
+    }) as any;
+  });
+
+  afterEach(() => {
+    process.stdout.write = originalWrite;
+  });
+
+  test('migration scenario reports raw "Stop migrated" (not "Stop ok")', async () => {
+    const settingsPath = join(tempDir, '.claude', 'settings.json');
+    await writeFile(
+      settingsPath,
+      JSON.stringify({
+        hooks: {
+          Stop: [
+            {
+              matcher: '',
+              hooks: [{ type: 'command', command: 'onebrain checkpoint stop' }],
+            },
+          ],
+        },
+      }),
+      'utf8',
+    );
+
+    const result = await runRegisterHooks({ vaultDir: tempDir, isTTY: false });
+    expect(result.ok).toBe(true);
+    expect(result.hooks['Stop']).toBe('migrated');
+
+    const out = captured.join('');
+    expect(out).toContain('Stop migrated');
+    expect(out).not.toContain('Stop ok');
+  });
+
+  test('fresh install reports raw "Stop added"', async () => {
+    const result = await runRegisterHooks({ vaultDir: tempDir, isTTY: false });
+    expect(result.ok).toBe(true);
+
+    const out = captured.join('');
+    expect(out).toContain('Stop added');
+    expect(out).not.toContain('Stop ok');
+  });
+
+  test('idempotent re-run reports raw "Stop ok"', async () => {
+    await runRegisterHooks({ vaultDir: tempDir, isTTY: false });
+    captured.length = 0;
+
+    const result = await runRegisterHooks({ vaultDir: tempDir, isTTY: false });
+    expect(result.ok).toBe(true);
+    expect(result.hooks['Stop']).toBe('ok');
+
+    const out = captured.join('');
+    expect(out).toContain('Stop ok');
+  });
+});

--- a/src/commands/internal/register-hooks.ts
+++ b/src/commands/internal/register-hooks.ts
@@ -15,7 +15,7 @@ import { dirname, join } from 'node:path';
 import { spinner } from '@clack/prompts';
 import pc from 'picocolors';
 import { loadVaultConfig, mkdirIdempotent } from '../../lib/index.js';
-import { detectHarness } from './harness.js';
+import { detectHarnesses } from './harness.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -483,7 +483,7 @@ export async function runRegisterHooks(
   const vaultRoot = opts.vaultDir ?? process.cwd();
   const isTTY = opts.isTTY ?? process.stdout.isTTY ?? false;
 
-  const harness = await detectHarness(vaultRoot);
+  const harnesses = await detectHarnesses(vaultRoot);
   let qmdCollection: string | undefined;
   try {
     const vaultConfig = await loadVaultConfig(vaultRoot);
@@ -514,74 +514,81 @@ export async function runRegisterHooks(
   let permSpinner: ReturnType<typeof spinner> | null = null;
 
   try {
-    // ── Steps 1-3: Claude harness only — write .claude/settings.json ─────
-    if (harness === 'claude') {
-      hooksSpinner = isTTY ? spinner() : null;
-      hooksSpinner?.start('Registering hooks...');
+    // Iterate every detected harness. A vault with both `.claude/` and
+    // `.gemini/` present should have OneBrain configured for BOTH — the
+    // previous implementation early-returned on the first match and silently
+    // skipped the other. Each branch writes independent config files; the
+    // shared `result` is populated only by the claude branch (it owns the
+    // .claude/settings.json hook/permission state).
+    for (const harness of harnesses) {
+      // ── Steps 1-3: Claude harness — write .claude/settings.json ─────
+      if (harness === 'claude') {
+        hooksSpinner = isTTY ? spinner() : null;
+        hooksSpinner?.start('Registering hooks...');
 
-      const settings = await readSettings(settingsPath);
-      result.hooks = applyHooks(settings);
+        const settings = await readSettings(settingsPath);
+        result.hooks = applyHooks(settings);
 
-      // ── Step 1b: qmd PostToolUse hook (applied before stop so it appears in hook line) ──
-      let qmdStatus: HookStatus | undefined;
-      if (qmdCollection) {
-        qmdStatus = applyQmdHook(settings);
-      } else {
-        // qmd disabled (no qmd_collection in vault.yml): strip any legacy
-        // `qmd update …` PostToolUse entries so they don't keep firing against
-        // a collection the user no longer maintains. Issue #127.
-        const groups = settings.hooks?.['PostToolUse'] ?? [];
-        const stripped = migrateLegacyQmdEntries(groups, false);
-        if (stripped && groups.length === 0 && settings.hooks) {
-          // Removing the key (rather than setting it to undefined) keeps the
-          // serialized JSON clean — `JSON.stringify` would emit `"PostToolUse":null`
-          // for the assignment form, which surprises downstream consumers.
-          // biome-ignore lint/performance/noDelete: see comment above
-          delete settings.hooks['PostToolUse'];
+        // ── Step 1b: qmd PostToolUse hook (applied before stop so it appears in hook line) ──
+        let qmdStatus: HookStatus | undefined;
+        if (qmdCollection) {
+          qmdStatus = applyQmdHook(settings);
+        } else {
+          // qmd disabled (no qmd_collection in vault.yml): strip any legacy
+          // `qmd update …` PostToolUse entries so they don't keep firing against
+          // a collection the user no longer maintains. Issue #127.
+          const groups = settings.hooks?.['PostToolUse'] ?? [];
+          const stripped = migrateLegacyQmdEntries(groups, false);
+          if (stripped && groups.length === 0 && settings.hooks) {
+            // Removing the key (rather than setting it to undefined) keeps the
+            // serialized JSON clean — `JSON.stringify` would emit `"PostToolUse":null`
+            // for the assignment form, which surprises downstream consumers.
+            // biome-ignore lint/performance/noDelete: see comment above
+            delete settings.hooks['PostToolUse'];
+          }
         }
-      }
 
-      if (isTTY) {
-        const parts = HOOK_EVENTS.map((e) => {
-          const status = result.hooks[e];
-          const icon = pc.green(status === 'ok' ? '✓' : status === 'migrated' ? '↑' : '+');
-          return `${pc.dim(e)} ${icon}`;
-        });
-        if (qmdStatus) {
-          const qmdIcon = qmdStatus === 'ok' ? '✓' : qmdStatus === 'migrated' ? '↑' : '+';
-          parts.push(`${pc.dim('PostToolUse')} ${pc.green(qmdIcon)}`);
+        if (isTTY) {
+          const parts = HOOK_EVENTS.map((e) => {
+            const status = result.hooks[e];
+            const icon = pc.green(status === 'ok' ? '✓' : status === 'migrated' ? '↑' : '+');
+            return `${pc.dim(e)} ${icon}`;
+          });
+          if (qmdStatus) {
+            const qmdIcon = qmdStatus === 'ok' ? '✓' : qmdStatus === 'migrated' ? '↑' : '+';
+            parts.push(`${pc.dim('PostToolUse')} ${pc.green(qmdIcon)}`);
+          }
+          hooksSpinner?.stop(`Hooks  ${parts.join('  ')}`);
+        } else {
+          const hookLine = HOOK_EVENTS.map((e) => {
+            const status = result.hooks[e] ?? 'ok';
+            return `${e} ${status}`;
+          }).join('  ');
+          note(hookLine);
+          if (qmdStatus) note(`PostToolUse ${qmdStatus}`);
         }
-        hooksSpinner?.stop(`Hooks  ${parts.join('  ')}`);
-      } else {
-        const hookLine = HOOK_EVENTS.map((e) => {
-          const status = result.hooks[e];
-          const label =
-            status === 'ok' || status === 'added' || status === 'migrated'
-              ? 'ok'
-              : (status ?? 'ok');
-          return `${e} ${label}`;
-        }).join('  ');
-        note(hookLine);
-        if (qmdStatus) note(`PostToolUse ${qmdStatus}`);
+
+        // ── Step 2: Permissions ───────────────────────────────────────────────
+        permSpinner = isTTY ? spinner() : null;
+        permSpinner?.start('Updating permissions...');
+
+        result.permissionsAdded = applyPermissions(settings);
+        await writeSettings(settingsPath, settings);
+
+        permSpinner?.stop('Permissions ok');
+        if (!isTTY) note('permissions ok');
+      } // end claude harness block
+
+      // ── Step 4: Gemini harness — no-op (handled by extension link, see header) ──
+      // (Intentionally empty — Gemini reads hooks/commands/skills from the
+      // self-contained extension at .claude/plugins/onebrain/gemini/, which
+      // the user links via `gemini extensions link`.)
+
+      // ── Step 5: Direct harness ────────────────────────────────────────────
+      if (harness === 'direct') {
+        await registerDirectPath();
       }
-
-      // ── Step 2: Permissions ───────────────────────────────────────────────
-      permSpinner = isTTY ? spinner() : null;
-      permSpinner?.start('Updating permissions...');
-
-      result.permissionsAdded = applyPermissions(settings);
-      await writeSettings(settingsPath, settings);
-
-      permSpinner?.stop('Permissions ok');
-      if (!isTTY) note('permissions ok');
-    } // end claude harness block
-
-    // ── Step 4: Gemini harness — no-op (handled by extension link, see header) ──
-
-    // ── Step 5: Direct harness ────────────────────────────────────────────
-    if (harness === 'direct') {
-      await registerDirectPath();
-    }
+    } // end harness iteration
 
     result.ok = true;
 


### PR DESCRIPTION
## Summary
Two bugs found while verifying PR #169 (exec-form hooks) on a multi-harness vault.

## Bug 1 — Multi-harness vault breaks register-hooks migration
`detectHarness()` returned a single harness via priority order, exiting on first match. Vaults with BOTH \`.gemini/\` AND \`.claude/\` directories (e.g., users running OneBrain on Claude Code + Gemini concurrently) fell into the 'gemini' branch → 'claude' code block skipped → \`.claude/settings.json\` never updated by \`onebrain register-hooks\`.

**Fix:** \`detectHarnesses()\` returns \`Harness[]\` (all detected). \`runRegisterHooks\` iterates all detected harnesses. Legacy \`detectHarness\` (singular) preserved as a thin backward-compat wrapper.

## Bug 2 — Status label cosmetic
Non-TTY mode collapsed Stop hook's 'migrated'/'added'/'ok' statuses all to 'ok' in the hookLine output. CI/scripted users couldn't see when a migration happened.

**Fix:** Use raw status (\`Stop migrated\`) in non-TTY mode. Matches the qmd PostToolUse line.

## Workaround for affected vaults (pre-2.2.5)
\`ONEBRAIN_HARNESS=claude onebrain register-hooks\`

## Test plan
- [x] \`detectHarnesses\` tests: both dirs → \`['claude', 'gemini']\` · single dir each · neither · ONEBRAIN_HARNESS variants
- [x] Legacy \`detectHarness\` (singular) backward-compat preserved
- [x] Multi-harness register-hooks test: vault with both dirs → \`.claude/settings.json\` gets exec-form hooks, \`.gemini/\` untouched
- [x] Non-TTY status: \`Stop migrated\` shown when migration happened, \`Stop added\` for fresh, \`Stop ok\` for no-op
- [x] 354 tests pass (was 320; +34 across harness + register-hooks suites)
- [x] 3-round parallel review: all APPROVED, zero non-English audit clean, conventions respected

CLI v2.2.4 → 2.2.5

## How found
While verifying PR #169 exec-form migration on the primary vault (which has both .gemini/ + .claude/ configured), discovered \`onebrain register-hooks\` ran without error but left vault settings.json untouched. Mtime + md5 bracket confirmed no write. Traced to harness detection priority. See follow-up tracker entries in [[OneBrain CLI]] Action Items.