### PR TITLE
feat(scheduler): hook-style command mode for direct CLI scheduling (E15-A)

### DIFF
--- a/.claude/plugins/onebrain/.claude-plugin/plugin.json
+++ b/.claude/plugins/onebrain/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "onebrain",
-  "version": "2.4.7",
+  "version": "2.4.8",
   "description": "OneBrain — Where human and AI thinking become one. A powerful thinking partner powered by AI synergy.",
   "author": {
     "name": "OneBrain Contributors"

--- a/.claude/plugins/onebrain/INSTRUCTIONS.md
+++ b/.claude/plugins/onebrain/INSTRUCTIONS.md
@@ -415,6 +415,8 @@ schedule:
 
 Use skill mode for OneBrain workflows. Use command mode for CLI maintenance and generic binaries that don't have (or don't need) a skill wrapper.
 
+**Adding entries:** the `/schedule-add` wizard targets skill mode only. To add a command-mode entry, edit `vault.yml` directly and re-run `onebrain register-schedule`. The `/schedule-list` and `/schedule-remove` skills handle both modes transparently.
+
 ## Headless invocation
 
 Scheduled skills run via headless Claude Code: `claude --vault {VAULT} --skill /daily --headless`. The session loads MEMORY.md, vault.yml, MEMORY-INDEX.md as normal (SessionStart hook fires). PreToolUse, PostToolUse, Stop hooks fire as normal. PreCompact / PostCompact do not fire (sessions are too short).

--- a/.claude/plugins/onebrain/INSTRUCTIONS.md
+++ b/.claude/plugins/onebrain/INSTRUCTIONS.md
@@ -388,6 +388,33 @@ For interactive setup:
 
 For manual config: edit `vault.yml` `schedule:` block + run `onebrain register-schedule`.
 
+### Skill mode vs command mode
+
+`vault.yml` `schedule:` entries support two coexisting modes:
+
+- **Skill mode** (`skill: /daily`) — invokes a OneBrain skill via headless Claude Code. Args use map form: `args: { key: value }` (emitted as `--key=value` flags). Requires the skill's frontmatter to declare `schedulable: true` (or `schedulable_with_args: true` with `required_args`).
+- **Command mode** (`command: onebrain`) — invokes any CLI binary directly using the same `command + args[]` shape as Claude Code hooks (`settings.json`). Args use string array: `args: [arg1, arg2]` (positional argv). No frontmatter validation; trust model matches hooks.
+
+Example:
+
+```yaml
+schedule:
+  - cron: "0 9 * * *"
+    skill: /daily
+  - cron: "0 9 * * *"
+    skill: /distill
+    args:
+      topic: this-week
+  - cron: "0 3 * * 0"
+    command: onebrain
+    args: [qmd-reindex]
+  - cron: "0 5 * * *"
+    command: rsync
+    args: [-av, /vault, /backup]
+```
+
+Use skill mode for OneBrain workflows. Use command mode for CLI maintenance and generic binaries that don't have (or don't need) a skill wrapper.
+
 ## Headless invocation
 
 Scheduled skills run via headless Claude Code: `claude --vault {VAULT} --skill /daily --headless`. The session loads MEMORY.md, vault.yml, MEMORY-INDEX.md as normal (SessionStart hook fires). PreToolUse, PostToolUse, Stop hooks fire as normal. PreCompact / PostCompact do not fire (sessions are too short).

--- a/.claude/plugins/onebrain/skills/schedule-list/SKILL.md
+++ b/.claude/plugins/onebrain/skills/schedule-list/SKILL.md
@@ -41,7 +41,7 @@ This emits plain text (not JSON). Each line is one entry with the `[cron]` or `[
 
 The CLI does not track last-run, next-run, or last-status — that detail is in `[logs_folder]/scheduler/YYYY/MM/`.
 
-If `onebrain register-schedule --status` is unavailable or fails: fall back to checking launchd plist existence in `~/Library/LaunchAgents/` for each entry. Compute the plist filename as `com.onebrain.<labelSafe>.plist` where `labelSafe` is the binary name (for command mode) or the skill name with leading slash stripped (for skill mode), with non-alphanumeric characters replaced by `-`.
+If `onebrain register-schedule --status` is unavailable or fails: fall back to checking launchd plist existence in `~/Library/LaunchAgents/` for each entry. Compute the plist filename as `com.onebrain.<labelSafe>.plist` where `labelSafe` is the binary name (for command mode) or the skill name with leading slash stripped (for skill mode), with non-alphanumeric, non-hyphen characters replaced by `-`.
 
 ### Step 3: Format output
 

--- a/.claude/plugins/onebrain/skills/schedule-list/SKILL.md
+++ b/.claude/plugins/onebrain/skills/schedule-list/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: schedule-list
-description: Show all scheduled OneBrain skills with their cron schedule and last/next run times.
+description: Show all scheduled OneBrain entries (skills + CLI commands) with cron/at expressions and installed-on-disk status.
 schedulable: false
 ---
 
-# /schedule-list — Show scheduled skills
+# /schedule-list — Show scheduled entries
 
 ## Purpose
 
-Display a formatted summary of all skills currently registered in the `schedule:` block of vault.yml, enriched with last-run and next-run information from launchd or the scheduler state file.
+Display a formatted summary of all entries currently registered in the `schedule:` block of vault.yml. Both skill-mode entries (`skill: /daily`) and command-mode entries (`command: onebrain` + `args: [...]`) are shown side by side, with installed-on-disk status from launchd.
 
 ---
 
@@ -21,7 +21,7 @@ Read vault.yml from the vault root. Locate the `schedule:` block.
 If vault.yml does not exist or has no `schedule:` block, or the block is empty:
 
 ```
