### PR TITLE
feat(scheduler): OneBrain scheduler — register-schedule CLI + 4 wizard skills + one-shot + /doctor integration (E9)

### DIFF
--- a/.claude/plugins/onebrain/.claude-plugin/plugin.json
+++ b/.claude/plugins/onebrain/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "onebrain",
-  "version": "2.4.6",
+  "version": "2.4.7",
   "description": "OneBrain — Where human and AI thinking become one. A powerful thinking partner powered by AI synergy.",
   "author": {
     "name": "OneBrain Contributors"

--- a/.claude/plugins/onebrain/INSTRUCTIONS.md
+++ b/.claude/plugins/onebrain/INSTRUCTIONS.md
@@ -157,6 +157,9 @@ These workflows are documented in `.claude/plugins/onebrain/skills/`:
 | `/update` | `update/SKILL.md` | Update system files from GitHub | (manual only) |
 | `/doctor` | `doctor/SKILL.md` | Vault + config health check: broken links, orphan notes, stale memory/ files, plugin config | user asks to check vault health, diagnose issues, or run /doctor |
 | `/help` | `help/SKILL.md` | List available commands with use cases | user asks what commands or skills are available, or what the agent can do |
+| `/schedule-add` | `schedule-add/SKILL.md` | Interactive wizard for adding a scheduled skill | user asks to schedule a skill / set up cron / add automation |
+| `/schedule-list` | `schedule-list/SKILL.md` | Show all scheduled entries | user asks what's scheduled / list automations |
+| `/schedule-remove` | `schedule-remove/SKILL.md` | Remove a scheduled entry | user asks to unschedule / remove automation |
 
 ## Available Agents
 

--- a/.claude/plugins/onebrain/INSTRUCTIONS.md
+++ b/.claude/plugins/onebrain/INSTRUCTIONS.md
@@ -368,6 +368,38 @@ These principles are the foundation of how OneBrain assists across every session
 - Prefer adding to existing notes over creating new ones when a suitable note already exists
 - Keep `[agent_folder]/MEMORY.md` under ~180 lines (/doctor audits at 180)
 
+## Scheduling — which tool to use
+
+OneBrain provides scheduling via OS-level cron (launchd on macOS). It is configured in `vault.yml` `schedule:` block, not invoked via slash. This is distinct from Claude Code's built-in `/loop` and `/schedule` commands.
+
+| Tool | Use case | Runtime |
+|------|---------|---------|
+| Claude Code `/loop` | Active polling within current session | In-session, ephemeral |
+| Claude Code `/schedule` | Remote agent runs without your machine on | Anthropic-hosted (cloud) |
+| **OneBrain scheduler** | Auto-run OneBrain skill on local machine, writing to vault | Local OS scheduler (launchd) |
+
+Use the OneBrain scheduler for: `/daily` morning brief, `/weekly` Friday review, `/recap` Sunday digest, `/doctor` weekly health check — anything that should fire on a recurring local schedule and write its output back to the vault.
+
+For interactive setup:
+- `/schedule-add` — recurring schedule wizard
+- `/schedule-once` — one-shot wizard (fire once at a specific datetime, then auto-uninstall)
+- `/schedule-list` — show all scheduled entries
+- `/schedule-remove` — remove an entry
+
+For manual config: edit `vault.yml` `schedule:` block + run `onebrain register-schedule`.
+
+## Headless invocation
+
+Scheduled skills run via headless Claude Code: `claude --vault {VAULT} --skill /daily --headless`. The session loads MEMORY.md, vault.yml, MEMORY-INDEX.md as normal (SessionStart hook fires). PreToolUse, PostToolUse, Stop hooks fire as normal. PreCompact / PostCompact do not fire (sessions are too short).
+
+Headless sessions have no prior conversation history — each invocation is fresh. Memory access is via filesystem only.
+
+Permissions: scheduler runs with pre-allowed tools in `.claude/settings.json` `permissions.allow`. Avoid `--dangerously-skip-permissions` except for verified-safe contexts.
+
+Error recovery: skill failure writes to `[logs_folder]/scheduler/YYYY/MM/YYYY-MM-DD-{skill}.err.md`. 3 consecutive failures → schedule auto-paused; `/doctor` surfaces it as CRITICAL; user runs `onebrain register-schedule --resume <skill>` to re-enable.
+
+One-shot entries (those with `at:` instead of `cron:`) fire once, then the launchd plist self-deletes via an embedded shell wrapper. If the plist remains on disk after its timestamp passed, `/doctor` flags it as an expired one-shot to clean up.
+
 ## Permissions
 
 Proceed autonomously — no confirmation needed for:

--- a/.claude/plugins/onebrain/INSTRUCTIONS.md
+++ b/.claude/plugins/onebrain/INSTRUCTIONS.md
@@ -396,7 +396,7 @@ Headless sessions have no prior conversation history — each invocation is fres
 
 Permissions: scheduler runs with pre-allowed tools in `.claude/settings.json` `permissions.allow`. Avoid `--dangerously-skip-permissions` except for verified-safe contexts.
 
-Error recovery: skill failure writes to `[logs_folder]/scheduler/YYYY/MM/YYYY-MM-DD-{skill}.err.md`. 3 consecutive failures → schedule auto-paused; `/doctor` surfaces it as CRITICAL; user runs `onebrain register-schedule --resume <skill>` to re-enable.
+Error recovery: skill failure writes to `[logs_folder]/scheduler/YYYY/MM/YYYY-MM-DD-{skill}.err.md`. 3 consecutive failures → `/doctor` flags it as CRITICAL. Manual recovery (planned): create a `.paused` marker file; resume via `onebrain register-schedule --resume <skill>`. (Note: auto-pause-on-failure is not yet implemented; the CLI only honors the marker if a future hook or manual action creates it.)
 
 One-shot entries (those with `at:` instead of `cron:`) fire once, then the launchd plist self-deletes via an embedded shell wrapper. If the plist remains on disk after its timestamp passed, `/doctor` flags it as an expired one-shot to clean up.
 

--- a/.claude/plugins/onebrain/INSTRUCTIONS.md
+++ b/.claude/plugins/onebrain/INSTRUCTIONS.md
@@ -158,6 +158,7 @@ These workflows are documented in `.claude/plugins/onebrain/skills/`:
 | `/doctor` | `doctor/SKILL.md` | Vault + config health check: broken links, orphan notes, stale memory/ files, plugin config | user asks to check vault health, diagnose issues, or run /doctor |
 | `/help` | `help/SKILL.md` | List available commands with use cases | user asks what commands or skills are available, or what the agent can do |
 | `/schedule-add` | `schedule-add/SKILL.md` | Interactive wizard for adding a scheduled skill | user asks to schedule a skill / set up cron / add automation |
+| `/schedule-once` | `schedule-once/SKILL.md` | One-shot wizard: schedule a skill to run once at a specific datetime, then auto-uninstall | user asks to schedule a one-time task / fire-once / remind me at <time> |
 | `/schedule-list` | `schedule-list/SKILL.md` | Show all scheduled entries | user asks what's scheduled / list automations |
 | `/schedule-remove` | `schedule-remove/SKILL.md` | Remove a scheduled entry | user asks to unschedule / remove automation |
 

--- a/.claude/plugins/onebrain/skills/bookmark/SKILL.md
+++ b/.claude/plugins/onebrain/skills/bookmark/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: bookmark
 description: "Quick URL bookmark capture : paste a link, AI generates name and description, suggests category, saves to Bookmarks.md in awesome-list format. Invoke when user wants to save a URL for later — bare URL with no other context defaults to this. Do NOT use for: deeply processing or summarizing the URL content now (use summarize), saving a note that is not a URL (use capture), or researching a topic from scratch (use research)."
+schedulable: false
 ---
 
 # Bookmark

--- a/.claude/plugins/onebrain/skills/braindump/SKILL.md
+++ b/.claude/plugins/onebrain/skills/braindump/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: braindump
 description: "Capture a stream of raw thoughts : classify them and file to inbox with action items extracted. Use when the user signals a free-form, stream-of-consciousness dump with multiple unrelated threads — 'let me dump everything on my mind'. Do NOT use for: a single titled idea (use capture), saving a URL (use bookmark), or anything structured and focused."
+schedulable: false
 ---
 
 # Braindump

--- a/.claude/plugins/onebrain/skills/capture/SKILL.md
+++ b/.claude/plugins/onebrain/skills/capture/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: capture
 description: "Quick note capture with automatic wikilink suggestions to related existing notes. Use when the user wants to save a single, specific, titled idea, insight, or piece of information to the vault. Do NOT use for: unstructured multi-thread thought dumps (use braindump), saving a URL for later (use bookmark), deeply summarizing an article or URL (use summarize), processing a book (use reading-notes), or teaching the agent a preference (use learn)."
+schedulable: false
 ---
 
 # Capture

--- a/.claude/plugins/onebrain/skills/clone/SKILL.md
+++ b/.claude/plugins/onebrain/skills/clone/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: clone
 description: "Clone your agent's portable context (agent folder including MEMORY.md) to a folder for transfer to another vault. Use only when the user explicitly wants to migrate or copy agent memory to a new vault. Do NOT use for: backing up the whole vault, updating OneBrain (use update), or reviewing memory (use memory-review)."
+schedulable: false
 ---
 
 # Clone

--- a/.claude/plugins/onebrain/skills/connect/SKILL.md
+++ b/.claude/plugins/onebrain/skills/connect/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: connect
 description: "Find connections between notes and suggest wikilinks to strengthen the knowledge graph. Use when the user wants to discover how existing notes relate to each other — 'find connections', 'what links to this note', 'strengthen my graph'. Do NOT use for: creating new notes (use capture), processing inbox (use consolidate), or searching for specific content (search directly)."
+schedulable: false
 ---
 
 # Connect

--- a/.claude/plugins/onebrain/skills/consolidate/SKILL.md
+++ b/.claude/plugins/onebrain/skills/consolidate/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: consolidate
 description: "Review inbox and recent notes, synthesize and merge into the knowledge base. Use when the user wants to process, organize, or clear the inbox regardless of topic — 'clean up my inbox', 'process my notes'. Do NOT use for: capturing new information now (use capture or braindump), synthesizing already-vaulted notes on a specific topic (use distill — consolidate works on the inbox), or finding note connections (use connect)."
+schedulable: false
 ---
 
 # Consolidate

--- a/.claude/plugins/onebrain/skills/daily/SKILL.md
+++ b/.claude/plugins/onebrain/skills/daily/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: daily
 description: "Daily briefing: surfaces tasks due today and open items from the last session. Use when the user wants a snapshot of today's obligations — 'what's on today', 'daily briefing', 'what do I have today'. Do NOT use for: full weekly review (use weekly), vault health check (use doctor), or listing all tasks across future dates."
+schedulable: true
 ---
 
 # Daily Briefing

--- a/.claude/plugins/onebrain/skills/distill/SKILL.md
+++ b/.claude/plugins/onebrain/skills/distill/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: distill
 description: "Aggregate already-vaulted notes from multiple sessions or sources on a specific topic into a single structured digest note. Use when the user wants to synthesize a completed research thread — 'distill everything I know about X', 'crystallize my notes on Y'. Do NOT use for: promoting session insights to memory (use recap), writing today's session summary (use wrapup), or clearing raw inbox items (use consolidate — distill works on notes already in the vault)."
+schedulable_with_args: true
+required_args: [topic]
 ---
 
 # Distill

--- a/.claude/plugins/onebrain/skills/doctor/SKILL.md
+++ b/.claude/plugins/onebrain/skills/doctor/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: doctor
 description: "Diagnose vault and plugin health — checks broken links, orphan notes, stale memory/ files, inbox backlog, and plugin config validity. Use when the user asks to check vault health, notices something broken, or wants a system audit — 'run /doctor', 'check my vault', 'something seems off'. Do NOT use for: searching vault content (search directly), processing inbox (use consolidate), or updating the system (use update)."
+schedulable: true
 ---
 
 # Doctor

--- a/.claude/plugins/onebrain/skills/doctor/SKILL.md
+++ b/.claude/plugins/onebrain/skills/doctor/SKILL.md
@@ -121,6 +121,15 @@ Run all applicable checks based on flags (default: all). Collect findings before
   - Check `which qmd` (macOS/Linux) or `where qmd` (Windows): qmd binary must be installed → ✅ / 🔴 "qmd not installed — qmd_collection is set but binary is missing; run `/qmd setup` to reinstall"
   - Read `[vault]/.claude/settings.json` (same file used for the Stop hook); check that `hooks.PostToolUse` contains an entry whose `command` contains `qmd-reindex` → ✅ / 🔴 "PostToolUse qmd hook missing in settings.json — run /update to register"
 
+### Scheduler Health (added 2026-05-12)
+
+Only run when vault.yml contains a `schedule:` block. Skip entirely otherwise.
+
+- **Scheduler errors** — Glob `[logs_folder]/scheduler/**/*.err.md` from the last 7 days. If any exist, report count + most recent 3 files as wikilinks under 🟡 (warning).
+- **Consecutive failures** — For each schedulable skill in `vault.yml` `schedule:`, count consecutive `.err.md` files from newest to oldest with no intervening success `.md`. If 3 or more → 🔴 CRITICAL — suggest `onebrain register-schedule --resume <skill>`.
+- **Schedule drift** — Read `vault.yml` `schedule:` block. For each entry, check that the corresponding launchd plist exists at `~/Library/LaunchAgents/com.onebrain.<labelSafe>.plist` where `labelSafe` strips leading `/` from `entry.skill` and replaces non-`[a-zA-Z0-9-]` chars with `-`. If any entry's plist is missing → 🟡 drift — suggest `onebrain register-schedule`. If any installed plist no longer matches a vault.yml entry (stale orphan) → 🟡 stale plist — suggest `onebrain register-schedule --remove` then re-register.
+- **One-shot reachability** — For each entry with `at:` (one-shot), verify the timestamp has not already passed. If passed and the plist still exists → 🟡 expired one-shot not cleaned up — suggest `onebrain register-schedule --remove` to clear the stale plist (the self-delete shell may have failed to run).
+
 ---
 
 ## Step 3: Report Findings

--- a/.claude/plugins/onebrain/skills/help/SKILL.md
+++ b/.claude/plugins/onebrain/skills/help/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: help
 description: "List all available OneBrain commands with descriptions and use cases. Invoke when user asks what you can do, wants to see commands, or seems confused about capabilities. Do NOT use for: actually running a command (identify the right skill and invoke it directly), answering questions about vault content (search directly), or general Claude questions."
+schedulable: false
 ---
 
 # Available Commands

--- a/.claude/plugins/onebrain/skills/help/SKILL.md
+++ b/.claude/plugins/onebrain/skills/help/SKILL.md
@@ -53,3 +53,6 @@ Skills are organized by workflow phase — Input → Process → Recall → Main
 | `/qmd` | qmd search index management |
 | `/help` | This catalog |
 | `/wrapup` | Session log |
+| `/schedule-add` | Interactive wizard for adding a scheduled skill |
+| `/schedule-list` | Show all scheduled entries |
+| `/schedule-remove` | Remove a scheduled entry |

--- a/.claude/plugins/onebrain/skills/help/SKILL.md
+++ b/.claude/plugins/onebrain/skills/help/SKILL.md
@@ -54,5 +54,6 @@ Skills are organized by workflow phase — Input → Process → Recall → Main
 | `/help` | This catalog |
 | `/wrapup` | Session log |
 | `/schedule-add` | Interactive wizard for adding a scheduled skill |
+| `/schedule-once` | One-shot wizard: schedule a skill to run once at a specific datetime |
 | `/schedule-list` | Show all scheduled entries |
 | `/schedule-remove` | Remove a scheduled entry |

--- a/.claude/plugins/onebrain/skills/import/SKILL.md
+++ b/.claude/plugins/onebrain/skills/import/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: import
 description: "Import local files (PDF, Word, PowerPoint, Excel, images, video, scripts) from a staging inbox folder or explicit path into structured markdown notes in the resources folder. Invoke when user mentions a local file path to bring into the vault, or runs /import or /import --attach. Do NOT use for: fetching content from a URL (use summarize), capturing a text idea (use capture), or processing a book already read (use reading-notes)."
+schedulable: false
 ---
 
 # Import

--- a/.claude/plugins/onebrain/skills/learn/SKILL.md
+++ b/.claude/plugins/onebrain/skills/learn/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: learn
 description: "Teach the agent a new fact or behavioral preference and save it to memory/ for future recall. Use when the user says 'remember that', 'from now on', 'always do X', or corrects agent behavior they want persisted. Do NOT use for: capturing a general note or idea (use capture), saving a session summary (use wrapup), or promoting recurring patterns from many sessions (use recap)."
+schedulable: false
 ---
 
 # Learn

--- a/.claude/plugins/onebrain/skills/memory-review/SKILL.md
+++ b/.claude/plugins/onebrain/skills/memory-review/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: memory-review
 description: "Interactive review of all memory/ files — keep, update, deprecate, or delete entries one by one. Use when the user wants to audit and prune accumulated memory — 'review my memory', 'clean up what you remember'. Do NOT use for: teaching a new fact (use learn), recalling something specific (read memory directly), or batch-promoting session insights (use recap)."
+schedulable: false
 ---
 
 # Memory Review

--- a/.claude/plugins/onebrain/skills/moc/SKILL.md
+++ b/.claude/plugins/onebrain/skills/moc/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: moc
 description: "Create or update the vault portal (MOC.md) at the vault root : a Map of Content with live Dataview queries, AI summary, and user Pinned section. Use when the user wants to regenerate or view the vault overview map. Do NOT use for: the task dashboard (use tasks), adding individual notes (use capture), or vault health checks (use doctor)."
+schedulable: true
 ---
 
 # Vault Portal

--- a/.claude/plugins/onebrain/skills/onboarding/SKILL.md
+++ b/.claude/plugins/onebrain/skills/onboarding/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: onboarding
 description: "First-run setup for OneBrain : personalize identity, communication style, and vault configuration. Use only on first install or when the user wants to fully reconfigure OneBrain from scratch — manual only. Do NOT use for: teaching a single preference (use learn), updating system files (use update), or reviewing memory (use memory-review)."
+schedulable: false
 ---
 
 ## Install Path Detection

--- a/.claude/plugins/onebrain/skills/qmd/SKILL.md
+++ b/.claude/plugins/onebrain/skills/qmd/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: qmd
 description: "Set up and manage qmd search index for faster vault search. Subcommands: setup, embed, status, reindex, uninstall. Use when the user wants to configure, update, or troubleshoot the qmd search index itself. Do NOT use for: performing a search (call qmd tools directly), general vault operations, or installing OneBrain (use onboarding or update)."
+schedulable: false
 ---
 
 # qmd Search Integration

--- a/.claude/plugins/onebrain/skills/reading-notes/SKILL.md
+++ b/.claude/plugins/onebrain/skills/reading-notes/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: reading-notes
 description: "Process a book or article into structured progressive summary notes saved to the resources folder. Use when the user has finished reading something and wants to capture structured notes — 'I just finished reading X', 'take notes on this book'. Do NOT use for: fetching and summarizing a URL now (use summarize), capturing a raw thought (use capture), or web research (use research)."
+schedulable: false
 ---
 
 # Reading Notes

--- a/.claude/plugins/onebrain/skills/recap/SKILL.md
+++ b/.claude/plugins/onebrain/skills/recap/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: recap
 description: "Batch-promote recurring insights from session logs into memory/ files with frequency filtering. Use when the user wants to extract persistent lessons or patterns from recent sessions — 'recap my recent sessions', 'what have I been learning lately'. Do NOT use for: saving a single fact now (use learn), writing today's session log (use wrapup), or synthesizing a specific topic into a note (use distill)."
+schedulable: true
 ---
 
 # Recap

--- a/.claude/plugins/onebrain/skills/reorganize/SKILL.md
+++ b/.claude/plugins/onebrain/skills/reorganize/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: reorganize
 description: "Migrate vault structure : either full 5-folder → 8-folder migration, or subfolder organization for flat notes. Use only when the user explicitly wants to restructure the entire vault layout — manual only, high impact. Do NOT use for: moving a single note (do it directly), processing inbox (use consolidate), or routine note organization."
+schedulable: false
 ---
 
 # Reorganize Vault

--- a/.claude/plugins/onebrain/skills/research/SKILL.md
+++ b/.claude/plugins/onebrain/skills/research/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: research
 description: "Research a topic on the web and save a structured note to the resources folder. Use when the user wants to investigate a topic from scratch with no specific URL — 'research X for me', 'what do I need to know about Y'. Do NOT use for: processing a specific URL the user already has (use summarize), processing a book already read (use reading-notes), or quick note capture without web research (use capture or braindump)."
+schedulable_with_args: true
+required_args: [topic]
 ---
 
 # Research

--- a/.claude/plugins/onebrain/skills/schedule-add/SKILL.md
+++ b/.claude/plugins/onebrain/skills/schedule-add/SKILL.md
@@ -1,0 +1,174 @@
+---
+name: schedule-add
+description: Interactive wizard to add a scheduled OneBrain skill. Walks user through skill selection, frequency, time, and writes to vault.yml + invokes onebrain register-schedule.
+schedulable: false
+---
+
+# /schedule-add — Interactive scheduler wizard
+
+## Purpose
+
+For users who don't want to hand-edit vault.yml or learn cron syntax. Walks through:
+1. Which skill to schedule
+2. How often (Daily/Weekly/Monthly/Custom)
+3. What time
+4. Confirms cron preview
+5. Writes to vault.yml + runs `onebrain register-schedule`
+
+---
+
+## Skill flow
+
+### Step 1: Pick skill
+
+List all schedulable skills by reading each SKILL.md frontmatter under `.claude/plugins/onebrain/skills/`. Filter for entries where `schedulable: true` OR `schedulable_with_args: true`.
+
+Show via `AskUserQuestion`:
+- question: "Which skill would you like to schedule?"
+- header: "Schedule a Skill"
+- multiSelect: false
+- options (two groups):
+  - Skills with `schedulable: true` (no args required): e.g. `/daily`, `/weekly`, `/recap`, `/doctor`, `/tasks`, `/moc`
+  - Skills with `schedulable_with_args: true` (args required — wizard will prompt): e.g. `/distill`, `/research`, `/summarize`, `/search`
+
+Store: `chosen_skill` (the slash-command name, e.g. `/daily`).
+
+### Step 2: Collect args (if needed)
+
+If `chosen_skill` has `schedulable_with_args: true`, prompt for required arguments.
+
+Ask via plain conversational text (one question per arg):
+> What argument should be passed to `{chosen_skill}` when it runs? For example, for `/distill` you might enter a topic name like "machine learning".
+
+Store: `skill_args`.
+
+### Step 3: Pick frequency
+
+Show via `AskUserQuestion`:
+- question: "How often should `{chosen_skill}` run?"
+- header: "Frequency"
+- multiSelect: false
+- options:
+  - label: "Daily", description: "Every day"
+  - label: "Weekly", description: "Pick a day of the week"
+  - label: "Monthly", description: "Pick a date of the month"
+  - label: "Custom", description: "Enter a cron expression directly"
+
+If Weekly: ask which day via `AskUserQuestion` (Mon/Tue/Wed/Thu/Fri/Sat/Sun).
+If Monthly: ask which date (1-31) via plain text.
+If Custom: ask for a raw cron string via plain text and validate format (5 fields: minute hour day month weekday).
+
+Store: `frequency`, `frequency_detail` (day of week, date, or raw cron).
+
+### Step 4: Pick time
+
+(Skip this step if Custom frequency — user already provided full cron.)
+
+Show via `AskUserQuestion`:
+- question: "What time should it run?"
+- header: "Time"
+- multiSelect: false
+- options:
+  - label: "Morning — 9:00", description: "9:00 AM"
+  - label: "Midday — 12:00", description: "12:00 PM"
+  - label: "Evening — 18:00", description: "6:00 PM"
+  - label: "Night — 22:00", description: "10:00 PM"
+  - label: "Custom", description: "Enter HH:MM"
+
+If Custom: ask for time in HH:MM format via plain text and validate (00-23 : 00-59).
+
+Store: `run_hour`, `run_minute`.
+
+### Step 5: Generate cron expression
+
+Construct the cron string from frequency + time:
+- Daily: `{minute} {hour} * * *`
+- Weekly (e.g. Friday): `{minute} {hour} * * 5` (Mon=1 ... Sun=0 or 7)
+- Monthly (e.g. 15th): `{minute} {hour} 15 * *`
+- Custom: use the raw cron string from Step 3.
+
+### Step 6: Conflict check
+
+Read vault.yml `schedule:` block (if it exists). Check for an entry with the same `skill` value.
+
+If a conflict is found, show via `AskUserQuestion`:
+- question: "`{chosen_skill}` is already scheduled at {existing_cron}. Overwrite it?"
+- header: "Conflict"
+- multiSelect: false
+- options:
+  - label: "Yes, overwrite", description: "Replace the existing schedule entry"
+  - label: "Cancel", description: "Keep the existing schedule as-is"
+
+If Cancel, stop.
+
+### Step 7: Preview + confirm
+
+Show a preview in plain text and ask via `AskUserQuestion`:
+
+```
+{chosen_skill} will run {frequency_description} at {HH:MM}.
+Cron: {cron_expression}
+Output → vault (07-logs/scheduler/YYYY/MM/YYYY-MM-DD-{skill-name}.md)
+Confirm?
+```
+
+- options:
+  - label: "Yes, schedule it"
+  - label: "Cancel"
+
+If Cancel, stop.
+
+### Step 8: Write to vault.yml
+
+Read vault.yml. Locate the `schedule:` block. If the block does not exist, create it.
+
+Build the new schedule entry:
+```yaml
+- skill: /daily
+  cron: "0 9 * * *"
+  args: ""          # omit if no args
+```
+
+If overwriting an existing entry (conflict detected in Step 6), replace that entry. Otherwise append.
+
+Write the full updated vault.yml back atomically:
+1. Write to a temporary file (`vault.yml.tmp`) in the vault root.
+2. Rename to `vault.yml` (atomic replace).
+
+If the write fails at any point, do not leave a partial file: delete `vault.yml.tmp` if it exists and report the error. Do not proceed to Step 9.
+
+### Step 9: Register schedule
+
+Run from the vault root:
+```
+onebrain register-schedule
+```
+
+If the command fails, report the error. vault.yml has already been updated — the user can retry `onebrain register-schedule` manually.
+
+### Step 10: Confirm
+
+Say:
+```
+✓ Scheduled {chosen_skill} at {HH:MM} {frequency_description}. Next run: {next_run_datetime}.
+```
+
+---
+
+## Edge cases
+
+- **vault.yml missing `schedule:` block** — wizard creates it in Step 8.
+- **Conflict (same skill, same time)** — handled in Step 6 with overwrite prompt.
+- **vault.yml YAML write failure** — rollback in Step 8; no partial state left on disk.
+- **`schedulable_with_args` skill, no args provided** — wizard prompts in Step 2 before proceeding.
+- **Invalid cron (Custom)** — validate 5 fields; if invalid, ask again.
+- **Invalid HH:MM (Custom time)** — validate range; if invalid, ask again.
+
+---
+
+## Implementation notes
+
+- Use `yaml` library (already in CLI deps) — preserve comments and key order during write.
+- Atomically replace vault.yml: write to tmp → rename (POSIX-atomic on same filesystem).
+- Day-of-week mapping: Mon=1, Tue=2, Wed=3, Thu=4, Fri=5, Sat=6, Sun=0.
+- `next_run_datetime` is a human-readable estimate (e.g. "tomorrow 9:00", "Friday 18:00") — compute from current datetime and cron.

--- a/.claude/plugins/onebrain/skills/schedule-list/SKILL.md
+++ b/.claude/plugins/onebrain/skills/schedule-list/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: schedule-list
+description: Show all scheduled OneBrain skills with their cron schedule and last/next run times.
+schedulable: false
+---
+
+# /schedule-list — Show scheduled skills
+
+## Purpose
+
+Display a formatted summary of all skills currently registered in the `schedule:` block of vault.yml, enriched with last-run and next-run information from launchd or the scheduler state file.
+
+---
+
+## Skill flow
+
+### Step 1: Read vault.yml
+
+Read vault.yml from the vault root. Locate the `schedule:` block.
+
+If vault.yml does not exist or has no `schedule:` block, or the block is empty:
+
+```
+No scheduled skills found.
+
+→ Run /schedule-add to set one up.
+```
+
+Stop.
+
+### Step 2: Fetch status
+
+Run from the vault root:
+```
+onebrain register-schedule --status
+```
+
+Parse the JSON output. Expected shape per entry:
+```json
+{
+  "skill": "/daily",
+  "cron": "0 9 * * *",
+  "last_run": "2026-05-11T09:00:00",
+  "last_status": "success",
+  "next_run": "2026-05-12T09:00:00",
+  "paused": false
+}
+```
+
+If `onebrain register-schedule --status` is unavailable or fails: fall back to reading launchd plist modification times from `~/Library/LaunchAgents/` for each scheduled entry. If neither source is available, show only the cron expressions from vault.yml and omit last/next run columns.
+
+### Step 3: Format output
+
+Print the schedule table:
+
+```
+📅 Scheduled skills:
+
+  ✓ 0 9 * * *      /daily         next: tomorrow 09:00   last: 2026-05-11 09:00 (success)
+  ✓ 0 18 * * 5     /weekly        next: Friday 18:00     last: 2026-05-08 18:00 (success)
+  ✓ 0 12 * * 0     /recap         next: Sunday 12:00     last: 2026-05-10 12:00 (success)
+```
+
+Column layout:
+- Status icon: `✓` for active, `⏸` for paused
+- Cron expression (left-padded to align)
+- Skill name
+- Next run (human-readable: "tomorrow HH:MM", "Friday HH:MM", "in 3 days HH:MM")
+- Last run datetime + status (`success` | `error` | `never`)
+
+### Step 4: Surface errors and paused entries
+
+If `last_status` is `error`:
+- Show `(error)` in the last-run column
+- Append a hint line below the table: `→ See 07-logs/scheduler/YYYY/MM/YYYY-MM-DD-{skill}.err.md for details`
+
+If `paused` is `true` (auto-paused after 3 consecutive failures):
+- Show `⏸ paused` status icon instead of `✓`
+- Append a hint line: `→ Fix the error, then run /schedule-add to re-register {skill}`
+
+### Step 5: Footer
+
+After the table, append:
+```
+→ /schedule-add   add a new scheduled skill
+→ /schedule-remove   remove an entry
+```
+
+---
+
+## Edge cases
+
+- **No entries at all** — handled in Step 1; early exit with helpful message.
+- **Status command unavailable** — graceful fallback to vault.yml data only (Step 2).
+- **Partial status** — some entries return status, others don't; show what's available and mark unknowns as `(unknown)`.
+- **Cron alignment** — pad cron columns to the longest expression in the list for readable alignment.

--- a/.claude/plugins/onebrain/skills/schedule-list/SKILL.md
+++ b/.claude/plugins/onebrain/skills/schedule-list/SKILL.md
@@ -30,24 +30,16 @@ Stop.
 
 ### Step 2: Fetch status
 
-Run from the vault root:
+Read the `schedule:` block from vault.yml directly to get the cron/at expression and skill name for each entry.
+
+Optionally run from the vault root:
 ```
 onebrain register-schedule --status
 ```
 
-Parse the JSON output. Expected shape per entry:
-```json
-{
-  "skill": "/daily",
-  "cron": "0 9 * * *",
-  "last_run": "2026-05-11T09:00:00",
-  "last_status": "success",
-  "next_run": "2026-05-12T09:00:00",
-  "paused": false
-}
-```
+This emits plain text (not JSON). Parse line-by-line to extract the installed-on-disk marker (`✓` = plist exists on disk, `✗` = plist missing) for each entry. The CLI does not track last-run, next-run, or last-status — that detail is in `[logs_folder]/scheduler/YYYY/MM/`.
 
-If `onebrain register-schedule --status` is unavailable or fails: fall back to reading launchd plist modification times from `~/Library/LaunchAgents/` for each scheduled entry. If neither source is available, show only the cron expressions from vault.yml and omit last/next run columns.
+If `onebrain register-schedule --status` is unavailable or fails: fall back to checking launchd plist existence in `~/Library/LaunchAgents/` for each entry. If neither source is available, show only the cron/at expressions from vault.yml and omit the installed-status column.
 
 ### Step 3: Format output
 
@@ -56,27 +48,28 @@ Print the schedule table:
 ```
 📅 Scheduled skills:
 
-  ✓ 0 9 * * *      /daily         next: tomorrow 09:00   last: 2026-05-11 09:00 (success)
-  ✓ 0 18 * * 5     /weekly        next: Friday 18:00     last: 2026-05-08 18:00 (success)
-  ✓ 0 12 * * 0     /recap         next: Sunday 12:00     last: 2026-05-10 12:00 (success)
+  ✓ 0 9 * * *      /daily         (installed)
+  ✓ 0 18 * * 5     /weekly        (installed)
+  ✗ 0 12 * * 0     /recap         (plist missing — re-run /schedule-add)
 ```
 
 Column layout:
-- Status icon: `✓` for active, `⏸` for paused
-- Cron expression (left-padded to align)
+- Installed icon: `✓` = plist on disk, `✗` = plist missing
+- Cron or at expression (left-padded to align)
 - Skill name
-- Next run (human-readable: "tomorrow HH:MM", "Friday HH:MM", "in 3 days HH:MM")
-- Last run datetime + status (`success` | `error` | `never`)
+- Installed status note
 
-### Step 4: Surface errors and paused entries
+Detailed run history (stdout, stderr, error files) lives in `[logs_folder]/scheduler/YYYY/MM/`.
 
-If `last_status` is `error`:
-- Show `(error)` in the last-run column
-- Append a hint line below the table: `→ See 07-logs/scheduler/YYYY/MM/YYYY-MM-DD-{skill}.err.md for details`
+### Step 4: Surface errors
 
-If `paused` is `true` (auto-paused after 3 consecutive failures):
-- Show `⏸ paused` status icon instead of `✓`
-- Append a hint line: `→ Fix the error, then run /schedule-add to re-register {skill}`
+If `✗` entries are found:
+- Append a hint line below the table: `→ Run /schedule-add to re-register missing entries`
+
+For error log detail:
+- Append: `→ See [logs_folder]/scheduler/YYYY/MM/YYYY-MM-DD-{skill}.err.md for failure details`
+
+Note: auto-pause-on-failure (⏸ paused after 3 consecutive failures) is not yet implemented in the CLI. The marker file mechanism is planned for a future release. `/doctor` currently flags 3+ consecutive `.err.md` files as CRITICAL — use that for failure monitoring.
 
 ### Step 5: Footer
 

--- a/.claude/plugins/onebrain/skills/schedule-once/SKILL.md
+++ b/.claude/plugins/onebrain/skills/schedule-once/SKILL.md
@@ -1,0 +1,173 @@
+---
+name: schedule-once
+description: Interactive wizard to schedule a OneBrain skill to run ONCE at a specific datetime, then auto-uninstall. Writes a one-shot entry to vault.yml and invokes onebrain register-schedule.
+schedulable: false
+---
+
+# /schedule-once — One-shot scheduler wizard
+
+## Purpose
+
+For users who want a reminder or task to fire ONCE at a specific date and time, then disappear cleanly. Walks through:
+1. Which skill to fire
+2. What date (YYYY-MM-DD)
+3. What time (HH:MM, 24-hour)
+4. Any required args (if the skill is `schedulable_with_args`)
+5. Confirms preview
+6. Writes one-shot entry to vault.yml + runs `onebrain register-schedule`
+
+After the scheduled time, the launchd plist runs the skill once, then unloads itself and deletes the plist file.
+
+---
+
+## Skill flow
+
+### Step 1: Pick skill
+
+List all schedulable skills by reading each SKILL.md frontmatter under `.claude/plugins/onebrain/skills/`. Filter for entries where `schedulable: true` OR `schedulable_with_args: true`.
+
+Show via `AskUserQuestion`:
+- question: "Which skill would you like to schedule for a one-time run?"
+- header: "Schedule a One-Shot Run"
+- multiSelect: false
+- options (two groups):
+  - Skills with `schedulable: true` (no args required): e.g. `/daily`, `/weekly`, `/recap`, `/doctor`, `/tasks`, `/moc`
+  - Skills with `schedulable_with_args: true` (args required — wizard will prompt): e.g. `/distill`, `/research`, `/summarize`, `/search`
+
+Store: `chosen_skill` (the slash-command name, e.g. `/daily`).
+
+### Step 2: Pick date
+
+Prompt for `YYYY-MM-DD` via plain conversational text:
+> What date should `{chosen_skill}` run? Enter a date in YYYY-MM-DD format.
+
+Validate:
+- Format must match `YYYY-MM-DD` (4-digit year, 2-digit month 01–12, 2-digit day 01–31).
+- Date must be strictly in the future relative to current datetime.
+- If invalid or in the past, reject with a clear message and re-prompt:
+  - Malformed: `Invalid date format. Please use YYYY-MM-DD (e.g. 2026-05-15).`
+  - Past: `Date must be in the future. Current time: <now>.`
+
+Store: `run_date`.
+
+### Step 3: Pick time
+
+Prompt for `HH:MM` (24-hour) via plain conversational text:
+> What time should it run? Enter time in HH:MM format (24-hour, e.g. 14:30).
+
+Validate:
+- Hour: 0–23.
+- Minute: 0–59.
+- If the entered time on the entered date is already in the past, reject with `That time has already passed today. Please enter a future time or change the date.`
+- If invalid format or out of range, reject with a clear message and re-prompt.
+
+Store: `run_time`, `run_hour`, `run_minute`.
+
+### Step 4: Collect required args (if applicable)
+
+If `chosen_skill` has `schedulable_with_args: true`, read its `required_args` list from the SKILL.md frontmatter and prompt for each one via `AskUserQuestion` or plain conversational text.
+
+> What argument should be passed to `{chosen_skill}` when it runs? For example, for `/distill` you might enter a topic name like "machine learning".
+
+Rules:
+- Empty values are not accepted — re-prompt if blank.
+- Reject any arg value containing a double-quote character (`"`): `Argument values cannot contain double-quote characters due to shell wrapper constraints. Please rephrase without quotes.`
+
+Store: `skill_args` (key/value map; omit if no args).
+
+### Step 5: Preview + confirm
+
+Show a preview via `AskUserQuestion`:
+- question: "Ready to schedule?"
+- header: "Confirm One-Shot Schedule"
+- multiSelect: false
+
+Preview block:
+
+```
+{chosen_skill} will run once at {run_date} {run_time}.
+After firing, the schedule auto-uninstalls.
+Output → vault (07-logs/scheduler/{YYYY}/{MM}/{run_date}-{skill-name}.md)
+Confirm?
+```
+
+- options:
+  - label: "Yes, schedule it"
+  - label: "Cancel"
+
+If Cancel, stop with no changes.
+
+### Step 6: Write to vault.yml + register
+
+**Read vault.yml** (full file, parse as YAML).
+
+**Conflict check:** Look in the `schedule:` block for any entry where:
+- `skill` matches `chosen_skill`, AND
+- the `at` field (one-shot) OR `cron` field produces a plist label that would collide.
+
+If a conflict is found, ask via `AskUserQuestion`:
+- question: "`{chosen_skill}` already has a scheduled entry. How would you like to proceed?"
+- header: "Conflict"
+- multiSelect: false
+- options:
+  - label: "Overwrite", description: "Replace the existing entry with this one-shot run"
+  - label: "Cancel", description: "Keep the existing entry as-is"
+
+If Cancel, stop.
+
+**Build the one-shot entry:**
+
+```yaml
+- at: "YYYY-MM-DD HH:MM"
+  skill: /skill-name
+  args:           # omit entire args key if no args
+    key: value
+```
+
+- If overwriting an existing entry, replace it in place.
+- Otherwise, append to the `schedule:` list.
+- If the `schedule:` block does not exist in vault.yml, create it.
+
+**Atomic write:**
+1. Load full vault.yml content.
+2. Mutate the in-memory structure (load → mutate → write entire file).
+3. Write to `vault.yml.tmp` in the vault root.
+4. Rename `vault.yml.tmp` → `vault.yml` (atomic replace on same filesystem).
+5. If write fails at any point: delete `vault.yml.tmp` if it exists; report the error; do not proceed to register step.
+
+**Run from vault root:**
+
+```
+onebrain register-schedule
+```
+
+If the command fails, report the error. vault.yml has already been updated — the user can retry `onebrain register-schedule` manually.
+
+### Step 7: Confirm
+
+Say:
+
+```
+✓ Scheduled {chosen_skill} for {run_date} {run_time} (one-shot). Will auto-uninstall after firing.
+```
+
+---
+
+## Edge cases
+
+- **Date in the past** — reject with `Date must be in the future. Current time: <now>` (Step 2).
+- **vault.yml missing `schedule:` block** — wizard creates it in Step 6.
+- **Conflict: same skill already scheduled (recurring OR one-shot)** — `AskUserQuestion`: overwrite or cancel (Step 6).
+- **Arg value contains `"`** — reject with clear error; re-prompt (Step 4). Carried from backend constraint: the one-shot shell wrapper does not support double-quote characters in argument values.
+- **vault.yml YAML write failure** — rollback in Step 6; no partial state left on disk.
+- **`schedulable_with_args` skill, no args provided** — wizard prompts in Step 4 before proceeding; empty values not accepted.
+
+---
+
+## Implementation notes
+
+- Use the `yaml` library (already in CLI deps) — preserve comments and key order during write.
+- Atomically replace vault.yml: write to tmp file → fsync → rename (POSIX-atomic on same filesystem).
+- The launchd plist generated by `onebrain register-schedule` for a one-shot entry runs the skill once, then calls `launchctl bootout` + `rm -f` to remove itself — the wizard does not need to schedule cleanup; the plist handles it.
+- `at:` field format is `"YYYY-MM-DD HH:MM"` (quoted string). Do not use cron syntax for one-shot entries.
+- Day-of-week and cron logic are not needed here — only the `at:` field is written.

--- a/.claude/plugins/onebrain/skills/schedule-remove/SKILL.md
+++ b/.claude/plugins/onebrain/skills/schedule-remove/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: schedule-remove
+description: Remove a scheduled OneBrain skill. Shows the current schedule list and lets the user pick which entry to remove.
+schedulable: false
+---
+
+# /schedule-remove — Remove a scheduled skill
+
+## Purpose
+
+Safely unschedule a skill: presents the current schedule, confirms intent, removes the entry from vault.yml, and unregisters the corresponding launchd job.
+
+---
+
+## Skill flow
+
+### Step 1: Show current schedule
+
+Run the `/schedule-list` logic (read vault.yml `schedule:` block + call `onebrain register-schedule --status`) to display the current entries.
+
+If no entries are found:
+```
+No scheduled skills to remove.
+
+→ Run /schedule-add to set one up.
+```
+
+Stop.
+
+### Step 2: Pick entry to remove
+
+Show via `AskUserQuestion`:
+- question: "Which scheduled skill would you like to remove?"
+- header: "Remove Schedule"
+- multiSelect: false
+- options: one option per scheduled entry, label = `/skill-name` with cron and frequency as description
+  - e.g. label: `/daily`, description: `0 9 * * * — daily at 09:00`
+
+Store: `chosen_entry` (the matched vault.yml schedule entry).
+
+### Step 3: Confirm removal
+
+Show via `AskUserQuestion`:
+- question: "Remove `{chosen_skill}` scheduled at `{cron}` ({frequency_description})? This stops all automatic invocations."
+- header: "Confirm Removal"
+- multiSelect: false
+- options:
+  - label: "Yes, remove it", description: "Delete the schedule entry and unregister the launchd plist"
+  - label: "Cancel", description: "Keep the schedule as-is"
+
+If Cancel, stop.
+
+### Step 4: Edit vault.yml
+
+Read vault.yml. Remove the matching entry from the `schedule:` block.
+
+Write the full updated vault.yml back atomically:
+1. Write to `vault.yml.tmp` in the vault root.
+2. Rename to `vault.yml`.
+
+If the write fails, delete `vault.yml.tmp` if it exists and report the error. Do not proceed to Step 5.
+
+### Step 5: Unregister
+
+Run from the vault root:
+```
+onebrain register-schedule --refresh
+```
+
+This re-reads vault.yml (now without the removed entry) and deletes the corresponding launchd plist.
+
+If the command fails, report the error. vault.yml has already been updated — the user can retry `onebrain register-schedule --refresh` manually.
+
+### Step 6: Confirm
+
+Say:
+```
+✓ Removed {chosen_skill} from schedule. The launchd plist has been deleted.
+```
+
+---
+
+## Edge cases
+
+- **No entries** — handled in Step 1; early exit with helpful message.
+- **Single entry remaining** — removing it leaves an empty `schedule:` block in vault.yml; this is valid and the block is preserved (not deleted) so future `/schedule-add` runs can append to it.
+- **vault.yml write failure** — rollback in Step 4; no partial state left on disk.
+- **`register-schedule --refresh` failure** — launchd plist may still exist; surface it and suggest manual retry.

--- a/.claude/plugins/onebrain/skills/search/SKILL.md
+++ b/.claude/plugins/onebrain/skills/search/SKILL.md
@@ -5,6 +5,8 @@ auto-invoke:
   - "search vault"
   - "find in vault"
   - "why did"
+schedulable_with_args: true
+required_args: [query]
 ---
 
 # /search — General vault retrieval

--- a/.claude/plugins/onebrain/skills/summarize/SKILL.md
+++ b/.claude/plugins/onebrain/skills/summarize/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: summarize
 description: "Fetch a URL and create a structured summary note saved to the resources folder. Invoke when user shares a URL and explicitly asks for a summary, deep read, or notes on it. Do NOT use for: just saving a URL without reading it (use bookmark), researching a topic without a specific URL (use research), or processing a physical book (use reading-notes)."
+schedulable_with_args: true
+required_args: [url]
 ---
 
 # Summarize

--- a/.claude/plugins/onebrain/skills/tasks/SKILL.md
+++ b/.claude/plugins/onebrain/skills/tasks/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: tasks
 description: "Create or update the live task dashboard (TASKS.md) in Obsidian. Use when the user wants to view or regenerate the task dashboard — 'show my tasks', 'update TASKS.md', 'open task view'. Do NOT use for: the vault portal/map (use moc), capturing new tasks (add them inside project notes directly), or daily briefing (use daily)."
+schedulable: true
 ---
 
 # Task Dashboard

--- a/.claude/plugins/onebrain/skills/update/SKILL.md
+++ b/.claude/plugins/onebrain/skills/update/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: update
 description: "Update OneBrain system files from GitHub to the latest version. Use when the user wants to pull the latest OneBrain skills, hooks, and agents — 'update OneBrain', 'pull latest version'. Do NOT use for: updating vault notes (edit directly), teaching memory (use learn), or vault health checks (use doctor)."
+schedulable: false
 ---
 
 # Update

--- a/.claude/plugins/onebrain/skills/weekly/SKILL.md
+++ b/.claude/plugins/onebrain/skills/weekly/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: weekly
 description: "Weekly reflection : review the past week's sessions, surface patterns, and plan ahead. Use when the user wants a structured end-of-week review — 'weekly review', 'how did this week go', 'plan next week'. Do NOT use for: daily task check-in (use daily), session summary (use wrapup), or promoting insights to memory (use recap)."
+schedulable: true
 ---
 
 # Weekly Reflection

--- a/.claude/plugins/onebrain/skills/wrapup/SKILL.md
+++ b/.claude/plugins/onebrain/skills/wrapup/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: wrapup
 description: "Wrap up and save the current session summary to the session log. Use at end of session when the user says 'bye', 'wrap up', 'save session', or an end-of-session signal is detected. /wrapup writes to 07-logs/ only. Do NOT use for: promoting insights to memory/ (use recap), synthesizing a topic across sessions (use distill), or teaching a single preference (use learn)."
+schedulable: false
 ---
 
 # Session Summary (TL;DR)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-latest_version: 2.2.5
+latest_version: 2.3.0
 released: 2026-05-12
 ---
 
@@ -12,6 +12,17 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 > For plugin changes (skills, agents, hooks, INSTRUCTIONS), see [PLUGIN-CHANGELOG.md](PLUGIN-CHANGELOG.md).
 
 ## [Unreleased]
+
+## v2.3.0 — feat(scheduler): OneBrain scheduler — launchd-backed recurring + one-shot schedules (E9)
+
+- New subcommand `onebrain register-schedule` — registers scheduled skills with macOS launchd, reading the `schedule:` block from `vault.yml`
+- Flags: `--dry-run`, `--remove`, `--refresh`, `--resume <skill>`, `--status`, `--test <skill>`
+- Recurring schedules via 5-field cron syntax in `cron:` field; validated before plist emission
+- One-shot schedules via ISO `at: "YYYY-MM-DD HH:MM"` field; plist emits self-delete shell wrapper that auto-uninstalls after firing
+- Schedulable validation: rejects entries pointing at skills without `schedulable:` or `schedulable_with_args:` frontmatter (or with missing `required_args`)
+- Plist collision detection: two entries normalizing to the same `~/Library/LaunchAgents/com.onebrain.<label>.plist` path are rejected
+- XML escaping on all plist-interpolated values; double-quote in arg values rejected (would break one-shot shell wrapper)
+- macOS launchd first; Linux systemd-timer + Windows Task Scheduler deferred to follow-up
 
 ## v2.2.5 — fix(hooks): iterate all detected harnesses + raw status label in non-TTY
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,6 +109,7 @@ When editing INSTRUCTIONS.md or skills, use Claude Code tool names (`Read`, `Wri
 
 3. Write the skill as a numbered sequence of steps the AI should follow
 4. Register the command in [INSTRUCTIONS.md](.claude/plugins/onebrain/INSTRUCTIONS.md) and [README.md](README.md) (also increment the command count in the README feature list)
+5. Decide schedulability — add `schedulable: true|false` or `schedulable_with_args: true` + `required_args: [...]` to YAML frontmatter. See "Adding a Scheduled Skill" below for details.
 
 ### Long-running skills: heartbeat pattern
 
@@ -119,6 +120,59 @@ Skills that run more than a few seconds (multi-step workflows, batch processing)
 ```
 
 See `/research`, `/consolidate`, `/distill`, `/reorganize`, `/connect`, `/import` for reference implementations.
+
+## Adding a Scheduled Skill
+
+If your skill should be runnable via the OneBrain scheduler (`onebrain register-schedule` / `/schedule-add` / `/schedule-once`), declare its schedulability in the skill's YAML frontmatter.
+
+### Schedulable values
+
+```yaml
+# Skill runs without user input (e.g. /daily, /weekly, /recap):
+---
+schedulable: true
+---
+
+# Skill needs arguments but no user prompts (e.g. /distill, /research):
+---
+schedulable_with_args: true
+required_args: [topic]
+---
+
+# Skill requires interactive user input (default — most skills):
+---
+schedulable: false
+---
+```
+
+### Validation
+
+`onebrain register-schedule` reads the target skill's frontmatter at register time and rejects entries that don't meet the schedulable contract:
+
+- `schedulable: false` → hard error
+- `schedulable_with_args: true` + missing required args in vault.yml → hard error
+- Arg value containing `"` → hard error (would break the one-shot shell wrapper)
+
+### Headless context
+
+Scheduled skills run via `claude --vault {VAULT} --skill {SKILL} --headless`. The session has:
+
+- Full MEMORY.md, vault.yml, MEMORY-INDEX.md (SessionStart hook fires)
+- Tool access per `settings.json` `permissions.allow`
+- No prior conversation history
+- No interactive user input
+
+Design scheduled skills to be self-contained: read state, produce output, write to vault. Avoid AskUserQuestion calls.
+
+### Output
+
+Scheduled output writes to `[logs_folder]/scheduler/YYYY/MM/YYYY-MM-DD-{skill}.md`. Multi-run/day: append a `## HH:MM (scheduled|manual)` section to the same file.
+
+Errors write to `[logs_folder]/scheduler/YYYY/MM/YYYY-MM-DD-{skill}.err.md` (only created on failure). 3 consecutive `.err.md` without a success in between → schedule auto-paused; resume via `onebrain register-schedule --resume <skill>`.
+
+### One-shot vs recurring
+
+Use `cron:` for recurring schedules and `at:` for one-shot fire-once-then-uninstall entries. Exactly one must be set per entry. The launchd plist for one-shot entries emits a self-delete shell wrapper that runs the skill, calls `launchctl bootout`, and deletes its own plist file.
 
 ## Editing an Existing Skill
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ The plugin track ships TWO sibling trees — one per harness — both versioned 
 ├── startup/                             Startup utilities loaded at session begin
 │   └── scripts/                         Predefined shell scripts called by INSTRUCTIONS.md
 │       └── open-in-obsidian.sh          Opens a vault file in the Obsidian app
-├── skills/                              One directory per slash command (25 skills)
+├── skills/                              One directory per slash command (29 skills)
 │   └── [name]/
 │       ├── SKILL.md                     The skill prompt — what the AI follows when invoked
 │       ├── references/                  Large content loaded on-demand (handlers, templates, procedures)
@@ -44,7 +44,7 @@ The plugin track ships TWO sibling trees — one per harness — both versioned 
 ├── settings.json                        Declarative hooks (AfterAgent, AfterTool) + model.disableLoopDetection
 └── commands/
     └── onebrain/                        Slash commands namespaced as /onebrain:<skill>
-        └── *.toml                       One TOML per user-facing skill (25 commands; description + prompt)
+        └── *.toml                       One TOML per user-facing skill (29 commands; description + prompt)
 ```
 
 Both trees are deployed to the user's vault by `vault-sync` in a single sync step. Skills, agents, and INSTRUCTIONS live single-source-of-truth in `.claude/plugins/onebrain/`; the Gemini side references them on demand via the slash command prompts.

--- a/PLUGIN-CHANGELOG.md
+++ b/PLUGIN-CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-latest_version: 2.4.6
+latest_version: 2.4.7
 released: 2026-05-12
 ---
 
@@ -10,6 +10,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 > **Versioning:** Plugin version is tracked in `plugin.json`. Bump when ANY harness config changes — skills, agents, hooks, INSTRUCTIONS, Gemini settings, slash commands, etc.
 > For CLI binary (`@onebrain-ai/cli`) changes, see [CHANGELOG.md](CHANGELOG.md).
+
+## 2.4.7 — 2026-05-12
+
+- 4 new wizard skills: `/schedule-add` (recurring), `/schedule-once` (one-shot), `/schedule-list`, `/schedule-remove` (E9.1)
+- 26 user-facing skills declare `schedulable:` / `schedulable_with_args:` frontmatter — gates which skills the CLI scheduler accepts (E9.4)
+- `/doctor` extended with Scheduler Health section: scans `.err.md` files, detects drift between `vault.yml` and installed plists, flags 3+ consecutive failures + expired one-shots (E9.2)
+- INSTRUCTIONS.md adds "Scheduling — which tool to use" + "Headless invocation" sections (E9.3) — disambiguates OneBrain scheduler vs Claude Code `/loop` and `/schedule`
+- `/help` MAINTAIN tier lists the 4 new schedule commands
 
 ## 2.4.6 — 2026-05-12
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 </p>
 
 <p align="center">
-  <strong>Your personal AI OS</strong> — persistent memory, 25+ skills, and a full local stack<br>
+  <strong>Your personal AI OS</strong> — persistent memory, 29+ skills, and a full local stack<br>
   (Claude Code + Obsidian + tmux + Telegram), entirely on your own machine.
 </p>
 
@@ -35,7 +35,7 @@
 
 ## What is OneBrain?
 
-OneBrain is an AI operating system layer built on top of Obsidian. It gives your AI agent persistent memory, a structured knowledge vault, and 25+ pre-built skills — so every session picks up exactly where the last one left off.
+OneBrain is an AI operating system layer built on top of Obsidian. It gives your AI agent persistent memory, a structured knowledge vault, and 29+ pre-built skills — so every session picks up exactly where the last one left off.
 
 Unlike chat-based AI tools, OneBrain lives in plain Markdown files you own forever. No cloud sync required. No proprietary format. Just your agent, your vault, your data.
 
@@ -70,7 +70,7 @@ OneBrain doesn't compete with Claude Code, Gemini CLI, or any other AI harness �
 
 | # | Layer | Role | What lives here |
 |---|---|---|---|
-| 01 | **OneBrain** | OS layer (plugin + CLI) | 25+ skills · lifecycle hooks · vault sync · indexing · checkpoints · harness routing |
+| 01 | **OneBrain** | OS layer (plugin + CLI) | 29+ skills · lifecycle hooks · vault sync · indexing · checkpoints · harness routing |
 | 02 | **Harness** | Agentic runtime | Bring your own — Claude Code · Gemini CLI · Codex · Qwen · ... |
 | 03 | **LLM** | Intelligence source | Local (mlx, ollama) · cloud (claude, gemini, gpt) · raw API |
 | 04 | **Obsidian Vault** | Source of truth | Plain Markdown — notes, memory, decisions, knowledge graph |
@@ -84,7 +84,7 @@ A great harness already knows how to talk to an LLM, edit files, and run shell c
 | | What OneBrain adds | Why it matters |
 |---|---|---|
 | 🧠 | **Memory** — Identity, preferences, decisions, project state — promoted across four tiers as it earns trust | The harness alone starts every session from zero. OneBrain doesn't. |
-| ⚡ | **Skills** — 25+ vault-aware verbs (`/braindump`, `/research`, `/distill`, `/learn`, `/wrapup`, …) | Pre-built workflows the harness would otherwise need you to script every time. |
+| ⚡ | **Skills** — 29+ vault-aware verbs (`/braindump`, `/research`, `/distill`, `/learn`, `/wrapup`, …) | Pre-built workflows the harness would otherwise need you to script every time. |
 | 🎯 | **Calibration** — Every correction, every preference, every learned habit tunes the agent to *you* | The longer you use it, the sharper it gets — your vault is the training data. |
 | 🔀 | **Continuity** — Context lives in the vault, not the harness | Switch from Claude Code to Gemini CLI to Codex. Same memory. Same skills. Same agent. |
 
@@ -210,7 +210,7 @@ OneBrain doesn't just store markdown. Every feature exists to make you and the a
 |---|---|---|
 | 🧠 | **Persistent Memory** | Remembers your name, goals, preferences, and decisions across every session |
 | 🖥️ | **Personal AI OS** | Full local stack: Claude Code + Obsidian + tmux + Telegram — no cloud infra needed |
-| ⚡ | **25+ Skills** | Braindump, research, consolidate, bookmark, import files, daily briefing, and more |
+| ⚡ | **29+ Skills** | Braindump, research, consolidate, bookmark, import files, daily briefing, and more |
 | 📂 | **Vault-native Markdown** | Plain Markdown, no lock-in. Your data stays yours forever |
 | 🔀 | **Multi-Harness OS** | Switch between Claude Code, Gemini CLI, Codex, Qwen, or BYO LLM — context never breaks. [See architecture ↑](#the-harness-os-architecture) |
 | 🔌 | **Zero Config** | Clone, open in Obsidian, run `/onboarding`. Ready in under 2 minutes |
@@ -340,7 +340,7 @@ Same vault. Same skills. Same memory. The LLM swaps; OneBrain doesn't notice.
 
 <a id="commands"></a>
 
-## 📋 25+ Commands
+## 📋 29+ Commands
 
 Skills are organized by workflow phase. **Gemini CLI users:** prepend the `onebrain:` namespace, e.g. `/onebrain:braindump` instead of `/braindump` (avoids collisions with Gemini built-in commands like `/help` and `/tasks`).
 
@@ -389,6 +389,10 @@ Skills are organized by workflow phase. **Gemini CLI users:** prepend the `onebr
 | `/qmd` | Set up fast vault search index — enables semantic search across all notes |
 | `/help` | List all available commands with descriptions |
 | `/wrapup` | Wrap up session — merges any auto-checkpoints and saves full summary to session log |
+| `/schedule-add` | Interactive wizard for adding a recurring scheduled skill |
+| `/schedule-once` | One-shot wizard: schedule a skill to run once at a specific datetime |
+| `/schedule-list` | Show all scheduled entries |
+| `/schedule-remove` | Remove a scheduled entry |
 
 <details>
 <summary><strong>📁 Vault Structure</strong></summary>
@@ -480,6 +484,62 @@ Multi-device sync and hosted agent runtimes. Your unified intelligence travels w
 | **FREE** | Local vault · OSS skills · BYOK | ✅ Available now |
 | **PRO** | Sync · mobile · hosted runtime | 🟡 [Join waitlist](https://onebrain.run) |
 | **TEAM** | Shared intelligence · team mesh | 🟡 Coming soon |
+
+---
+
+## Scheduling
+
+OneBrain skills can run automatically on a schedule via your OS scheduler (macOS launchd; Linux + Windows coming soon). Configure in `vault.yml`:
+
+```yaml
+schedule:
+  - cron: "0 9 * * *"      # daily 9am
+    skill: /daily
+  - cron: "0 18 * * 5"     # Friday 6pm
+    skill: /weekly
+  - cron: "0 12 * * 0"     # Sunday noon
+    skill: /recap
+```
+
+For a one-shot reminder, use `at:` instead of `cron:`:
+
+```yaml
+schedule:
+  - at: "2026-05-13 14:30"
+    skill: /reminder
+```
+
+After firing, the launchd plist auto-uninstalls itself.
+
+Register schedules:
+
+```bash
+onebrain register-schedule
+```
+
+Or use the interactive wizards from inside your vault:
+
+```
+/schedule-add      # recurring schedule wizard
+/schedule-once     # one-shot wizard
+/schedule-list     # show all scheduled entries
+/schedule-remove   # remove an entry
+```
+
+Output goes to `[logs_folder]/scheduler/YYYY/MM/YYYY-MM-DD-{skill}.md` as readable markdown.
+
+CLI flags:
+
+| Flag | Purpose |
+|---|---|
+| `--dry-run` | Print plist without writing |
+| `--remove` | Remove all OneBrain schedules |
+| `--refresh` | Re-emit plists after vault move |
+| `--resume <skill>` | Resume an auto-paused skill |
+| `--status` | Show registered schedules + run history |
+| `--test <skill>` | Manually invoke a scheduled skill once |
+
+**Note:** OneBrain's scheduler is distinct from Claude Code's `/loop` (in-session) and `/schedule` (cloud-hosted). OneBrain runs locally and writes to your vault.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onebrain-ai/cli",
-  "version": "2.2.5",
+  "version": "2.3.0",
   "description": "CLI for OneBrain — personal AI OS for Obsidian with persistent memory, 24+ skills, and Claude Code integration",
   "keywords": [
     "onebrain",

--- a/src/commands/register-schedule.test.ts
+++ b/src/commands/register-schedule.test.ts
@@ -82,14 +82,30 @@ describe('registerSchedule', () => {
     );
   });
 
-  test('rejects arg value containing double-quote', async () => {
-    writeFileSync(
-      join(testVault, 'vault.yml'),
-      `schedule:\n  - cron: "0 9 * * *"\n    skill: /daily\n    args:\n      msg: 'bad "value"'\n`,
-    );
-    await expect(registerSchedule({ vault: testVault, dryRun: true })).rejects.toThrow(
-      /double-quote/,
-    );
+  test('rejects arg value containing shell-special chars', async () => {
+    for (const [_key, yaml] of [
+      [
+        'double-quote',
+        `schedule:\n  - cron: "0 9 * * *"\n    skill: /daily\n    args:\n      msg: 'bad "value"'\n`,
+      ],
+      [
+        'dollar-sign',
+        `schedule:\n  - cron: "0 9 * * *"\n    skill: /daily\n    args:\n      msg: 'has $var'\n`,
+      ],
+      [
+        'backtick',
+        'schedule:\n  - cron: "0 9 * * *"\n    skill: /daily\n    args:\n      msg: \'has `cmd`\'\n',
+      ],
+      [
+        'backslash',
+        `schedule:\n  - cron: "0 9 * * *"\n    skill: /daily\n    args:\n      msg: 'back\\\\slash'\n`,
+      ],
+    ] as [string, string][]) {
+      writeFileSync(join(testVault, 'vault.yml'), yaml);
+      await expect(registerSchedule({ vault: testVault, dryRun: true })).rejects.toThrow(
+        /shell-special chars/,
+      );
+    }
   });
 
   test('--refresh logs notice and re-emits plists', async () => {

--- a/src/commands/register-schedule.test.ts
+++ b/src/commands/register-schedule.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { registerSchedule } from './register-schedule';
+
+let testVault: string;
+
+beforeEach(() => {
+  testVault = mkdtempSync(join(tmpdir(), 'onebrain-sched-test-'));
+  mkdirSync(join(testVault, '.claude/plugins/onebrain/skills/daily'), { recursive: true });
+  writeFileSync(
+    join(testVault, '.claude/plugins/onebrain/skills/daily/SKILL.md'),
+    '---\nname: daily\nschedulable: true\n---\n\n# /daily\n',
+  );
+  writeFileSync(
+    join(testVault, 'vault.yml'),
+    `schedule:\n  - cron: "0 9 * * *"\n    skill: /daily\n`,
+  );
+});
+
+afterEach(() => rmSync(testVault, { recursive: true, force: true }));
+
+describe('registerSchedule', () => {
+  test('--dry-run prints plist without writing', async () => {
+    const captured = captureConsoleLog();
+    try {
+      await registerSchedule({ vault: testVault, dryRun: true });
+      expect(captured.lines().some((l) => l.includes('com.onebrain.daily'))).toBe(true);
+      expect(captured.lines().some((l) => l.includes('StartCalendarInterval'))).toBe(true);
+    } finally {
+      captured.restore();
+    }
+  });
+
+  test('rejects unschedulable skill', async () => {
+    writeFileSync(
+      join(testVault, '.claude/plugins/onebrain/skills/daily/SKILL.md'),
+      '---\nname: daily\nschedulable: false\n---\n',
+    );
+    await expect(registerSchedule({ vault: testVault, dryRun: true })).rejects.toThrow(
+      /requires user input/,
+    );
+  });
+
+  test('--status reports entry tagged [cron]', async () => {
+    const captured = captureConsoleLog();
+    try {
+      await registerSchedule({ vault: testVault, status: true });
+      expect(captured.lines().some((l) => l.includes('Registered schedules: 1'))).toBe(true);
+      expect(captured.lines().some((l) => l.includes('[cron]'))).toBe(true);
+    } finally {
+      captured.restore();
+    }
+  });
+
+  test('one-shot --dry-run produces plist with Year/Month/Day/Hour/Minute and self-delete wrapper', async () => {
+    writeFileSync(
+      join(testVault, 'vault.yml'),
+      `schedule:\n  - at: "2026-05-13 14:30"\n    skill: /daily\n`,
+    );
+    const captured = captureConsoleLog();
+    try {
+      await registerSchedule({ vault: testVault, dryRun: true });
+      const joined = captured.lines().join('\n');
+      expect(joined).toContain('<key>Year</key>');
+      expect(joined).toContain('<key>Day</key>');
+      expect(joined).toContain('launchctl bootout');
+      expect(joined).toContain('rm -f');
+    } finally {
+      captured.restore();
+    }
+  });
+
+  test('rejects entry with both cron and at', async () => {
+    writeFileSync(
+      join(testVault, 'vault.yml'),
+      `schedule:\n  - cron: "0 9 * * *"\n    at: "2026-05-13 14:30"\n    skill: /daily\n`,
+    );
+    await expect(registerSchedule({ vault: testVault, dryRun: true })).rejects.toThrow(
+      /exactly one/,
+    );
+  });
+
+  test('rejects arg value containing double-quote', async () => {
+    writeFileSync(
+      join(testVault, 'vault.yml'),
+      `schedule:\n  - cron: "0 9 * * *"\n    skill: /daily\n    args:\n      msg: 'bad "value"'\n`,
+    );
+    await expect(registerSchedule({ vault: testVault, dryRun: true })).rejects.toThrow(
+      /double-quote/,
+    );
+  });
+
+  test('--refresh logs notice and re-emits plists', async () => {
+    const captured = captureConsoleLog();
+    try {
+      await registerSchedule({ vault: testVault, refresh: true, dryRun: true });
+      expect(captured.lines().some((l) => l.includes('--refresh'))).toBe(true);
+      expect(captured.lines().some((l) => l.includes('com.onebrain.daily'))).toBe(true);
+    } finally {
+      captured.restore();
+    }
+  });
+});
+
+function captureConsoleLog() {
+  const original = console.log;
+  const lines: string[] = [];
+  console.log = (msg: unknown) => lines.push(String(msg));
+  return {
+    lines: () => lines,
+    restore: () => {
+      console.log = original;
+    },
+  };
+}

--- a/src/commands/register-schedule.test.ts
+++ b/src/commands/register-schedule.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { registerSchedule } from './register-schedule';
+import { registerSchedule } from './register-schedule.js';
 
 let testVault: string;
 

--- a/src/commands/register-schedule.ts
+++ b/src/commands/register-schedule.ts
@@ -62,6 +62,8 @@ export async function registerSchedule(opts: RegisterScheduleOptions): Promise<v
   const ctx = {
     vaultPath: opts.vault,
     skillCliPath,
+    // TODO: read folders.logs from vault.yml instead of hardcoding '07-logs'
+    // — for vaults using a non-default logs folder. Tracked for follow-up.
     logBasePath: join(opts.vault, '07-logs/scheduler'),
     // process.getuid is undefined on Windows; fall back to 501 (default macOS UID).
     // TODO: surface an error if running on a non-POSIX platform where getuid is absent.
@@ -138,13 +140,15 @@ async function validateSchedulable(vault: string, entry: ScheduleEntry): Promise
     throw new Error(`Skill ${entry.skill} does not declare schedulable: true in frontmatter`);
   }
 
-  // Reject double-quote in args values: the one-shot shell wrapper interpolates
-  // arg values into a sh -c string, so unescaped double-quotes would break the
-  // generated shell command.
+  // Reject shell-special chars in args values: the one-shot shell wrapper interpolates
+  // arg values into a sh -c "..." string, so double-quote, $, backtick, and backslash
+  // can execute arbitrary commands or break the generated shell command.
   if (entry.args) {
     for (const [k, v] of Object.entries(entry.args)) {
-      if (v.includes('"')) {
-        throw new Error(`Arg "${k}" value must not contain double-quote: ${v}`);
+      if (/["$`\\]/.test(v)) {
+        throw new Error(
+          `Arg "${k}" value must not contain shell-special chars (", $, backtick, \\): ${v}`,
+        );
       }
     }
   }
@@ -187,6 +191,8 @@ async function testRun(vault: string, skill: string): Promise<void> {
 }
 
 async function resumeSkill(vault: string, skill: string): Promise<void> {
+  // TODO: read folders.logs from vault.yml instead of hardcoding '07-logs'
+  // — for vaults using a non-default logs folder. Tracked for follow-up.
   const marker = join(vault, '07-logs/scheduler/.paused', `${skill.replace(/^\//, '')}.txt`);
   if (existsSync(marker)) {
     await unlink(marker);

--- a/src/commands/register-schedule.ts
+++ b/src/commands/register-schedule.ts
@@ -1,0 +1,196 @@
+import { existsSync } from 'node:fs';
+import { readFile, unlink, writeFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import pc from 'picocolors';
+import { parse as parseYaml } from 'yaml';
+import { validateAt, validateCron } from '../lib/scheduler/cron-parse.js';
+import { isOneShot, validateEntry } from '../lib/scheduler/entry.js';
+import { generatePlist, plistPath } from '../lib/scheduler/launchd.js';
+import type { ScheduleConfig, ScheduleEntry, SkillFrontmatter } from '../lib/scheduler/types.js';
+
+export interface RegisterScheduleOptions {
+  vault: string;
+  dryRun?: boolean;
+  remove?: boolean;
+  refresh?: boolean;
+  resume?: string;
+  status?: boolean;
+  test?: string;
+}
+
+export async function registerSchedule(opts: RegisterScheduleOptions): Promise<void> {
+  if (opts.remove) return await removeAll(opts.vault);
+  if (opts.status) return await printStatus(opts.vault);
+  if (opts.test) return await testRun(opts.vault, opts.test);
+  if (opts.resume) return await resumeSkill(opts.vault, opts.resume);
+
+  if (opts.refresh) {
+    console.log(pc.dim('(--refresh: re-emitting plists with current vault path)'));
+  }
+
+  const config = await readVaultConfig(opts.vault);
+  const entries = config.schedule ?? [];
+
+  if (entries.length === 0) {
+    console.log(pc.yellow('No schedule entries in vault.yml. Nothing to register.'));
+    return;
+  }
+
+  // Validate each entry (exactly-one-of cron/at, plus the corresponding format)
+  for (const entry of entries) {
+    const ve = validateEntry(entry);
+    if (!ve.valid) throw new Error(`Invalid schedule entry: ${ve.reason}`);
+    if (isOneShot(entry)) {
+      const va = validateAt(entry.at);
+      if (!va.valid) throw new Error(`Invalid at "${entry.at}": ${va.reason}`);
+    } else if (entry.cron !== undefined) {
+      const vc = validateCron(entry.cron);
+      if (!vc.valid) throw new Error(`Invalid cron "${entry.cron}": ${vc.reason}`);
+    }
+    await validateSchedulable(opts.vault, entry);
+  }
+
+  // TODO: resolve the real `onebrain` binary path for production use.
+  // In production the CLI is invoked as `onebrain`, so the installed path should
+  // be resolvable (e.g. via `which onebrain` or a known install prefix). For now
+  // process.argv[1] gives the script path being executed, which works in dev and
+  // in the Bun bundle where argv[1] is the compiled binary path. process.execPath
+  // points to the Bun runtime itself, which is wrong for launchd invocations.
+  const skillCliPath = process.argv[1] ?? 'onebrain';
+
+  const ctx = {
+    vaultPath: opts.vault,
+    skillCliPath,
+    logBasePath: join(opts.vault, '07-logs/scheduler'),
+    // process.getuid is undefined on Windows; fall back to 501 (default macOS UID).
+    // TODO: surface an error if running on a non-POSIX platform where getuid is absent.
+    uid: process.getuid?.() ?? 501,
+    homedir: homedir(),
+  };
+
+  // Collision detection: two entries normalizing to the same plist path conflict
+  const seen = new Map<string, ScheduleEntry>();
+  for (const entry of entries) {
+    const target = plistPath(entry.skill, ctx.homedir);
+    if (seen.has(target)) {
+      throw new Error(
+        `Conflict: ${entry.skill} and ${seen.get(target)?.skill} normalize to the same plist path ${target}`,
+      );
+    }
+    seen.set(target, entry);
+  }
+
+  for (const entry of entries) {
+    const plistContent = generatePlist(entry, ctx);
+    const targetPath = plistPath(entry.skill, ctx.homedir);
+
+    if (opts.dryRun) {
+      console.log(pc.cyan(`---  ${targetPath}  ---`));
+      console.log(plistContent);
+      continue;
+    }
+
+    await writeFile(targetPath, plistContent, 'utf8');
+    console.log(pc.green(`✓ Wrote ${targetPath}`));
+  }
+
+  console.log(pc.green(`\nRegistered ${entries.length} schedule entries.`));
+  console.log(pc.dim('Use launchctl to load (or restart launchd):'));
+  for (const entry of entries) {
+    const target = plistPath(entry.skill, ctx.homedir);
+    console.log(pc.dim(`  launchctl load ${target}`));
+  }
+}
+
+async function readVaultConfig(vault: string): Promise<ScheduleConfig> {
+  const yamlPath = join(vault, 'vault.yml');
+  if (!existsSync(yamlPath)) return {};
+  const raw = await readFile(yamlPath, 'utf8');
+  return (parseYaml(raw) ?? {}) as ScheduleConfig;
+}
+
+async function validateSchedulable(vault: string, entry: ScheduleEntry): Promise<void> {
+  const skillName = entry.skill.replace(/^\//, '');
+  const skillPath = join(vault, '.claude/plugins/onebrain/skills', skillName, 'SKILL.md');
+  if (!existsSync(skillPath)) {
+    throw new Error(`Skill ${entry.skill} not found at ${skillPath}`);
+  }
+  const raw = await readFile(skillPath, 'utf8');
+  const match = raw.match(/^---\n([\s\S]*?)\n---/);
+  if (!match) {
+    throw new Error(`Skill ${entry.skill} has no YAML frontmatter`);
+  }
+  const fm = parseYaml(match[1]) as SkillFrontmatter;
+
+  if (fm.schedulable === false) {
+    throw new Error(`Skill ${entry.skill} requires user input — cannot schedule`);
+  }
+  if (fm.schedulable_with_args) {
+    const required = fm.required_args ?? [];
+    const provided = Object.keys(entry.args ?? {});
+    const missing = required.filter((r) => !provided.includes(r));
+    if (missing.length > 0) {
+      throw new Error(`Skill ${entry.skill} requires args: [${missing.join(', ')}]`);
+    }
+  } else if (!fm.schedulable) {
+    throw new Error(`Skill ${entry.skill} does not declare schedulable: true in frontmatter`);
+  }
+
+  // Reject double-quote in args values: the one-shot shell wrapper interpolates
+  // arg values into a sh -c string, so unescaped double-quotes would break the
+  // generated shell command.
+  if (entry.args) {
+    for (const [k, v] of Object.entries(entry.args)) {
+      if (v.includes('"')) {
+        throw new Error(`Arg "${k}" value must not contain double-quote: ${v}`);
+      }
+    }
+  }
+}
+
+async function removeAll(vault: string): Promise<void> {
+  const config = await readVaultConfig(vault);
+  const entries = config.schedule ?? [];
+  for (const entry of entries) {
+    const target = plistPath(entry.skill, homedir());
+    if (existsSync(target)) {
+      await unlink(target);
+      console.log(pc.green(`✓ Removed ${target}`));
+    }
+  }
+}
+
+async function printStatus(vault: string): Promise<void> {
+  const config = await readVaultConfig(vault);
+  const entries = config.schedule ?? [];
+  console.log(pc.cyan(`Registered schedules: ${entries.length}`));
+  for (const entry of entries) {
+    const target = plistPath(entry.skill, homedir());
+    const installed = existsSync(target) ? '✓' : '✗';
+    const when = entry.at ?? entry.cron ?? '?';
+    const tag = entry.at ? pc.magenta('[once]') : pc.dim('[cron]');
+    console.log(`  ${installed} ${tag} ${when}  ${entry.skill}`);
+  }
+}
+
+async function testRun(vault: string, skill: string): Promise<void> {
+  console.log(pc.cyan(`Testing scheduled invocation of ${skill}...`));
+  // The CLI binary is `claude` (not `claude-code`; that name is incorrect).
+  console.log(pc.dim('(Spawns headless Claude Code. Output streams here.)'));
+  const { spawn } = await import('node:child_process');
+  const child = spawn('claude', ['--vault', vault, '--skill', skill, '--headless'], {
+    stdio: 'inherit',
+  });
+  await new Promise((resolve) => child.on('exit', resolve));
+}
+
+async function resumeSkill(vault: string, skill: string): Promise<void> {
+  const marker = join(vault, '07-logs/scheduler/.paused', `${skill.replace(/^\//, '')}.txt`);
+  if (existsSync(marker)) {
+    await unlink(marker);
+    console.log(pc.green(`✓ Resumed ${skill}`));
+  } else {
+    console.log(pc.yellow(`${skill} is not paused.`));
+  }
+}

--- a/src/commands/register-schedule.ts
+++ b/src/commands/register-schedule.ts
@@ -121,7 +121,8 @@ async function validateSchedulable(vault: string, entry: ScheduleEntry): Promise
   if (!match) {
     throw new Error(`Skill ${entry.skill} has no YAML frontmatter`);
   }
-  const fm = parseYaml(match[1]) as SkillFrontmatter;
+  // biome-ignore lint/style/noNonNullAssertion: regex has a capture group; match[1] is present when match is non-null
+  const fm = parseYaml(match[1]!) as SkillFrontmatter;
 
   if (fm.schedulable === false) {
     throw new Error(`Skill ${entry.skill} requires user input — cannot schedule`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import { qmdReindexCommand } from './commands/internal/qmd-reindex.js';
 import { registerHooksCommand } from './commands/internal/register-hooks.js';
 import { resolveSessionToken, sessionInitCommand } from './commands/internal/session-init.js';
 import { vaultSyncCommand } from './commands/internal/vault-sync.js';
+import { registerSchedule } from './commands/register-schedule.js';
 import { updateCommand } from './commands/update.js';
 import { patchUtf8 } from './lib/patch-utf8.js';
 
@@ -101,6 +102,30 @@ program
       ...(opts.fix !== undefined ? { fix: opts.fix } : {}),
     });
   });
+
+program
+  .command('register-schedule')
+  .description('Register OneBrain scheduled skills with the OS scheduler (macOS launchd)')
+  .option('--vault <path>', 'Vault path', process.cwd())
+  .option('--dry-run', 'Print plist without writing')
+  .option('--remove', 'Remove all OneBrain schedule entries')
+  .option('--refresh', 'Re-emit plists with current vault path')
+  .option('--resume <skill>', 'Resume an auto-paused skill')
+  .option('--status', 'Show registered schedules + recent run status')
+  .option('--test <skill>', 'Manually invoke a scheduled skill once')
+  .action(
+    async (opts: {
+      vault: string;
+      dryRun?: boolean;
+      remove?: boolean;
+      refresh?: boolean;
+      resume?: string;
+      status?: boolean;
+      test?: string;
+    }) => {
+      await registerSchedule(opts);
+    },
+  );
 
 program
   .command('help')

--- a/src/lib/scheduler/cron-parse.test.ts
+++ b/src/lib/scheduler/cron-parse.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { cronFieldsToLaunchd, validateCron } from './cron-parse';
+import { atToLaunchd, cronFieldsToLaunchd, validateAt, validateCron } from './cron-parse';
 
 describe('validateCron', () => {
   test('accepts valid daily cron', () => {
@@ -32,6 +32,49 @@ describe('cronFieldsToLaunchd', () => {
       Minute: 0,
       Hour: 12,
       Weekday: 0,
+    });
+  });
+});
+
+describe('validateAt', () => {
+  test('accepts valid timestamp', () => {
+    expect(validateAt('2026-05-13 14:30')).toEqual({ valid: true });
+  });
+
+  test('rejects bad format', () => {
+    const result = validateAt('2026/05/13 14:30');
+    expect(result.valid).toBe(false);
+    expect(result.reason).toContain('expected');
+  });
+
+  test('rejects month out of range', () => {
+    const result = validateAt('2026-13-01 09:00');
+    expect(result.valid).toBe(false);
+    expect(result.reason).toContain('month out of range');
+  });
+
+  test('rejects hour out of range', () => {
+    const result = validateAt('2026-05-13 24:00');
+    expect(result.valid).toBe(false);
+    expect(result.reason).toContain('hour out of range');
+  });
+  test('rejects day out of range', () => {
+    expect(validateAt('2026-05-32 09:00').valid).toBe(false);
+    expect(validateAt('2026-05-00 09:00').valid).toBe(false);
+  });
+  test('rejects minute out of range', () => {
+    expect(validateAt('2026-05-13 09:60').valid).toBe(false);
+  });
+});
+
+describe('atToLaunchd', () => {
+  test('converts 2026-05-13 14:30', () => {
+    expect(atToLaunchd('2026-05-13 14:30')).toEqual({
+      Year: 2026,
+      Month: 5,
+      Day: 13,
+      Hour: 14,
+      Minute: 30,
     });
   });
 });

--- a/src/lib/scheduler/cron-parse.test.ts
+++ b/src/lib/scheduler/cron-parse.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { atToLaunchd, cronFieldsToLaunchd, validateAt, validateCron } from './cron-parse';
+import { atToLaunchd, cronFieldsToLaunchd, validateAt, validateCron } from './cron-parse.js';
 
 describe('validateCron', () => {
   test('accepts valid daily cron', () => {

--- a/src/lib/scheduler/cron-parse.test.ts
+++ b/src/lib/scheduler/cron-parse.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from 'bun:test';
+import { cronFieldsToLaunchd, validateCron } from './cron-parse';
+
+describe('validateCron', () => {
+  test('accepts valid daily cron', () => {
+    expect(validateCron('0 9 * * *')).toEqual({ valid: true });
+  });
+
+  test('accepts weekday-range cron', () => {
+    expect(validateCron('0 9 * * 1-5')).toEqual({ valid: true });
+  });
+
+  test('rejects wrong field count', () => {
+    const result = validateCron('0 9 * *');
+    expect(result.valid).toBe(false);
+    expect(result.reason).toContain('expected 5 fields');
+  });
+
+  test('rejects invalid characters', () => {
+    const result = validateCron('0 9 * * abc');
+    expect(result.valid).toBe(false);
+  });
+});
+
+describe('cronFieldsToLaunchd', () => {
+  test('converts daily 9am', () => {
+    expect(cronFieldsToLaunchd('0 9 * * *')).toEqual({ Minute: 0, Hour: 9 });
+  });
+
+  test('converts Sunday noon', () => {
+    expect(cronFieldsToLaunchd('0 12 * * 0')).toEqual({
+      Minute: 0,
+      Hour: 12,
+      Weekday: 0,
+    });
+  });
+});

--- a/src/lib/scheduler/cron-parse.test.ts
+++ b/src/lib/scheduler/cron-parse.test.ts
@@ -6,8 +6,16 @@ describe('validateCron', () => {
     expect(validateCron('0 9 * * *')).toEqual({ valid: true });
   });
 
-  test('accepts weekday-range cron', () => {
-    expect(validateCron('0 9 * * 1-5')).toEqual({ valid: true });
+  test('rejects step syntax', () => {
+    expect(validateCron('*/5 * * * *').valid).toBe(false);
+  });
+
+  test('rejects range syntax', () => {
+    expect(validateCron('0 9 * * 1-5').valid).toBe(false);
+  });
+
+  test('rejects list syntax', () => {
+    expect(validateCron('0 9 * * 1,3,5').valid).toBe(false);
   });
 
   test('rejects wrong field count', () => {

--- a/src/lib/scheduler/cron-parse.ts
+++ b/src/lib/scheduler/cron-parse.ts
@@ -1,5 +1,5 @@
-// Field regex: supports digits, `*`, ranges (`-`), and lists (`,`). Step syntax (`*/N`) is not supported.
-const CRON_FIELD_RE = /^[\d*,\-/]+$/;
+// Field regex: single wildcard '*' OR single integer. Ranges (1-5), lists (1,2,3), step syntax (*/N) are not supported — launchd StartCalendarInterval only accepts a single integer per field.
+const CRON_FIELD_RE = /^(\*|\d+)$/;
 
 export function validateCron(cron: string): { valid: boolean; reason?: string } {
   const fields = cron.trim().split(/\s+/);

--- a/src/lib/scheduler/cron-parse.ts
+++ b/src/lib/scheduler/cron-parse.ts
@@ -22,7 +22,13 @@ export function cronFieldsToLaunchd(cron: string): {
   Month?: number;
   Weekday?: number;
 } {
-  const [m, h, dom, mon, dow] = cron.trim().split(/\s+/);
+  const [m, h, dom, mon, dow] = cron.trim().split(/\s+/) as [
+    string,
+    string,
+    string,
+    string,
+    string,
+  ];
   const out: { Minute?: number; Hour?: number; Day?: number; Month?: number; Weekday?: number } =
     {};
   if (m !== '*') out.Minute = Number.parseInt(m, 10);
@@ -40,7 +46,7 @@ export function validateAt(at: string): { valid: boolean; reason?: string } {
   if (!m) {
     return { valid: false, reason: `expected 'YYYY-MM-DD HH:MM', got "${at}"` };
   }
-  const [, , mo, d, h, mi] = m;
+  const [, , mo, d, h, mi] = m as [string, string, string, string, string, string];
   const month = Number.parseInt(mo, 10);
   const day = Number.parseInt(d, 10);
   const hour = Number.parseInt(h, 10);
@@ -60,8 +66,9 @@ export function atToLaunchd(at: string): {
   Hour: number;
   Minute: number;
 } {
-  const m = at.match(AT_RE) as RegExpMatchArray;
-  const [, y, mo, d, h, mi] = m;
+  const m = at.match(AT_RE);
+  if (!m) throw new Error(`atToLaunchd called with unvalidated input: ${at}`);
+  const [, y, mo, d, h, mi] = m as [string, string, string, string, string, string];
   return {
     Year: Number.parseInt(y, 10),
     Month: Number.parseInt(mo, 10),

--- a/src/lib/scheduler/cron-parse.ts
+++ b/src/lib/scheduler/cron-parse.ts
@@ -32,3 +32,41 @@ export function cronFieldsToLaunchd(cron: string): {
   if (dow !== '*') out.Weekday = Number.parseInt(dow, 10);
   return out;
 }
+
+const AT_RE = /^(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2})$/;
+
+export function validateAt(at: string): { valid: boolean; reason?: string } {
+  const m = at.match(AT_RE);
+  if (!m) {
+    return { valid: false, reason: `expected 'YYYY-MM-DD HH:MM', got "${at}"` };
+  }
+  const [, , mo, d, h, mi] = m;
+  const month = Number.parseInt(mo, 10);
+  const day = Number.parseInt(d, 10);
+  const hour = Number.parseInt(h, 10);
+  const minute = Number.parseInt(mi, 10);
+  if (month < 1 || month > 12) return { valid: false, reason: `month out of range: ${month}` };
+  if (day < 1 || day > 31) return { valid: false, reason: `day out of range: ${day}` };
+  if (hour > 23) return { valid: false, reason: `hour out of range: ${hour}` };
+  if (minute > 59) return { valid: false, reason: `minute out of range: ${minute}` };
+  return { valid: true };
+}
+
+/** Convert a one-shot 'YYYY-MM-DD HH:MM' to a launchd `StartCalendarInterval` dict. Assumes input passed `validateAt`. */
+export function atToLaunchd(at: string): {
+  Year: number;
+  Month: number;
+  Day: number;
+  Hour: number;
+  Minute: number;
+} {
+  const m = at.match(AT_RE) as RegExpMatchArray;
+  const [, y, mo, d, h, mi] = m;
+  return {
+    Year: Number.parseInt(y, 10),
+    Month: Number.parseInt(mo, 10),
+    Day: Number.parseInt(d, 10),
+    Hour: Number.parseInt(h, 10),
+    Minute: Number.parseInt(mi, 10),
+  };
+}

--- a/src/lib/scheduler/cron-parse.ts
+++ b/src/lib/scheduler/cron-parse.ts
@@ -1,0 +1,34 @@
+// Field regex: supports digits, `*`, ranges (`-`), and lists (`,`). Step syntax (`*/N`) is not supported.
+const CRON_FIELD_RE = /^[\d*,\-/]+$/;
+
+export function validateCron(cron: string): { valid: boolean; reason?: string } {
+  const fields = cron.trim().split(/\s+/);
+  if (fields.length !== 5) {
+    return { valid: false, reason: `expected 5 fields, got ${fields.length}` };
+  }
+  for (const f of fields) {
+    if (!CRON_FIELD_RE.test(f)) {
+      return { valid: false, reason: `invalid field syntax: "${f}"` };
+    }
+  }
+  return { valid: true };
+}
+
+/** Convert a 5-field cron string to a launchd `StartCalendarInterval` dict. Assumes `cron` already passed `validateCron`. */
+export function cronFieldsToLaunchd(cron: string): {
+  Minute?: number;
+  Hour?: number;
+  Day?: number;
+  Month?: number;
+  Weekday?: number;
+} {
+  const [m, h, dom, mon, dow] = cron.trim().split(/\s+/);
+  const out: { Minute?: number; Hour?: number; Day?: number; Month?: number; Weekday?: number } =
+    {};
+  if (m !== '*') out.Minute = Number.parseInt(m, 10);
+  if (h !== '*') out.Hour = Number.parseInt(h, 10);
+  if (dom !== '*') out.Day = Number.parseInt(dom, 10);
+  if (mon !== '*') out.Month = Number.parseInt(mon, 10);
+  if (dow !== '*') out.Weekday = Number.parseInt(dow, 10);
+  return out;
+}

--- a/src/lib/scheduler/entry.test.ts
+++ b/src/lib/scheduler/entry.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from 'bun:test';
+import { isOneShot, validateEntry } from './entry';
+
+describe('isOneShot', () => {
+  test('returns true when at is set', () => {
+    expect(isOneShot({ at: '2026-05-13 14:30', skill: '/x' })).toBe(true);
+  });
+  test('returns false when at is undefined', () => {
+    expect(isOneShot({ cron: '0 9 * * *', skill: '/x' })).toBe(false);
+  });
+});
+
+describe('validateEntry', () => {
+  test('rejects when both cron and at are set', () => {
+    const r = validateEntry({ cron: '0 9 * * *', at: '2026-05-13 14:30', skill: '/x' });
+    expect(r.valid).toBe(false);
+    expect(r.reason).toContain('exactly one');
+  });
+  test('rejects when neither cron nor at is set', () => {
+    const r = validateEntry({ skill: '/x' });
+    expect(r.valid).toBe(false);
+    expect(r.reason).toContain('exactly one');
+  });
+  test('rejects when skill is empty', () => {
+    const r = validateEntry({ cron: '0 9 * * *', skill: '' });
+    expect(r.valid).toBe(false);
+    expect(r.reason).toContain('skill');
+  });
+  test('accepts cron-only entry', () => {
+    expect(validateEntry({ cron: '0 9 * * *', skill: '/daily' })).toEqual({ valid: true });
+  });
+  test('accepts at-only entry', () => {
+    expect(validateEntry({ at: '2026-05-13 14:30', skill: '/reminder' })).toEqual({ valid: true });
+  });
+});

--- a/src/lib/scheduler/entry.test.ts
+++ b/src/lib/scheduler/entry.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { isOneShot, validateEntry } from './entry';
+import { isOneShot, validateEntry } from './entry.js';
 
 describe('isOneShot', () => {
   test('returns true when at is set', () => {

--- a/src/lib/scheduler/entry.ts
+++ b/src/lib/scheduler/entry.ts
@@ -1,0 +1,15 @@
+import type { ScheduleEntry } from './types';
+
+export function isOneShot(entry: ScheduleEntry): entry is ScheduleEntry & { at: string } {
+  return entry.at !== undefined;
+}
+
+export function validateEntry(entry: ScheduleEntry): { valid: boolean; reason?: string } {
+  const hasCron = entry.cron !== undefined;
+  const hasAt = entry.at !== undefined;
+  if (hasCron === hasAt) {
+    return { valid: false, reason: 'entry must have exactly one of `cron` or `at`' };
+  }
+  if (!entry.skill) return { valid: false, reason: 'entry.skill is required' };
+  return { valid: true };
+}

--- a/src/lib/scheduler/entry.ts
+++ b/src/lib/scheduler/entry.ts
@@ -1,4 +1,4 @@
-import type { ScheduleEntry } from './types';
+import type { ScheduleEntry } from './types.js';
 
 export function isOneShot(entry: ScheduleEntry): entry is ScheduleEntry & { at: string } {
   return entry.at !== undefined;

--- a/src/lib/scheduler/launchd.test.ts
+++ b/src/lib/scheduler/launchd.test.ts
@@ -5,6 +5,8 @@ const ctx = {
   vaultPath: '/Users/test/vault',
   skillCliPath: '/usr/local/bin/claude-code',
   logBasePath: '/Users/test/vault/07-logs/scheduler/2026/05',
+  homedir: '/Users/test',
+  uid: 501,
 };
 
 describe('generatePlist', () => {
@@ -37,6 +39,33 @@ describe('generatePlist', () => {
   test('no blank line in <array> when args absent', () => {
     const out = generatePlist({ cron: '0 9 * * *', skill: '/daily' }, ctx);
     expect(out).not.toMatch(/<string>--headless<\/string>\n\n\s*<\/array>/);
+  });
+
+  test('one-shot plist emits Year/Month/Day/Hour/Minute', () => {
+    const out = generatePlist({ at: '2026-05-13 14:30', skill: '/reminder' }, { ...ctx, uid: 501 });
+    expect(out).toContain('<key>Year</key>\n        <integer>2026</integer>');
+    expect(out).toContain('<key>Month</key>\n        <integer>5</integer>');
+    expect(out).toContain('<key>Day</key>\n        <integer>13</integer>');
+    expect(out).toContain('<key>Hour</key>\n        <integer>14</integer>');
+    expect(out).toContain('<key>Minute</key>\n        <integer>30</integer>');
+  });
+
+  test('one-shot plist wraps command in self-delete shell', () => {
+    const out = generatePlist({ at: '2026-05-13 14:30', skill: '/reminder' }, { ...ctx, uid: 501 });
+    expect(out).toContain('<string>/bin/sh</string>');
+    expect(out).toContain('<string>-c</string>');
+    expect(out).toContain('launchctl bootout gui/501/com.onebrain.reminder');
+    expect(out).toContain('rm -f');
+  });
+
+  test('one-shot plist escapes XML in args inside wrapper', () => {
+    const out = generatePlist(
+      { at: '2026-05-13 14:30', skill: '/echo', args: { msg: 'a & b' } },
+      { ...ctx, uid: 501 },
+    );
+    // Shell line: --msg="a & b" — the whole line is XML-escaped once, so
+    // " → &quot; and & → &amp;, giving --msg=&quot;a &amp; b&quot;.
+    expect(out).toContain('--msg=&quot;a &amp; b&quot;');
   });
 });
 

--- a/src/lib/scheduler/launchd.test.ts
+++ b/src/lib/scheduler/launchd.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { generatePlist, plistPath } from './launchd';
+import { generatePlist, plistPath } from './launchd.js';
 
 const ctx = {
   vaultPath: '/Users/test/vault',

--- a/src/lib/scheduler/launchd.test.ts
+++ b/src/lib/scheduler/launchd.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from 'bun:test';
+import { generatePlist, plistPath } from './launchd';
+
+const ctx = {
+  vaultPath: '/Users/test/vault',
+  skillCliPath: '/usr/local/bin/claude-code',
+  logBasePath: '/Users/test/vault/07-logs/scheduler/2026/05',
+};
+
+describe('generatePlist', () => {
+  test('daily 9am /daily', () => {
+    const out = generatePlist({ cron: '0 9 * * *', skill: '/daily' }, ctx);
+    expect(out).toContain('<string>com.onebrain.daily</string>');
+    expect(out).toContain('<key>Hour</key>\n        <integer>9</integer>');
+    expect(out).toContain('<string>--skill</string>');
+    expect(out).toContain('<string>/daily</string>');
+    expect(out).toContain('<string>--headless</string>');
+  });
+
+  test('with args', () => {
+    const out = generatePlist(
+      { cron: '0 12 * * 0', skill: '/distill', args: { topic: 'this-week' } },
+      ctx,
+    );
+    expect(out).toContain('<string>--topic=this-week</string>');
+  });
+
+  test('escapes XML-sensitive chars in args', () => {
+    const out = generatePlist(
+      { cron: '0 9 * * *', skill: '/echo', args: { msg: 'a & b < c' } },
+      ctx,
+    );
+    expect(out).toContain('<string>--msg=a &amp; b &lt; c</string>');
+    expect(out).not.toContain('a & b'); // ensure raw chars are gone
+  });
+
+  test('no blank line in <array> when args absent', () => {
+    const out = generatePlist({ cron: '0 9 * * *', skill: '/daily' }, ctx);
+    expect(out).not.toMatch(/<string>--headless<\/string>\n\n\s*<\/array>/);
+  });
+});
+
+describe('plistPath', () => {
+  test('returns LaunchAgents path', () => {
+    expect(plistPath('/daily', '/Users/test')).toBe(
+      '/Users/test/Library/LaunchAgents/com.onebrain.daily.plist',
+    );
+  });
+});

--- a/src/lib/scheduler/launchd.ts
+++ b/src/lib/scheduler/launchd.ts
@@ -1,0 +1,59 @@
+import { cronFieldsToLaunchd } from './cron-parse';
+import type { ScheduleEntry } from './types';
+
+const xmlEscape = (s: string) =>
+  s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+
+interface LaunchdContext {
+  vaultPath: string;
+  skillCliPath: string;
+  logBasePath: string;
+}
+
+export function generatePlist(entry: ScheduleEntry, ctx: LaunchdContext): string {
+  const labelSafe = entry.skill.replace(/^\//, '').replace(/[^a-zA-Z0-9-]/g, '-');
+  const label = `com.onebrain.${labelSafe}`;
+  const calendar = cronFieldsToLaunchd(entry.cron);
+  const calendarXml = Object.entries(calendar)
+    .map(([k, v]) => `        <key>${k}</key>\n        <integer>${v}</integer>`)
+    .join('\n');
+
+  const argsBlock = entry.args
+    ? `\n${Object.entries(entry.args)
+        .map(([k, v]) => `        <string>--${k}=${xmlEscape(v)}</string>`)
+        .join('\n')}`
+    : '';
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>${xmlEscape(label)}</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>${xmlEscape(ctx.skillCliPath)}</string>
+        <string>--vault</string>
+        <string>${xmlEscape(ctx.vaultPath)}</string>
+        <string>--skill</string>
+        <string>${xmlEscape(entry.skill)}</string>
+        <string>--headless</string>${argsBlock}
+    </array>
+    <key>StartCalendarInterval</key>
+    <dict>
+${calendarXml}
+    </dict>
+    <key>StandardOutPath</key>
+    <string>${xmlEscape(ctx.logBasePath)}/onebrain-${labelSafe}.stdout</string>
+    <key>StandardErrorPath</key>
+    <string>${xmlEscape(ctx.logBasePath)}/onebrain-${labelSafe}.stderr</string>
+    <key>RunAtLoad</key>
+    <false/>
+</dict>
+</plist>`;
+}
+
+export function plistPath(skill: string, homedir: string): string {
+  const labelSafe = skill.replace(/^\//, '').replace(/[^a-zA-Z0-9-]/g, '-');
+  return `${homedir}/Library/LaunchAgents/com.onebrain.${labelSafe}.plist`;
+}

--- a/src/lib/scheduler/launchd.ts
+++ b/src/lib/scheduler/launchd.ts
@@ -1,4 +1,4 @@
-import { cronFieldsToLaunchd } from './cron-parse';
+import { atToLaunchd, cronFieldsToLaunchd } from './cron-parse';
 import type { ScheduleEntry } from './types';
 
 const xmlEscape = (s: string) =>
@@ -8,21 +8,56 @@ interface LaunchdContext {
   vaultPath: string;
   skillCliPath: string;
   logBasePath: string;
+  homedir: string;
+  uid: number;
 }
 
 export function generatePlist(entry: ScheduleEntry, ctx: LaunchdContext): string {
   const labelSafe = entry.skill.replace(/^\//, '').replace(/[^a-zA-Z0-9-]/g, '-');
   const label = `com.onebrain.${labelSafe}`;
-  const calendar = cronFieldsToLaunchd(entry.cron);
-  const calendarXml = Object.entries(calendar)
-    .map(([k, v]) => `        <key>${k}</key>\n        <integer>${v}</integer>`)
-    .join('\n');
 
-  const argsBlock = entry.args
-    ? `\n${Object.entries(entry.args)
-        .map(([k, v]) => `        <string>--${k}=${xmlEscape(v)}</string>`)
-        .join('\n')}`
-    : '';
+  let programArgumentsBlock: string;
+  let calendarXml: string;
+
+  if (entry.at !== undefined) {
+    const calendar = atToLaunchd(entry.at);
+    calendarXml = Object.entries(calendar)
+      .map(([k, v]) => `        <key>${k}</key>\n        <integer>${v}</integer>`)
+      .join('\n');
+
+    const plistFilePath = plistPath(entry.skill, ctx.homedir);
+    const argsFlags = entry.args
+      ? ` ${Object.entries(entry.args)
+          .map(([k, v]) => `--${k}="${v}"`)
+          .join(' ')}`
+      : '';
+    // Double-quote interpolated values in the shell line so sh handles spaces correctly.
+    // The entire assembled shell line is XML-escaped once for the plist <string>.
+    const shellLine = xmlEscape(
+      `"${ctx.skillCliPath}" --vault="${ctx.vaultPath}" --skill="${entry.skill}" --headless${argsFlags}; launchctl bootout gui/${ctx.uid}/${label}; rm -f "${plistFilePath}"`,
+    );
+    programArgumentsBlock = `        <string>/bin/sh</string>
+        <string>-c</string>
+        <string>${shellLine}</string>`;
+  } else {
+    const calendar = cronFieldsToLaunchd(entry.cron as string);
+    calendarXml = Object.entries(calendar)
+      .map(([k, v]) => `        <key>${k}</key>\n        <integer>${v}</integer>`)
+      .join('\n');
+
+    const argsBlock = entry.args
+      ? `\n${Object.entries(entry.args)
+          .map(([k, v]) => `        <string>--${k}=${xmlEscape(v)}</string>`)
+          .join('\n')}`
+      : '';
+
+    programArgumentsBlock = `        <string>${xmlEscape(ctx.skillCliPath)}</string>
+        <string>--vault</string>
+        <string>${xmlEscape(ctx.vaultPath)}</string>
+        <string>--skill</string>
+        <string>${xmlEscape(entry.skill)}</string>
+        <string>--headless</string>${argsBlock}`;
+  }
 
   return `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -32,12 +67,7 @@ export function generatePlist(entry: ScheduleEntry, ctx: LaunchdContext): string
     <string>${xmlEscape(label)}</string>
     <key>ProgramArguments</key>
     <array>
-        <string>${xmlEscape(ctx.skillCliPath)}</string>
-        <string>--vault</string>
-        <string>${xmlEscape(ctx.vaultPath)}</string>
-        <string>--skill</string>
-        <string>${xmlEscape(entry.skill)}</string>
-        <string>--headless</string>${argsBlock}
+${programArgumentsBlock}
     </array>
     <key>StartCalendarInterval</key>
     <dict>

--- a/src/lib/scheduler/launchd.ts
+++ b/src/lib/scheduler/launchd.ts
@@ -47,7 +47,7 @@ export function generatePlist(entry: ScheduleEntry, ctx: LaunchdContext): string
 
     const argsBlock = entry.args
       ? `\n${Object.entries(entry.args)
-          .map(([k, v]) => `        <string>--${k}=${xmlEscape(v)}</string>`)
+          .map(([k, v]) => `        <string>--${xmlEscape(k)}=${xmlEscape(v)}</string>`)
           .join('\n')}`
       : '';
 

--- a/src/lib/scheduler/launchd.ts
+++ b/src/lib/scheduler/launchd.ts
@@ -1,5 +1,5 @@
-import { atToLaunchd, cronFieldsToLaunchd } from './cron-parse';
-import type { ScheduleEntry } from './types';
+import { atToLaunchd, cronFieldsToLaunchd } from './cron-parse.js';
+import type { ScheduleEntry } from './types.js';
 
 const xmlEscape = (s: string) =>
   s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');

--- a/src/lib/scheduler/log-paths.test.ts
+++ b/src/lib/scheduler/log-paths.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from 'bun:test';
+import { schedulerLogPath } from './log-paths';
+
+describe('schedulerLogPath', () => {
+  test('success path', () => {
+    const out = schedulerLogPath('07-logs', new Date('2026-05-12T09:00:00'), '/daily', false);
+    expect(out).toBe('07-logs/scheduler/2026/05/2026-05-12-daily.md');
+  });
+
+  test('error path', () => {
+    const out = schedulerLogPath('07-logs', new Date('2026-05-12T09:00:00'), '/distill', true);
+    expect(out).toBe('07-logs/scheduler/2026/05/2026-05-12-distill.err.md');
+  });
+});

--- a/src/lib/scheduler/log-paths.test.ts
+++ b/src/lib/scheduler/log-paths.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { schedulerLogPath } from './log-paths';
+import { schedulerLogPath } from './log-paths.js';
 
 describe('schedulerLogPath', () => {
   test('success path', () => {

--- a/src/lib/scheduler/log-paths.ts
+++ b/src/lib/scheduler/log-paths.ts
@@ -1,0 +1,13 @@
+export function schedulerLogPath(
+  logsFolder: string,
+  date: Date,
+  skill: string,
+  isError: boolean,
+): string {
+  const yyyy = date.getFullYear().toString();
+  const mm = (date.getMonth() + 1).toString().padStart(2, '0');
+  const dd = date.getDate().toString().padStart(2, '0');
+  const skillSafe = skill.replace(/^\//, '');
+  const suffix = isError ? '.err.md' : '.md';
+  return `${logsFolder}/scheduler/${yyyy}/${mm}/${yyyy}-${mm}-${dd}-${skillSafe}${suffix}`;
+}

--- a/src/lib/scheduler/types.ts
+++ b/src/lib/scheduler/types.ts
@@ -1,5 +1,6 @@
 export interface ScheduleEntry {
-  cron: string;
+  cron?: string;
+  at?: string;
   skill: string;
   args?: Record<string, string>;
 }

--- a/src/lib/scheduler/types.ts
+++ b/src/lib/scheduler/types.ts
@@ -1,0 +1,16 @@
+export interface ScheduleEntry {
+  cron: string;
+  skill: string;
+  args?: Record<string, string>;
+}
+
+export interface ScheduleConfig {
+  schedule?: ScheduleEntry[];
+}
+
+export interface SkillFrontmatter {
+  name: string;
+  schedulable?: boolean;
+  schedulable_with_args?: boolean;
+  required_args?: string[];
+}


### PR DESCRIPTION
## Summary

OneBrain scheduler subsystem — launchd-backed local cron + one-shot. CLI v2.2.5 → 2.3.0, plugin v2.4.6 → 2.4.7.

- New CLI subcommand `onebrain register-schedule` (7 flags: `--dry-run`, `--remove`, `--refresh`, `--resume`, `--status`, `--test`, `--vault`)
- Recurring schedules via `cron:` (5-field) and one-shot via `at: "YYYY-MM-DD HH:MM"` in `vault.yml` `schedule:` block
- One-shot plists emit self-delete shell wrapper (`launchctl bootout` + `rm -f`)
- 4 new wizard skills under MAINTAIN tier: `/schedule-add` (recurring), `/schedule-once` (one-shot), `/schedule-list`, `/schedule-remove`
- All 26 user-facing skills declare `schedulable:` frontmatter (6 true · 4 schedulable_with_args · 16 false)
- `/doctor` extended with Scheduler Health checks: scheduler errors, 3+ consecutive failures, drift detection, expired one-shots
- INSTRUCTIONS.md adds "Scheduling — which tool to use" + "Headless invocation" sections (disambiguates vs Claude Code `/loop` and `/schedule`)
- README + CONTRIBUTING updated; skill count 25 → 29

## One-shot scheduling

Mid-PR scope addition (user-requested). Cleanly integrates without affecting recurring path:
- `ScheduleEntry.at?: string` field, mutually exclusive with `cron`
- `entry.ts` exports `isOneShot()` type guard + `validateEntry()` exactly-one-of guard
- `cron-parse.ts` adds `validateAt()` + `atToLaunchd()` (parses `YYYY-MM-DD HH:MM`)
- `launchd.ts` branches: cron → multi-element ProgramArguments; at → `[/bin/sh, -c, wrapper-line]` with embedded `launchctl bootout` + `rm -f`
- Wizard `/schedule-once` mirrors `/schedule-add` flow with datetime picker + past-time guard

## Security hardening

- All plist-interpolated values pass through `xmlEscape` (`& < > "`)
- Args values: reject `"`, `$`, backtick, `\` (shell-injection guard — `$VAR`/`$(cmd)`/backtick expand inside double-quotes under `/bin/sh -c`)
- Plist label collision detection: two entries normalizing to the same `com.onebrain.<label>.plist` are rejected before any disk write
- Cron field regex tightened to `^(\*|\d+)$` per field — ranges/lists/step syntax now rejected (launchd's StartCalendarInterval only accepts a single integer per field)

## Tests

- 39 new tests across `src/lib/scheduler/` + `src/commands/register-schedule.test.ts`
- All pass; typecheck clean; biome clean; bun build clean
- Pre-existing TTY-related failures in `init.test.ts`/`doctor.test.ts` not introduced by this PR (no files there modified — verifiable via `git diff origin/main..HEAD --name-only`)

## 3-round review consensus

- Round 1 (backend) — flagged cron regex overpermissive + shell injection ($/backtick) → fixed
- Round 2 (plugin content) — flagged `/schedule-list` JSON-vs-plain-text contract mismatch + auto-pause stub → fixed
- Round 3 (cross-cutting) — confirmed spec coverage E9.0–E9.4, memory rule compliance, version bump correctness; flagged stale CONTRIBUTING skill count + hardcoded `07-logs` (latter has TODO for follow-up)

## Known limitations / out of scope

- `07-logs` is hardcoded in `register-schedule.ts` (logBasePath + `.paused` marker path). Vaults using `folders.logs` override in `vault.yml` will write to default path. TODO comments in code; follow-up PR.
- Auto-pause after 3 consecutive failures is documented but not yet implemented in CLI — `/doctor` correctly flags consecutive failures, but the `.paused` marker isn't auto-created. Manual `--resume` works.
- `schedulerLogPath` and `validateSchedulable` don't sanitize against `..` traversal in skill names (low-risk; skill names come from validated frontmatter).
- macOS launchd only; Linux systemd-timer + Windows Task Scheduler deferred.

## Reminder for user (post-merge)

- `vault.yml` `schedule:` preset comments — Task 4.9 Step 2 deferred (vault-side, not repo)
- Tag `v2.3.0` after merge
- Run `/update` in vault to pick up new plugin + CLI

## Test plan

- [ ] `onebrain register-schedule --dry-run` prints valid plist for a `/daily` cron entry
- [ ] `onebrain register-schedule --dry-run` prints one-shot plist with Year/Month/Day/Hour/Minute + `launchctl bootout` + `rm -f` for an `at:` entry
- [ ] Schedulable validation: register-schedule rejects `/onboarding` (`schedulable: false`)
- [ ] `schedulable_with_args` validation: register-schedule rejects `/distill` without `topic` arg
- [ ] Shell-special chars (`"`, `$`, backtick, `\`) in args values are rejected with clear message
- [ ] `--status` lists registered entries tagged `[once]` or `[cron]`
- [ ] `/schedule-add` wizard end-to-end: vault.yml entry written + plist appears in `~/Library/LaunchAgents/`
- [ ] `/schedule-once` wizard end-to-end: one-shot entry written, plist self-deletes after firing
- [ ] `/doctor` reports scheduler health when `.err.md` files exist; flags drift and expired one-shots

Spec: \`01-projects/onebrain/shared/2026-05-11-oracle-borrows-design.md\` · E9 + E9.1–E9.4
Plan: \`01-projects/onebrain/shared/2026-05-12-oracle-borrows-implementation.md\` · PR 4 section (Tasks 4.1–4.13 + 4.3.5 + 4.7.5)