### PR TITLE
fix(plugin): remove vault-author-specific references from skills

### DIFF
--- a/.claude/plugins/onebrain/.claude-plugin/plugin.json
+++ b/.claude/plugins/onebrain/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "onebrain",
-  "version": "2.4.5",
+  "version": "2.4.6",
   "description": "OneBrain — Where human and AI thinking become one. A powerful thinking partner powered by AI synergy.",
   "author": {
     "name": "OneBrain Contributors"

--- a/.claude/plugins/onebrain/skills/capture/SKILL.md
+++ b/.claude/plugins/onebrain/skills/capture/SKILL.md
@@ -117,9 +117,9 @@ Say in one line:
 
 | Input | Type | Destination |
 |-------|------|-------------|
-| "checkpoint write-before-delete ordering is critical" | personal insight | `03-knowledge/onebrain/Checkpoint Write Ordering.md` |
-| "found this Obsidian PKM article" | external reference | `04-resources/productivity/Obsidian PKM Methods.md` |
-| "just started the Mac Mini research project" | project update | append to `01-projects/hardware/Mac Mini.md` |
+| "write-before-delete ordering is critical" | personal insight | `[knowledge_folder]/dev/Write-Before-Delete Ordering.md` |
+| "found this Obsidian PKM article" | external reference | `[resources_folder]/productivity/Obsidian PKM Methods.md` |
+| "just started a new research project" | project update | append to `[projects_folder]/example/Project Name.md` |
 
 ## Known Gotchas
 

--- a/.claude/plugins/onebrain/skills/clone/SKILL.md
+++ b/.claude/plugins/onebrain/skills/clone/SKILL.md
@@ -146,8 +146,8 @@ Per-skill body template (canonical `## Run HH:MM` heading; metadata in first bul
 ```markdown
 ## Run HH:MM
 - Method: folder-copy
-- Source vault: /Users/keng/.../ob-1
-- Destination: /tmp/clone-target/
+- Source vault: /path/to/source/vault
+- Destination: /path/to/destination/
 - Files copied: N
 - Memory bundle: included (12 files)
 ```

--- a/.claude/plugins/onebrain/skills/consolidate/SKILL.md
+++ b/.claude/plugins/onebrain/skills/consolidate/SKILL.md
@@ -171,8 +171,8 @@ Per-skill body template (canonical `## Run HH:MM` heading; metadata in first bul
 - Inbox files processed: N
 
 ### Moved
-- `00-inbox/2026-05-10-ai-thoughts.md` → `03-knowledge/ai/AI Architecture Thoughts.md` (new)
-- `00-inbox/2026-05-09-meeting-notes.md` → appended to `01-projects/finastra/Finastra.md`
+- `[inbox_folder]/2026-05-10-ai-thoughts.md` → `[knowledge_folder]/ai/AI Architecture Thoughts.md` (new)
+- `[inbox_folder]/2026-05-09-meeting-notes.md` → appended to `[projects_folder]/example/Project Name.md`
 
 ### Wikilinks added
 - `03-knowledge/ai/AI Architecture Thoughts.md` ↔ `[[Agent Frameworks]]`, `[[OneBrain CLI]]`

--- a/.claude/plugins/onebrain/skills/search/SKILL.md
+++ b/.claude/plugins/onebrain/skills/search/SKILL.md
@@ -23,10 +23,9 @@ Distinct from existing skills:
 1. `[agent_folder]/MEMORY.md` — always-loaded persona/active-projects
 2. `[agent_folder]/memory/*.md` — match via MEMORY-INDEX topics
 3. `[logs_folder]/session/**/*-session-*.md` — past session logs
-4. `[projects_folder]/onebrain/plans/*.md` — implementation plans
-5. Project tracker decisions log tables (e.g. `OneBrain CLI.md`, `OneBrain Cloud.md`)
-6. Vault notes (`03-knowledge/`, `01-projects/`, `04-resources/`, `02-areas/`)
-7. `[logs_folder]/checkpoint/*.md` — in-session-state recovery (for current-day questions)
+4. Project tracker decisions log tables (project MOCs under `[projects_folder]/`)
+5. Vault notes (`[knowledge_folder]/`, `[projects_folder]/`, `[resources_folder]/`, `[areas_folder]/`)
+6. `[logs_folder]/checkpoint/*.md` — in-session-state recovery (for current-day questions)
 
 ## Tools used
 

--- a/.claude/plugins/onebrain/skills/search/SKILL.md
+++ b/.claude/plugins/onebrain/skills/search/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: search
-description: General vault retrieval — answers both "what" and "why" questions across MEMORY.md, memory/, session logs, plan files, decisions logs, and vault notes. Uses qmd (lex+vec+hyde) with grep fallback.
+description: General vault retrieval — answers both "what" and "why" questions across MEMORY.md, memory/, session logs, project trackers, and vault notes. Uses qmd (lex+vec+hyde) with grep fallback.
 auto-invoke:
   - "search vault"
   - "find in vault"
@@ -23,9 +23,10 @@ Distinct from existing skills:
 1. `[agent_folder]/MEMORY.md` — always-loaded persona/active-projects
 2. `[agent_folder]/memory/*.md` — match via MEMORY-INDEX topics
 3. `[logs_folder]/session/**/*-session-*.md` — past session logs
-4. Project tracker decisions log tables (project MOCs under `[projects_folder]/`)
-5. Vault notes (`[knowledge_folder]/`, `[projects_folder]/`, `[resources_folder]/`, `[areas_folder]/`)
-6. `[logs_folder]/checkpoint/*.md` — in-session-state recovery (for current-day questions)
+4. `[projects_folder]/**/*.md` — project notes including embedded specs/plans/design docs
+5. Project tracker decisions log tables (project MOCs under `[projects_folder]/`)
+6. Vault notes (`[knowledge_folder]/`, `[resources_folder]/`, `[areas_folder]/`)
+7. `[logs_folder]/checkpoint/*.md` — in-session-state recovery (for current-day questions)
 
 ## Tools used
 
@@ -77,7 +78,7 @@ This skill is long-running for large vaults. Emit:
 
 ```
 → [step 1/4] detecting question type · routing to qmd...
-→ [step 2/4] running qmd lex+vec+hyde across 7 sources...
+→ [step 2/4] running qmd lex+vec+hyde across all sources...
 → [step 3/4] scoring + ranking results...
 → [step 4/4] formatting answer...
 ```

--- a/PLUGIN-CHANGELOG.md
+++ b/PLUGIN-CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-latest_version: 2.4.5
+latest_version: 2.4.6
 released: 2026-05-12
 ---
 
@@ -10,6 +10,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 > **Versioning:** Plugin version is tracked in `plugin.json`. Bump when ANY harness config changes — skills, agents, hooks, INSTRUCTIONS, Gemini settings, slash commands, etc.
 > For CLI binary (`@onebrain-ai/cli`) changes, see [CHANGELOG.md](CHANGELOG.md).
+
+## 2.4.6 — 2026-05-12
+
+- Remove vault-author-specific references from plugin source for genericity
+- /search SKILL.md: drop hardcoded `[projects_folder]/onebrain/plans/*.md` source — replaced with generic project tracker reference (OneBrain users don't have a fixed `plans/` directory)
+- /search SKILL.md: replace hardcoded vault folder names (`03-knowledge/`, `01-projects/`, `04-resources/`, `02-areas/`) with `[knowledge_folder]/`, `[projects_folder]/`, `[resources_folder]/`, `[areas_folder]/` placeholders
+- /clone SKILL.md: replace personal example path `/Users/keng/.../ob-1` with generic `/path/to/source/vault` in audit-log template
 
 ## 2.4.5 — 2026-05-12
 

--- a/PLUGIN-CHANGELOG.md
+++ b/PLUGIN-CHANGELOG.md
@@ -14,9 +14,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## 2.4.6 — 2026-05-12
 
 - Remove vault-author-specific references from plugin source for genericity
-- /search SKILL.md: drop hardcoded `[projects_folder]/onebrain/plans/*.md` source — replaced with generic project tracker reference (OneBrain users don't have a fixed `plans/` directory)
-- /search SKILL.md: replace hardcoded vault folder names (`03-knowledge/`, `01-projects/`, `04-resources/`, `02-areas/`) with `[knowledge_folder]/`, `[projects_folder]/`, `[resources_folder]/`, `[areas_folder]/` placeholders
-- /clone SKILL.md: replace personal example path `/Users/keng/.../ob-1` with generic `/path/to/source/vault` in audit-log template
+- /search: drop hardcoded `[projects_folder]/onebrain/plans/*.md` source; replace with generic `[projects_folder]/**/*.md` covering embedded specs/plans/design docs (keeps search coverage for projects with any folder layout)
+- /search: replace hardcoded vault folder names with `[knowledge_folder]`/`[projects_folder]`/`[resources_folder]`/`[areas_folder]` placeholders; update progress line + frontmatter description to match
+- /clone: replace personal example path with generic `/path/to/source/vault` in audit-log template
+- /capture, /consolidate: replace concrete vault-author note paths in routing/moved examples with `[folder]/example/...` placeholders
 
 ## 2.4.5 — 2026-05-12
 


### PR DESCRIPTION
## Summary

Plugin source had a handful of references that were specific to one vault author's setup. Plugin source is open OneBrain — references must be generic for all users.

**Specific removals:**
- `/search` SKILL.md: hardcoded `[projects_folder]/onebrain/plans/*.md` source (vault-specific folder) → generic `[projects_folder]/**/*.md` covering any embedded specs/plans/design docs; folder names `03-knowledge`/`01-projects`/`04-resources`/`02-areas` → `[knowledge_folder]`/`[projects_folder]`/... placeholders; progress line + frontmatter description updated to match
- `/clone` SKILL.md: example path `/Users/keng/.../ob-1` → generic `/path/to/source/vault`
- `/capture` SKILL.md: 3 vault-author-specific routing-table example paths → `[folder]/example/...` placeholders
- `/consolidate` SKILL.md: 2 vault-author-specific Moved example paths → placeholders

**Plugin version:** 2.4.5 → 2.4.6. PLUGIN-CHANGELOG entry added (5 bullets).

**Scope kept tight:** retained `kengio/onebrain` literal in `validator.ts` / `doctor.ts` / `migration-steps.md` — those are intentional historical migration logic (rewriting stale marketplace config), not author leak.

## Review status

3 parallel reviews + 1 re-review after fix-up commit:
- Round 1 (correctness): 3 🟡 in `/search` — addressed in 2nd commit
- Round 2 (dev-workflow): ✅ PASS clean
- Round 3 (completeness): 2 🟡 in `/capture` + `/consolidate` — addressed in 2nd commit
- Re-review: ✅ APPROVE for push

## Test plan

- [ ] `npm run check` (lint + typecheck) passes locally — N/A for doc-only PR
- [ ] Visual diff of `/search`, `/clone`, `/capture`, `/consolidate` SKILL.md renders correctly in Obsidian
- [ ] After merge: `/update` syncs to vault; verify `/search` skill still works end-to-end