-No scheduled skills found.
+No scheduled entries found.
 
 → Run /schedule-add to set one up.
 ```
@@ -30,44 +30,54 @@ Stop.
 
 ### Step 2: Fetch status
 
-Read the `schedule:` block from vault.yml directly to get the cron/at expression and skill name for each entry.
+Read the `schedule:` block from vault.yml directly to get the cron/at expression and `skill`/`command` field for each entry.
 
 Optionally run from the vault root:
 ```
 onebrain register-schedule --status
 ```
 
-This emits plain text (not JSON). Parse line-by-line to extract the installed-on-disk marker (`✓` = plist exists on disk, `✗` = plist missing) for each entry. The CLI does not track last-run, next-run, or last-status — that detail is in `[logs_folder]/scheduler/YYYY/MM/`.
+This emits plain text (not JSON). Each line is one entry with the `[cron]` or `[once]` tag, the cron/at value, and either `skill: /name (k=v, k2=v2)` (skill mode with optional args) or `cmd: binary arg1 arg2` (command mode with positional argv). The `✓` / `✗` prefix indicates whether the plist file exists on disk.
 
-If `onebrain register-schedule --status` is unavailable or fails: fall back to checking launchd plist existence in `~/Library/LaunchAgents/` for each entry. If neither source is available, show only the cron/at expressions from vault.yml and omit the installed-status column.
+The CLI does not track last-run, next-run, or last-status — that detail is in `[logs_folder]/scheduler/YYYY/MM/`.
+
+If `onebrain register-schedule --status` is unavailable or fails: fall back to checking launchd plist existence in `~/Library/LaunchAgents/` for each entry. Compute the plist filename as `com.onebrain.<labelSafe>.plist` where `labelSafe` is the binary name (for command mode) or the skill name with leading slash stripped (for skill mode), with non-alphanumeric characters replaced by `-`.
 
 ### Step 3: Format output
 
 Print the schedule table:
 
 ```
-📅 Scheduled skills:
+📅 Scheduled entries:
 
-  ✓ 0 9 * * *      /daily         (installed)
-  ✓ 0 18 * * 5     /weekly        (installed)
-  ✗ 0 12 * * 0     /recap         (plist missing — re-run /schedule-add)
+  ✓ [cron] 0 9 * * *      skill: /daily
+  ✓ [cron] 0 17 * * 5     skill: /weekly
+  ✓ [cron] 0 12 * * 0     skill: /recap
+  ✓ [cron] 0 9 * * *      skill: /distill (topic=this-week)
+  ✓ [cron] 0 3 * * 0      cmd: onebrain qmd-reindex
+  ✓ [cron] 0 5 * * *      cmd: rsync -av /vault /backup
+  ✓ [once] 2026-05-13 14:30  skill: /reminder
+  ✗ [cron] 0 18 * * 5     skill: /weekly (plist missing — re-run /schedule-add)
 ```
 
 Column layout:
 - Installed icon: `✓` = plist on disk, `✗` = plist missing
-- Cron or at expression (left-padded to align)
-- Skill name
-- Installed status note
+- Tag: `[cron]` (recurring) or `[once]` (one-shot at fires once then auto-deletes)
+- Cron or at expression (left-padded to align across the table)
+- Entry target:
+  - **Skill mode:** `skill: <skill-name>` with optional `(key=value, key2=value2)` when `args:` is a map
+  - **Command mode:** `cmd: <binary> <arg1> <arg2>` with positional argv joined by spaces
+- Installed status note when `✗` (plist missing)
 
 Detailed run history (stdout, stderr, error files) lives in `[logs_folder]/scheduler/YYYY/MM/`.
 
 ### Step 4: Surface errors
 
 If `✗` entries are found:
-- Append a hint line below the table: `→ Run /schedule-add to re-register missing entries`
+- Append a hint line below the table: `→ Run /schedule-add to re-register missing entries` (or for command-mode entries, `→ Re-run onebrain register-schedule to re-emit plists`)
 
 For error log detail:
-- Append: `→ See [logs_folder]/scheduler/YYYY/MM/YYYY-MM-DD-{skill}.err.md for failure details`
+- Append: `→ See [logs_folder]/scheduler/YYYY/MM/YYYY-MM-DD-{label}.err.md for failure details` where `{label}` is the skill name or command binary name.
 
 Note: auto-pause-on-failure (⏸ paused after 3 consecutive failures) is not yet implemented in the CLI. The marker file mechanism is planned for a future release. `/doctor` currently flags 3+ consecutive `.err.md` files as CRITICAL — use that for failure monitoring.
 
@@ -75,9 +85,12 @@ Note: auto-pause-on-failure (⏸ paused after 3 consecutive failures) is not yet
 
 After the table, append:
 ```
-→ /schedule-add   add a new scheduled skill
-→ /schedule-remove   remove an entry
+→ /schedule-add     add a new scheduled entry (skill mode wizard)
+→ /schedule-once    schedule a one-shot reminder
+→ /schedule-remove  remove an entry
 ```
+
+For command-mode entries: note that the `/schedule-add` wizard targets skill mode only — command entries are added by editing `vault.yml` directly and running `onebrain register-schedule`.
 
 ---
 
@@ -87,3 +100,4 @@ After the table, append:
 - **Status command unavailable** — graceful fallback to vault.yml data only (Step 2).
 - **Partial status** — some entries return status, others don't; show what's available and mark unknowns as `(unknown)`.
 - **Cron alignment** — pad cron columns to the longest expression in the list for readable alignment.
+- **Mixed skill + command** — display both interleaved per original `schedule:` order; do not sort or group by mode.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-latest_version: 2.3.0
+latest_version: 2.3.1
 released: 2026-05-12
 ---
 
@@ -12,6 +12,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 > For plugin changes (skills, agents, hooks, INSTRUCTIONS), see [PLUGIN-CHANGELOG.md](PLUGIN-CHANGELOG.md).
 
 ## [Unreleased]
+
+## v2.3.1 — feat(scheduler): hook-style command mode for direct CLI scheduling
+
+- `ScheduleEntry.command` field added: schedule any CLI binary using the same `command + args[]` shape as Claude Code hooks
+- `args` is now `Record<string, string>` (skill mode → `--key=value` flags) OR `string[]` (command mode → positional argv)
+- `validateEntry` enforces exactly-one-of(skill, command) + matching args shape; type guards `isSkillMode` / `isCommandMode` exported
+- One-shot command entries reject shell-special chars in args (`"`, `$`, backtick, `\`) — same guard as v2.3.0
+- `register-schedule --status` displays command entries as `cmd: <binary> <args>` and skill entries with inline `(key=value)` args
+- Collision detection extended: skill and command entries derive plist labels independently; conflicts reported with mode-tagged names
+- Zero breaking change to existing skill-mode entries — full v2.3.0 test suite passes without modification
 
 ## v2.3.0 — feat(scheduler): OneBrain scheduler — launchd-backed recurring + one-shot schedules (E9)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -174,6 +174,19 @@ Errors write to `[logs_folder]/scheduler/YYYY/MM/YYYY-MM-DD-{skill}.err.md` (onl
 
 Use `cron:` for recurring schedules and `at:` for one-shot fire-once-then-uninstall entries. Exactly one must be set per entry. The launchd plist for one-shot entries emits a self-delete shell wrapper that runs the skill, calls `launchctl bootout`, and deletes its own plist file.
 
+### Don't wrap CLI tasks in skills
+
+If you have a CLI maintenance task (e.g., `onebrain qmd-reindex`), do NOT create a thin wrapper skill just to make it schedulable. Use command mode in `vault.yml` instead:
+
+```yaml
+schedule:
+  - cron: "0 3 * * 0"
+    command: onebrain
+    args: [qmd-reindex]
+```
+
+Command mode matches the Claude Code hook shape — single source of pattern across event-driven (hooks) and time-driven (schedules) automation.
+
 ## Editing an Existing Skill
 
 - Keep the frontmatter intact

--- a/PLUGIN-CHANGELOG.md
+++ b/PLUGIN-CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-latest_version: 2.4.7
+latest_version: 2.4.8
 released: 2026-05-12
 ---
 
@@ -10,6 +10,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 > **Versioning:** Plugin version is tracked in `plugin.json`. Bump when ANY harness config changes — skills, agents, hooks, INSTRUCTIONS, Gemini settings, slash commands, etc.
 > For CLI binary (`@onebrain-ai/cli`) changes, see [CHANGELOG.md](CHANGELOG.md).
+
+## 2.4.8 — 2026-05-12
+
+- `/schedule-list` displays both skill-mode (`skill: /name (k=v)`) and command-mode (`cmd: binary arg1 arg2`) entries
+- INSTRUCTIONS.md adds "Skill mode vs command mode" subsection with full YAML example
+- README + CONTRIBUTING document command mode as alternative to thin wrapper skills
+- Companion to CLI v2.3.1 which introduces the command-mode backend
 
 ## 2.4.7 — 2026-05-12
 

--- a/README.md
+++ b/README.md
@@ -528,6 +528,22 @@ Or use the interactive wizards from inside your vault:
 
 Output goes to `[logs_folder]/scheduler/YYYY/MM/YYYY-MM-DD-{skill}.md` as readable markdown.
 
+### Command mode (CLI binaries, hook-style)
+
+For CLI maintenance tasks that aren't OneBrain skills, use the `command + args[]` shape:
+
+```yaml
+schedule:
+  - cron: "0 3 * * 0"
+    command: onebrain
+    args: [qmd-reindex]
+  - cron: "0 5 * * *"
+    command: rsync
+    args: [-av, /vault, /backup]
+```
+
+This matches the same shape Claude Code uses for `hooks` in `settings.json` — direct binary invocation with positional argv. No wrapper skill needed.
+
 CLI flags:
 
 | Flag | Purpose |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onebrain-ai/cli",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "CLI for OneBrain — personal AI OS for Obsidian with persistent memory, 24+ skills, and Claude Code integration",
   "keywords": [
     "onebrain",

--- a/src/commands/register-schedule.test.ts
+++ b/src/commands/register-schedule.test.ts
@@ -120,6 +120,114 @@ describe('registerSchedule', () => {
   });
 });
 
+describe('registerSchedule — command mode', () => {
+  test('--dry-run produces plist with command + argv', async () => {
+    writeFileSync(
+      join(testVault, 'vault.yml'),
+      `schedule:\n  - cron: "0 3 * * 0"\n    command: onebrain\n    args:\n      - qmd-reindex\n`,
+    );
+    const captured = captureConsoleLog();
+    try {
+      await registerSchedule({ vault: testVault, dryRun: true });
+      const joined = captured.lines().join('\n');
+      expect(joined).toContain('<string>onebrain</string>');
+      expect(joined).toContain('<string>qmd-reindex</string>');
+      expect(joined).not.toContain('<string>--skill</string>');
+    } finally {
+      captured.restore();
+    }
+  });
+
+  test('command entry skips schedulable validation', async () => {
+    writeFileSync(
+      join(testVault, 'vault.yml'),
+      `schedule:\n  - cron: "0 3 * * 0"\n    command: nonexistent-binary\n    args:\n      - foo\n`,
+    );
+    await expect(registerSchedule({ vault: testVault, dryRun: true })).resolves.toBeUndefined();
+  });
+
+  test('--status shows command entries with cmd: prefix and joined argv', async () => {
+    writeFileSync(
+      join(testVault, 'vault.yml'),
+      `schedule:\n  - cron: "0 9 * * *"\n    skill: /daily\n  - cron: "0 3 * * 0"\n    command: onebrain\n    args: [qmd-reindex]\n`,
+    );
+    const captured = captureConsoleLog();
+    try {
+      await registerSchedule({ vault: testVault, status: true });
+      const plain = stripAnsi(captured.lines().join('\n'));
+      expect(plain).toContain('Registered schedules: 2');
+      expect(plain).toContain('skill: /daily');
+      expect(plain).toContain('cmd: onebrain qmd-reindex');
+    } finally {
+      captured.restore();
+    }
+  });
+
+  test('--status shows skill args inline when present', async () => {
+    mkdirSync(join(testVault, '.claude/plugins/onebrain/skills/distill'), { recursive: true });
+    writeFileSync(
+      join(testVault, '.claude/plugins/onebrain/skills/distill/SKILL.md'),
+      '---\nname: distill\nschedulable_with_args: true\nrequired_args: [topic]\n---\n',
+    );
+    writeFileSync(
+      join(testVault, 'vault.yml'),
+      `schedule:\n  - cron: "0 9 * * *"\n    skill: /distill\n    args:\n      topic: this-week\n`,
+    );
+    const captured = captureConsoleLog();
+    try {
+      await registerSchedule({ vault: testVault, status: true });
+      const plain = stripAnsi(captured.lines().join('\n'));
+      expect(plain).toContain('skill: /distill (topic=this-week)');
+    } finally {
+      captured.restore();
+    }
+  });
+
+  test('one-shot command rejects shell-special chars', async () => {
+    writeFileSync(
+      join(testVault, 'vault.yml'),
+      `schedule:\n  - at: "2026-05-13 14:30"\n    command: onebrain\n    args:\n      - "$EVIL"\n`,
+    );
+    await expect(registerSchedule({ vault: testVault, dryRun: true })).rejects.toThrow(
+      /shell-special/,
+    );
+  });
+
+  test('mixed skill + command in same vault.yml — both register', async () => {
+    writeFileSync(
+      join(testVault, 'vault.yml'),
+      `schedule:\n  - cron: "0 9 * * *"\n    skill: /daily\n  - cron: "0 3 * * 0"\n    command: onebrain\n    args: [qmd-reindex]\n`,
+    );
+    const captured = captureConsoleLog();
+    try {
+      await registerSchedule({ vault: testVault, dryRun: true });
+      const joined = captured.lines().join('\n');
+      expect(joined).toContain('com.onebrain.daily');
+      expect(joined).toContain('com.onebrain.onebrain');
+    } finally {
+      captured.restore();
+    }
+  });
+
+  test('collision: skill /onebrain and command onebrain rejected', async () => {
+    mkdirSync(join(testVault, '.claude/plugins/onebrain/skills/onebrain'), { recursive: true });
+    writeFileSync(
+      join(testVault, '.claude/plugins/onebrain/skills/onebrain/SKILL.md'),
+      '---\nname: onebrain\nschedulable: true\n---\n',
+    );
+    writeFileSync(
+      join(testVault, 'vault.yml'),
+      `schedule:\n  - cron: "0 9 * * *"\n    skill: /onebrain\n  - cron: "0 3 * * 0"\n    command: onebrain\n`,
+    );
+    await expect(registerSchedule({ vault: testVault, dryRun: true })).rejects.toThrow(
+      /Conflict.*normalize to the same plist path/,
+    );
+  });
+});
+
+// biome-ignore lint/suspicious/noControlCharactersInRegex: stripping ANSI escape sequences
+const stripAnsi = (s: string) => s.replace(/\x1b\[[0-9;]*m/g, '');
+
 function captureConsoleLog() {
   const original = console.log;
   const lines: string[] = [];

--- a/src/commands/register-schedule.ts
+++ b/src/commands/register-schedule.ts
@@ -167,9 +167,9 @@ async function validateSchedulable(vault: string, entry: ScheduleEntry): Promise
     throw new Error(`Skill ${entry.skill} does not declare schedulable: true in frontmatter`);
   }
 
-  // Reject shell-special chars in args values for skill mode: the one-shot shell wrapper
-  // interpolates arg values into a sh -c "..." string, and recurring mode's plist generator
-  // also embeds arg values. Reject early here to provide a clear error message.
+  // Reject shell-special chars in args values for recurring skill mode: the plist generator
+  // embeds arg values as --key=value strings inside a sh -c "..." wrapper. One-shot entries
+  // are checked earlier by sanitizeArgsForOneShot before generatePlist is called.
   if (entry.args) {
     for (const [k, v] of Object.entries(entry.args as Record<string, string>)) {
       if (/["$`\\]/.test(v)) {

--- a/src/commands/register-schedule.ts
+++ b/src/commands/register-schedule.ts
@@ -5,8 +5,8 @@ import { join } from 'node:path';
 import pc from 'picocolors';
 import { parse as parseYaml } from 'yaml';
 import { validateAt, validateCron } from '../lib/scheduler/cron-parse.js';
-import { isOneShot, validateEntry } from '../lib/scheduler/entry.js';
-import { generatePlist, plistPath } from '../lib/scheduler/launchd.js';
+import { isCommandMode, isOneShot, isSkillMode, validateEntry } from '../lib/scheduler/entry.js';
+import { generatePlist, labelForEntry, plistPath } from '../lib/scheduler/launchd.js';
 import type { ScheduleConfig, ScheduleEntry, SkillFrontmatter } from '../lib/scheduler/types.js';
 
 export interface RegisterScheduleOptions {
@@ -37,18 +37,24 @@ export async function registerSchedule(opts: RegisterScheduleOptions): Promise<v
     return;
   }
 
-  // Validate each entry (exactly-one-of cron/at, plus the corresponding format)
+  // Validate each entry (exactly-one-of cron/at + skill/command, plus format checks)
   for (const entry of entries) {
     const ve = validateEntry(entry);
     if (!ve.valid) throw new Error(`Invalid schedule entry: ${ve.reason}`);
+
     if (isOneShot(entry)) {
       const va = validateAt(entry.at);
       if (!va.valid) throw new Error(`Invalid at "${entry.at}": ${va.reason}`);
+      sanitizeArgsForOneShot(entry);
     } else if (entry.cron !== undefined) {
       const vc = validateCron(entry.cron);
       if (!vc.valid) throw new Error(`Invalid cron "${entry.cron}": ${vc.reason}`);
     }
-    await validateSchedulable(opts.vault, entry);
+
+    if (isSkillMode(entry)) {
+      await validateSchedulable(opts.vault, entry);
+    }
+    // Command mode: no schedulable-frontmatter validation (hook-style trust model)
   }
 
   // TODO: resolve the real `onebrain` binary path for production use.
@@ -74,18 +80,25 @@ export async function registerSchedule(opts: RegisterScheduleOptions): Promise<v
   // Collision detection: two entries normalizing to the same plist path conflict
   const seen = new Map<string, ScheduleEntry>();
   for (const entry of entries) {
-    const target = plistPath(entry.skill, ctx.homedir);
+    const target = plistPath(labelForEntry(entry), ctx.homedir);
     if (seen.has(target)) {
-      throw new Error(
-        `Conflict: ${entry.skill} and ${seen.get(target)?.skill} normalize to the same plist path ${target}`,
-      );
+      const existing = seen.get(target);
+      if (existing) {
+        const existingLabel = isCommandMode(existing)
+          ? `command:${existing.command}`
+          : `skill:${existing.skill}`;
+        const newLabel = isCommandMode(entry) ? `command:${entry.command}` : `skill:${entry.skill}`;
+        throw new Error(
+          `Conflict: ${newLabel} and ${existingLabel} normalize to the same plist path ${target}`,
+        );
+      }
     }
     seen.set(target, entry);
   }
 
   for (const entry of entries) {
     const plistContent = generatePlist(entry, ctx);
-    const targetPath = plistPath(entry.skill, ctx.homedir);
+    const targetPath = plistPath(labelForEntry(entry), ctx.homedir);
 
     if (opts.dryRun) {
       console.log(pc.cyan(`---  ${targetPath}  ---`));
@@ -100,7 +113,7 @@ export async function registerSchedule(opts: RegisterScheduleOptions): Promise<v
   console.log(pc.green(`\nRegistered ${entries.length} schedule entries.`));
   console.log(pc.dim('Use launchctl to load (or restart launchd):'));
   for (const entry of entries) {
-    const target = plistPath(entry.skill, ctx.homedir);
+    const target = plistPath(labelForEntry(entry), ctx.homedir);
     console.log(pc.dim(`  launchctl load ${target}`));
   }
 }
@@ -112,7 +125,21 @@ async function readVaultConfig(vault: string): Promise<ScheduleConfig> {
   return (parseYaml(raw) ?? {}) as ScheduleConfig;
 }
 
+function sanitizeArgsForOneShot(entry: ScheduleEntry): void {
+  const values: string[] = isCommandMode(entry)
+    ? ((entry.args as string[] | undefined) ?? [])
+    : Object.values((entry.args as Record<string, string> | undefined) ?? {});
+  for (const v of values) {
+    if (/["$`\\]/.test(v)) {
+      throw new Error(`Arg value must not contain shell-special chars (", $, \`, \\): ${v}`);
+    }
+  }
+}
+
 async function validateSchedulable(vault: string, entry: ScheduleEntry): Promise<void> {
+  if (!entry.skill) {
+    throw new Error('validateSchedulable invoked on non-skill entry — caller bug');
+  }
   const skillName = entry.skill.replace(/^\//, '');
   const skillPath = join(vault, '.claude/plugins/onebrain/skills', skillName, 'SKILL.md');
   if (!existsSync(skillPath)) {
@@ -131,7 +158,7 @@ async function validateSchedulable(vault: string, entry: ScheduleEntry): Promise
   }
   if (fm.schedulable_with_args) {
     const required = fm.required_args ?? [];
-    const provided = Object.keys(entry.args ?? {});
+    const provided = Object.keys((entry.args as Record<string, string> | undefined) ?? {});
     const missing = required.filter((r) => !provided.includes(r));
     if (missing.length > 0) {
       throw new Error(`Skill ${entry.skill} requires args: [${missing.join(', ')}]`);
@@ -140,14 +167,14 @@ async function validateSchedulable(vault: string, entry: ScheduleEntry): Promise
     throw new Error(`Skill ${entry.skill} does not declare schedulable: true in frontmatter`);
   }
 
-  // Reject shell-special chars in args values: the one-shot shell wrapper interpolates
-  // arg values into a sh -c "..." string, so double-quote, $, backtick, and backslash
-  // can execute arbitrary commands or break the generated shell command.
+  // Reject shell-special chars in args values for skill mode: the one-shot shell wrapper
+  // interpolates arg values into a sh -c "..." string, and recurring mode's plist generator
+  // also embeds arg values. Reject early here to provide a clear error message.
   if (entry.args) {
-    for (const [k, v] of Object.entries(entry.args)) {
+    for (const [k, v] of Object.entries(entry.args as Record<string, string>)) {
       if (/["$`\\]/.test(v)) {
         throw new Error(
-          `Arg "${k}" value must not contain shell-special chars (", $, backtick, \\): ${v}`,
+          `Arg "${k}" value must not contain shell-special chars (", $, \`, \\): ${v}`,
         );
       }
     }
@@ -158,7 +185,7 @@ async function removeAll(vault: string): Promise<void> {
   const config = await readVaultConfig(vault);
   const entries = config.schedule ?? [];
   for (const entry of entries) {
-    const target = plistPath(entry.skill, homedir());
+    const target = plistPath(labelForEntry(entry), homedir());
     if (existsSync(target)) {
       await unlink(target);
       console.log(pc.green(`✓ Removed ${target}`));
@@ -171,11 +198,26 @@ async function printStatus(vault: string): Promise<void> {
   const entries = config.schedule ?? [];
   console.log(pc.cyan(`Registered schedules: ${entries.length}`));
   for (const entry of entries) {
-    const target = plistPath(entry.skill, homedir());
+    const target = plistPath(labelForEntry(entry), homedir());
     const installed = existsSync(target) ? '✓' : '✗';
     const when = entry.at ?? entry.cron ?? '?';
     const tag = entry.at ? pc.magenta('[once]') : pc.dim('[cron]');
-    console.log(`  ${installed} ${tag} ${when}  ${entry.skill}`);
+
+    let targetLabel: string;
+    if (isCommandMode(entry)) {
+      const argv = (entry.args as string[] | undefined) ?? [];
+      const argStr = argv.length ? ` ${argv.join(' ')}` : '';
+      targetLabel = `${pc.yellow('cmd:')} ${entry.command}${argStr}`;
+    } else {
+      const argsMap = (entry.args as Record<string, string> | undefined) ?? {};
+      const argStr = Object.keys(argsMap).length
+        ? ` (${Object.entries(argsMap)
+            .map(([k, v]) => `${k}=${v}`)
+            .join(', ')})`
+        : '';
+      targetLabel = `${pc.green('skill:')} ${entry.skill}${argStr}`;
+    }
+    console.log(`  ${installed} ${tag} ${when}  ${targetLabel}`);
   }
 }
 

--- a/src/lib/scheduler/entry.test.ts
+++ b/src/lib/scheduler/entry.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { isOneShot, validateEntry } from './entry.js';
+import { isCommandMode, isOneShot, isSkillMode, validateEntry } from './entry.js';
 
 describe('isOneShot', () => {
   test('returns true when at is set', () => {
@@ -31,5 +31,59 @@ describe('validateEntry', () => {
   });
   test('accepts at-only entry', () => {
     expect(validateEntry({ at: '2026-05-13 14:30', skill: '/reminder' })).toEqual({ valid: true });
+  });
+});
+
+describe('isSkillMode / isCommandMode', () => {
+  test('isSkillMode true for skill entry', () => {
+    expect(isSkillMode({ cron: '0 9 * * *', skill: '/daily' })).toBe(true);
+  });
+  test('isSkillMode false for command entry', () => {
+    expect(isSkillMode({ cron: '0 9 * * *', command: 'onebrain' })).toBe(false);
+  });
+  test('isCommandMode true for command entry', () => {
+    expect(isCommandMode({ cron: '0 9 * * *', command: 'onebrain' })).toBe(true);
+  });
+  test('isCommandMode false for skill entry', () => {
+    expect(isCommandMode({ cron: '0 9 * * *', skill: '/daily' })).toBe(false);
+  });
+});
+
+describe('validateEntry — command mode', () => {
+  test('accepts command-only entry with array args', () => {
+    expect(
+      validateEntry({ cron: '0 3 * * 0', command: 'onebrain', args: ['qmd-reindex'] }),
+    ).toEqual({ valid: true });
+  });
+  test('accepts command-only entry with no args', () => {
+    expect(validateEntry({ cron: '0 3 * * 0', command: 'onebrain' })).toEqual({ valid: true });
+  });
+  test('rejects both skill and command set', () => {
+    const r = validateEntry({ cron: '0 9 * * *', skill: '/daily', command: 'onebrain' });
+    expect(r.valid).toBe(false);
+    expect(r.reason).toContain('exactly one of `skill` or `command`');
+  });
+  test('rejects neither skill nor command set', () => {
+    const r = validateEntry({ cron: '0 9 * * *' });
+    expect(r.valid).toBe(false);
+    expect(r.reason).toContain('exactly one of `skill` or `command`');
+  });
+  test('rejects skill mode with array args', () => {
+    const r = validateEntry({
+      cron: '0 9 * * *',
+      skill: '/daily',
+      args: ['x'] as unknown as Record<string, string>,
+    });
+    expect(r.valid).toBe(false);
+    expect(r.reason).toContain('skill-mode');
+  });
+  test('rejects command mode with map args', () => {
+    const r = validateEntry({
+      cron: '0 9 * * *',
+      command: 'onebrain',
+      args: { k: 'v' } as unknown as string[],
+    });
+    expect(r.valid).toBe(false);
+    expect(r.reason).toContain('command-mode');
   });
 });

--- a/src/lib/scheduler/entry.ts
+++ b/src/lib/scheduler/entry.ts
@@ -4,12 +4,56 @@ export function isOneShot(entry: ScheduleEntry): entry is ScheduleEntry & { at: 
   return entry.at !== undefined;
 }
 
+export function isSkillMode(entry: ScheduleEntry): entry is ScheduleEntry & { skill: string } {
+  return entry.skill !== undefined;
+}
+
+export function isCommandMode(entry: ScheduleEntry): entry is ScheduleEntry & { command: string } {
+  return entry.command !== undefined;
+}
+
 export function validateEntry(entry: ScheduleEntry): { valid: boolean; reason?: string } {
   const hasCron = entry.cron !== undefined;
   const hasAt = entry.at !== undefined;
   if (hasCron === hasAt) {
     return { valid: false, reason: 'entry must have exactly one of `cron` or `at`' };
   }
-  if (!entry.skill) return { valid: false, reason: 'entry.skill is required' };
+
+  const hasSkill = entry.skill !== undefined;
+  const hasCommand = entry.command !== undefined;
+  if (hasSkill === hasCommand) {
+    return { valid: false, reason: 'entry must have exactly one of `skill` or `command`' };
+  }
+
+  if (hasSkill && !entry.skill) {
+    return { valid: false, reason: 'entry.skill must not be empty' };
+  }
+  if (hasCommand && !entry.command) {
+    return { valid: false, reason: 'entry.command must not be empty' };
+  }
+
+  if (entry.args !== undefined) {
+    const isArray = Array.isArray(entry.args);
+    if (hasSkill && isArray) {
+      return {
+        valid: false,
+        reason: 'skill-mode entries require `args` as a map (Record<string, string>), not an array',
+      };
+    }
+    if (hasCommand && !isArray) {
+      return {
+        valid: false,
+        reason: 'command-mode entries require `args` as a string array, not a map',
+      };
+    }
+    if (isArray) {
+      for (const v of entry.args as string[]) {
+        if (typeof v !== 'string') {
+          return { valid: false, reason: 'command-mode `args` must contain only strings' };
+        }
+      }
+    }
+  }
+
   return { valid: true };
 }

--- a/src/lib/scheduler/launchd.test.ts
+++ b/src/lib/scheduler/launchd.test.ts
@@ -111,12 +111,6 @@ describe('generatePlist — command mode', () => {
     expect(out).toContain('rm -f');
   });
 
-  test('one-shot rejects shell-special chars in args', () => {
-    expect(() =>
-      generatePlist({ at: '2026-05-13 14:30', command: 'onebrain', args: ['$evil'] }, cctx),
-    ).toThrow(/shell-special chars/);
-  });
-
   test('command with no args produces single-element argv', () => {
     const out = generatePlist({ cron: '0 3 * * 0', command: 'onebrain' }, cctx);
     expect(out).toContain('<string>onebrain</string>');
@@ -130,5 +124,15 @@ describe('generatePlist — command mode', () => {
     expect(out).toContain('<string>rsync</string>');
     expect(out).toContain('<string>-av</string>');
     expect(out).toContain('<string>com.onebrain.rsync</string>');
+  });
+
+  test('command-mode args containing XML-special chars are escaped', () => {
+    const out = generatePlist(
+      { cron: '0 5 * * *', command: 'rclone', args: ['--exclude', 'a & b'] },
+      cctx,
+    );
+    expect(out).toContain('<string>--exclude</string>');
+    expect(out).toContain('<string>a &amp; b</string>');
+    expect(out).not.toContain('<string>a & b</string>'); // raw `&` must not appear
   });
 });

--- a/src/lib/scheduler/launchd.test.ts
+++ b/src/lib/scheduler/launchd.test.ts
@@ -76,3 +76,59 @@ describe('plistPath', () => {
     );
   });
 });
+
+describe('generatePlist — command mode', () => {
+  const cctx = { ...ctx, uid: 501, homedir: '/Users/test' };
+
+  test('recurring command emits hook-style ProgramArguments', () => {
+    const out = generatePlist(
+      { cron: '0 3 * * 0', command: 'onebrain', args: ['qmd-reindex'] },
+      cctx,
+    );
+    expect(out).toContain('<string>onebrain</string>');
+    expect(out).toContain('<string>qmd-reindex</string>');
+    expect(out).not.toContain('<string>--skill</string>');
+    expect(out).not.toContain('<string>--vault</string>');
+    expect(out).not.toContain('<string>--headless</string>');
+  });
+
+  test('label derives from command name', () => {
+    const out = generatePlist(
+      { cron: '0 3 * * 0', command: 'onebrain', args: ['qmd-reindex'] },
+      cctx,
+    );
+    expect(out).toContain('<string>com.onebrain.onebrain</string>');
+  });
+
+  test('one-shot command wraps in self-delete shell', () => {
+    const out = generatePlist(
+      { at: '2026-05-13 14:30', command: 'onebrain', args: ['qmd-reindex'] },
+      cctx,
+    );
+    expect(out).toContain('<string>/bin/sh</string>');
+    expect(out).toContain('&quot;onebrain&quot; &quot;qmd-reindex&quot;');
+    expect(out).toContain('launchctl bootout gui/501/com.onebrain.onebrain');
+    expect(out).toContain('rm -f');
+  });
+
+  test('one-shot rejects shell-special chars in args', () => {
+    expect(() =>
+      generatePlist({ at: '2026-05-13 14:30', command: 'onebrain', args: ['$evil'] }, cctx),
+    ).toThrow(/shell-special chars/);
+  });
+
+  test('command with no args produces single-element argv', () => {
+    const out = generatePlist({ cron: '0 3 * * 0', command: 'onebrain' }, cctx);
+    expect(out).toContain('<string>onebrain</string>');
+  });
+
+  test('command with non-onebrain binary works (rsync example)', () => {
+    const out = generatePlist(
+      { cron: '0 5 * * *', command: 'rsync', args: ['-av', '/src', '/dst'] },
+      cctx,
+    );
+    expect(out).toContain('<string>rsync</string>');
+    expect(out).toContain('<string>-av</string>');
+    expect(out).toContain('<string>com.onebrain.rsync</string>');
+  });
+});

--- a/src/lib/scheduler/launchd.ts
+++ b/src/lib/scheduler/launchd.ts
@@ -33,14 +33,8 @@ export function generatePlist(entry: ScheduleEntry, ctx: LaunchdContext): string
 
   if (isOneShot(entry)) {
     if (isCommandMode(entry)) {
+      // Args pre-validated by sanitizeArgsForOneShot in register-schedule.ts before reaching here.
       const argv = (entry.args as string[] | undefined) ?? [];
-      for (const a of argv) {
-        if (/["$`\\]/.test(a)) {
-          throw new Error(
-            `Command-mode arg must not contain shell-special chars (", $, \`, \\): ${a}`,
-          );
-        }
-      }
       const quotedArgs = argv.map((a) => `"${a}"`).join(' ');
       const innerCommand = `"${entry.command}"${quotedArgs ? ` ${quotedArgs}` : ''}`;
       const plistFilePath = `${ctx.homedir}/Library/LaunchAgents/${label}.plist`;

--- a/src/lib/scheduler/launchd.ts
+++ b/src/lib/scheduler/launchd.ts
@@ -1,4 +1,5 @@
 import { atToLaunchd, cronFieldsToLaunchd } from './cron-parse.js';
+import { isCommandMode, isOneShot } from './entry.js';
 import type { ScheduleEntry } from './types.js';
 
 const xmlEscape = (s: string) =>
@@ -12,41 +13,69 @@ interface LaunchdContext {
   uid: number;
 }
 
+export function labelForEntry(entry: ScheduleEntry): string {
+  const raw = isCommandMode(entry) ? entry.command : (entry.skill ?? '').replace(/^\//, '');
+  return raw.replace(/[^a-zA-Z0-9-]/g, '-');
+}
+
 export function generatePlist(entry: ScheduleEntry, ctx: LaunchdContext): string {
-  const labelSafe = entry.skill.replace(/^\//, '').replace(/[^a-zA-Z0-9-]/g, '-');
+  const labelSafe = labelForEntry(entry);
   const label = `com.onebrain.${labelSafe}`;
 
+  const calendar = isOneShot(entry)
+    ? atToLaunchd(entry.at)
+    : cronFieldsToLaunchd(entry.cron as string);
+  const calendarXml = Object.entries(calendar)
+    .map(([k, v]) => `        <key>${k}</key>\n        <integer>${v}</integer>`)
+    .join('\n');
+
   let programArgumentsBlock: string;
-  let calendarXml: string;
 
-  if (entry.at !== undefined) {
-    const calendar = atToLaunchd(entry.at);
-    calendarXml = Object.entries(calendar)
-      .map(([k, v]) => `        <key>${k}</key>\n        <integer>${v}</integer>`)
-      .join('\n');
-
-    const plistFilePath = plistPath(entry.skill, ctx.homedir);
-    const argsFlags = entry.args
-      ? ` ${Object.entries(entry.args)
-          .map(([k, v]) => `--${k}="${v}"`)
-          .join(' ')}`
-      : '';
-    // Double-quote interpolated values in the shell line so sh handles spaces correctly.
-    // The entire assembled shell line is XML-escaped once for the plist <string>.
-    const shellLine = xmlEscape(
-      `"${ctx.skillCliPath}" --vault="${ctx.vaultPath}" --skill="${entry.skill}" --headless${argsFlags}; launchctl bootout gui/${ctx.uid}/${label}; rm -f "${plistFilePath}"`,
-    );
-    programArgumentsBlock = `        <string>/bin/sh</string>
+  if (isOneShot(entry)) {
+    if (isCommandMode(entry)) {
+      const argv = (entry.args as string[] | undefined) ?? [];
+      for (const a of argv) {
+        if (/["$`\\]/.test(a)) {
+          throw new Error(
+            `Command-mode arg must not contain shell-special chars (", $, \`, \\): ${a}`,
+          );
+        }
+      }
+      const quotedArgs = argv.map((a) => `"${a}"`).join(' ');
+      const innerCommand = `"${entry.command}"${quotedArgs ? ` ${quotedArgs}` : ''}`;
+      const plistFilePath = `${ctx.homedir}/Library/LaunchAgents/${label}.plist`;
+      const shellLine = xmlEscape(
+        `${innerCommand}; launchctl bootout gui/${ctx.uid}/${label}; rm -f "${plistFilePath}"`,
+      );
+      programArgumentsBlock = `        <string>/bin/sh</string>
         <string>-c</string>
         <string>${shellLine}</string>`;
+    } else {
+      // Skill mode one-shot — PR #172 form preserved VERBATIM
+      const plistFilePath = plistPath(entry.skill ?? '', ctx.homedir);
+      const argsFlags = entry.args
+        ? ` ${Object.entries(entry.args as Record<string, string>)
+            .map(([k, v]) => `--${k}="${v}"`)
+            .join(' ')}`
+        : '';
+      const shellLine = xmlEscape(
+        `"${ctx.skillCliPath}" --vault="${ctx.vaultPath}" --skill="${entry.skill}" --headless${argsFlags}; launchctl bootout gui/${ctx.uid}/${label}; rm -f "${plistFilePath}"`,
+      );
+      programArgumentsBlock = `        <string>/bin/sh</string>
+        <string>-c</string>
+        <string>${shellLine}</string>`;
+    }
+  } else if (isCommandMode(entry)) {
+    // Recurring command mode — hook-style argv array
+    const argv = (entry.args as string[] | undefined) ?? [];
+    programArgumentsBlock = [
+      `        <string>${xmlEscape(entry.command)}</string>`,
+      ...argv.map((a) => `        <string>${xmlEscape(a)}</string>`),
+    ].join('\n');
   } else {
-    const calendar = cronFieldsToLaunchd(entry.cron as string);
-    calendarXml = Object.entries(calendar)
-      .map(([k, v]) => `        <key>${k}</key>\n        <integer>${v}</integer>`)
-      .join('\n');
-
+    // Recurring skill mode — PR #172 form preserved VERBATIM
     const argsBlock = entry.args
-      ? `\n${Object.entries(entry.args)
+      ? `\n${Object.entries(entry.args as Record<string, string>)
           .map(([k, v]) => `        <string>--${xmlEscape(k)}=${xmlEscape(v)}</string>`)
           .join('\n')}`
       : '';
@@ -55,7 +84,7 @@ export function generatePlist(entry: ScheduleEntry, ctx: LaunchdContext): string
         <string>--vault</string>
         <string>${xmlEscape(ctx.vaultPath)}</string>
         <string>--skill</string>
-        <string>${xmlEscape(entry.skill)}</string>
+        <string>${xmlEscape(entry.skill ?? '')}</string>
         <string>--headless</string>${argsBlock}`;
   }
 
@@ -83,7 +112,9 @@ ${calendarXml}
 </plist>`;
 }
 
-export function plistPath(skill: string, homedir: string): string {
-  const labelSafe = skill.replace(/^\//, '').replace(/[^a-zA-Z0-9-]/g, '-');
+export function plistPath(skillOrLabel: string, homedir: string): string {
+  const labelSafe = skillOrLabel.startsWith('/')
+    ? skillOrLabel.replace(/^\//, '').replace(/[^a-zA-Z0-9-]/g, '-')
+    : skillOrLabel.replace(/[^a-zA-Z0-9-]/g, '-');
   return `${homedir}/Library/LaunchAgents/com.onebrain.${labelSafe}.plist`;
 }

--- a/src/lib/scheduler/types.ts
+++ b/src/lib/scheduler/types.ts
@@ -1,8 +1,15 @@
 export interface ScheduleEntry {
-  cron?: string;
-  at?: string;
-  skill: string;
-  args?: Record<string, string>;
+  cron?: string; // recurring — exactly-one-of with `at`
+  at?: string; // one-shot — exactly-one-of with `cron`
+
+  // Entry mode — exactly-one-of:
+  skill?: string; // OneBrain skill (e.g. /daily)
+  command?: string; // CLI binary name (e.g. "onebrain", "/bin/sh", "rsync")
+
+  // Args interpretation depends on mode:
+  // - With `skill`:   Record<string, string> → emitted as --key=value flags
+  // - With `command`: string[]                → emitted as positional argv (hook style)
+  args?: Record<string, string> | string[];
 }
 
 export interface ScheduleConfig {


### PR DESCRIPTION
## Summary

Extend the scheduler backend (PR #172) to accept hook-style `command + args[]` entries alongside existing `skill:` entries. Schema mirrors Claude Code's `settings.json` hooks. Skill mode unchanged; command mode is purely additive.

- CLI v2.3.0 → v2.3.1 · Plugin v2.4.7 → v2.4.8
- 62 tests pass (39 PR #172 baseline + 23 new) · typecheck clean · biome clean · build clean
- Zero breaking change to existing skill-mode entries
- `/schedule-list` displays both modes with args inline

## Why

CLI maintenance tasks like `onebrain qmd-reindex` aren't skills. Creating thin wrapper skills (e.g. `/qmd-embed`) duplicates intent and creates drift. Matching the Claude Code hook shape (`command + args[]`) unifies the user's mental model: same pattern for event-driven (hooks) and time-driven (schedules).

## Schema

```typescript
interface ScheduleEntry {
  cron?, at?: string;
  skill?: string;          // exactly-one-of with command
  command?: string;        // hook-style binary
  args?: Record<string, string> | string[];
  //   skill: map → --key=value flags
  //   command: array → positional argv (matches hooks)
}
```

## Example mixed schedule

```yaml
schedule:
  - cron: "0 9 * * *"
    skill: /daily
  - cron: "0 9 * * *"
    skill: /distill
    args: { topic: this-week }
  - cron: "0 3 * * 0"
    command: onebrain
    args: [qmd-reindex]
  - cron: "0 5 * * *"
    command: rsync
    args: [-av, /vault, /backup]
```

## Hook-shape parity

Compare with `settings.json` Stop hook:
- Hook: `{ "type": "command", "command": "onebrain", "args": ["checkpoint", "stop"] }`
- Schedule: `{ "command": "onebrain", "args": ["qmd-reindex"], "cron": "..." }`

The `type` field is omitted from schedule entries because the `command:` field is itself the mode discriminator within `ScheduleEntry`. Same pattern, no redundant discriminator.

## 3-round review consensus

- R1 (CLI backend): flagged dual shell-special guard → consolidated (single source in `sanitizeArgsForOneShot`)
- R2 (plugin/docs): flagged INSTRUCTIONS missing wizard-only note → added; minor `labelSafe` description fix
- R3 (cross-cutting): no issues; spec coverage 100%, memory rule compliance pass, hook-shape parity confirmed

All consensus issues fixed in `3553ecf` (final HEAD).

## Test plan

- [ ] PR #172 skill-mode tests pass unchanged (62/62 verified locally)
- [ ] `register-schedule --dry-run` for command entry produces hook-style ProgramArguments (binary + positional argv, no `--vault`/`--skill`/`--headless`)
- [ ] `register-schedule --status` shows `cmd: binary args` for command entries and `skill: /name (k=v)` for skill-with-args
- [ ] `validateEntry` rejects skill+command both set, neither set, wrong args shape
- [ ] One-shot command entries reject shell-special chars (`"`, `$`, backtick, `\`) via `sanitizeArgsForOneShot`
- [ ] Collision detection across mixed skill+command vault.yml works (skill `/foo` and command `foo` would collide)
- [ ] Command mode XML-escapes args correctly (e.g., `a & b` → `a & amp; b`)

## Blocks

This PR is a prerequisite for PR B (preset bundles — Tier 3 uses command mode). See `01-projects/onebrain/shared/2026-05-12-schedule-presets-design.md` for E15-B.

## Out of scope

- `/schedule-add` wizard branch for constructing command entries (defer to follow-up; users hand-edit vault.yml)
- Hash-of-args label suffix for same-binary command entries (defer until use case appears)
- Preset bundles (PR B, depends on this PR)

Spec: \`01-projects/onebrain/shared/2026-05-12-scheduler-command-mode-design.md\` (E15-A)
Plan: \`01-projects/onebrain/shared/2026-05-12-scheduler-command-mode-plan.md\`