### PR TITLE
feat(scheduler): preset bundles for /onboarding + /schedule-add first-run (E15-B)

### DIFF
--- a/.claude/plugins/onebrain/.claude-plugin/plugin.json
+++ b/.claude/plugins/onebrain/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "onebrain",
-  "version": "2.4.8",
+  "version": "2.4.9",
   "description": "OneBrain — Where human and AI thinking become one. A powerful thinking partner powered by AI synergy.",
   "author": {
     "name": "OneBrain Contributors"

--- a/.claude/plugins/onebrain/INSTRUCTIONS.md
+++ b/.claude/plugins/onebrain/INSTRUCTIONS.md
@@ -417,6 +417,21 @@ Use skill mode for OneBrain workflows. Use command mode for CLI maintenance and 
 
 **Adding entries:** the `/schedule-add` wizard targets skill mode only. To add a command-mode entry, edit `vault.yml` directly and re-run `onebrain register-schedule`. The `/schedule-list` and `/schedule-remove` skills handle both modes transparently.
 
+### Presets
+
+New users and fresh vaults can install a maintenance preset in one decision. Three opinionated tier bundles plus a custom escape hatch are defined in `_shared/schedule-presets.md`:
+
+- **Minimal** — `/daily` 09:00 (1 entry)
+- **Essentials (Recommended)** — `/daily` 09:00 + `/weekly` Friday 17:00 + `/recap` Sunday 12:00 (3 entries)
+- **Maintenance Plus** — Essentials + `/doctor` monthly + `/tasks` daily 06:00 + `onebrain qmd-reindex` Sunday 03:00 (6 entries; includes 1 command-mode entry)
+- **Custom** — drops into the `/schedule-add` wizard
+
+Presets surface automatically:
+- In `/onboarding` after agent identity setup (default = Essentials)
+- In `/schedule-add` Step 0 when `vault.yml` has no existing `schedule:` entries
+
+Users with a populated `schedule:` block never see the preset prompt — preset selection is strictly first-run.
+
 ## Headless invocation
 
 Scheduled skills run via headless Claude Code: `claude --vault {VAULT} --skill /daily --headless`. The session loads MEMORY.md, vault.yml, MEMORY-INDEX.md as normal (SessionStart hook fires). PreToolUse, PostToolUse, Stop hooks fire as normal. PreCompact / PostCompact do not fire (sessions are too short).

--- a/.claude/plugins/onebrain/skills/_shared/schedule-presets.md
+++ b/.claude/plugins/onebrain/skills/_shared/schedule-presets.md
@@ -1,0 +1,69 @@
+# Schedule Presets — Canonical Tier Definitions
+
+Used by `/schedule-add` (Step 0 first-run path) and `/onboarding` (preset selection step). This file is the single source of truth — when a preset entry changes, change it here only.
+
+All entries assume macOS launchd. Skill mode and command mode (hook-style) coexist; Tier 3 demonstrates both.
+
+## Tier 1 — Minimal (1 entry)
+
+```yaml
+schedule:
+  - cron: "0 9 * * *"      # all days 09:00 — daily briefing
+    skill: /daily
+```
+
+## Tier 2 — Essentials (3 entries) — default Recommended
+
+```yaml
+schedule:
+  - cron: "0 9 * * *"      # all days 09:00 — daily briefing
+    skill: /daily
+  - cron: "0 17 * * 5"     # Friday 17:00 — workday-end weekly review
+    skill: /weekly
+  - cron: "0 12 * * 0"     # Sunday 12:00 — weekend reflection (promote insights)
+    skill: /recap
+```
+
+## Tier 3 — Maintenance Plus (6 entries — mix of skill + command modes)
+
+```yaml
+schedule:
+  - cron: "0 9 * * *"      # all days 09:00 — daily briefing
+    skill: /daily
+  - cron: "0 17 * * 5"     # Friday 17:00 — weekly review (workday end)
+    skill: /weekly
+  - cron: "0 12 * * 0"     # Sunday 12:00 — recap (weekend reflection)
+    skill: /recap
+  - cron: "0 9 1 * *"      # 1st of month 09:00 — monthly health audit
+    skill: /doctor
+  - cron: "0 6 * * *"      # all days 06:00 — pre-work tasks dashboard refresh
+    skill: /tasks
+  - cron: "0 3 * * 0"      # Sunday 03:00 — qmd embed safety-net sweep (CLI command, hook-style)
+    command: onebrain
+    args: [qmd-reindex]
+```
+
+## Tier 4 — Custom
+
+No preset entries. Drop the user into the regular `/schedule-add` wizard for manual construction.
+
+## Time-of-day rationale
+
+| Hour | Used by | Why |
+|---|---|---|
+| 03:00 | command qmd-reindex (Sunday) | Quiet pre-dawn maintenance — no editing conflicts |
+| 06:00 | /tasks (daily) | Pre-work dashboard refresh — ready before 09:00 |
+| 09:00 | /daily (daily), /doctor (monthly) | Start-of-day briefing window |
+| 12:00 | /recap (Sunday) | Weekend mid-day quiet reflection |
+| 17:00 | /weekly (Friday) | Workday-end wrap-the-week signal |
+
+Schedules are staggered across the day so launchd never spawns multiple OneBrain jobs simultaneously.
+
+## Skill mode vs command mode (see INSTRUCTIONS.md for full spec)
+
+| Mode | Use case | Shape |
+|---|---|---|
+| `skill:` | OneBrain skills with `schedulable: true` frontmatter | `skill: /daily`, optional `args: { key: value }` map |
+| `command:` | CLI binaries / generic maintenance commands | `command: onebrain`, optional `args: [arg1, arg2]` string array |
+
+Both modes coexist in the same `schedule:` block (Tier 3 demonstrates).

--- a/.claude/plugins/onebrain/skills/onboarding/SKILL.md
+++ b/.claude/plugins/onebrain/skills/onboarding/SKILL.md
@@ -246,6 +246,29 @@ If user selects "Skip for now": continue to Step 12.
 
 ---
 
+## Step 11b2: Schedule Presets (optional)
+
+1. Read the canonical preset tier table from `.claude/plugins/onebrain/skills/_shared/schedule-presets.md`.
+
+2. If `vault.yml` already has a non-empty `schedule:` block (re-running onboarding on an existing vault), skip this step entirely.
+
+3. Show via `AskUserQuestion` with default = Tier 2:
+   - **Tier 1 — Minimal** (1 entry)
+   - **Tier 2 — Essentials (Recommended)** (3 entries — default)
+   - **Tier 3 — Maintenance Plus** (6 entries; includes a CLI command-mode entry)
+   - **Skip** (no presets — user can run `/schedule-add` later)
+
+4. On Tier 1/2/3 selection: atomically write entries to `vault.yml` `schedule:` block (load → mutate → write entire file). Then run `onebrain register-schedule`. Confirm: `✓ Installed Tier N preset.`
+
+5. On Skip: take no action; continue.
+
+#### Edge cases
+
+- `vault.yml` not yet created at this point → ensure this step runs AFTER vault.yml creation; reorder if needed.
+- `onebrain register-schedule` fails (e.g. CLI not on PATH yet) → log the failure but don't block onboarding completion. The entries are still in vault.yml; user can register manually later.
+
+---
+
 ## Step 11c: Write Onboarding Log
 
 Follow `../_shared/audit-log-format.md` (canonical frontmatter, failure mode) with:
@@ -485,6 +508,12 @@ Check if `vault.yml` already exists in the vault root:
 ## Path B : Step 12b: qmd Setup (Optional)
 
 Identical to Step 11b in Path A. Ask the user whether to set up qmd, and if yes, run the `/qmd setup` flow (skipping its initial confirmation question). Continue to Step 12c regardless of outcome.
+
+---
+
+## Path B : Step 12b2: Schedule Presets (optional)
+
+Identical to **Step 11b2** in Path A. Read presets from `_shared/schedule-presets.md`, skip if `vault.yml` already has a non-empty `schedule:` block, show `AskUserQuestion` with default = Tier 2, apply selected tier atomically. On `onebrain register-schedule` failure, log and continue — non-blocking.
 
 ---
 

--- a/.claude/plugins/onebrain/skills/schedule-add/SKILL.md
+++ b/.claude/plugins/onebrain/skills/schedule-add/SKILL.md
@@ -19,6 +19,32 @@ For users who don't want to hand-edit vault.yml or learn cron syntax. Walks thro
 
 ## Skill flow
 
+### Step 0: First-run preset detection (skip if schedule already has entries)
+
+1. Read `vault.yml`. Check if the `schedule:` key exists AND its value is a non-empty list.
+   - If `schedule:` is missing, null, or `[]` → continue with this step (preset selector).
+   - If `schedule:` has one or more entries → skip Step 0 entirely; go straight to Step 1.
+
+2. Read the canonical preset tier table from `.claude/plugins/onebrain/skills/_shared/schedule-presets.md`. The four tiers are defined there — never duplicate them inline in this skill file.
+
+3. Show preset selection via `AskUserQuestion`:
+   - **Tier 1 — Minimal** (1 entry: `/daily` 09:00 every day)
+   - **Tier 2 — Essentials (Recommended)** (3 entries: `/daily`, `/weekly` Friday, `/recap` Sunday)
+   - **Tier 3 — Maintenance Plus** (6 entries: Essentials + `/doctor` monthly + `/tasks` daily + `onebrain qmd-reindex` Sunday command-mode entry)
+   - **Tier 4 — Custom** (skip presets, go to manual wizard)
+
+4. Apply the chosen tier:
+   - **Tier 1, 2, or 3:** atomically write the preset entries (verbatim from `_shared/schedule-presets.md`) to `vault.yml` `schedule:` block (load → mutate → write entire file; use a tmp file + rename). Then run `onebrain register-schedule`. Confirm: `✓ Installed Tier N preset (M entries).`
+   - **Tier 4 (Custom):** fall through to Step 1 (the existing skill picker wizard).
+
+5. On Tier 1/2/3 success → the skill exits here. The user has scheduled entries. Subsequent invocations of `/schedule-add` will see `schedule:` is non-empty and skip Step 0, falling straight into the manual wizard for adding additional entries.
+
+#### Edge cases
+
+- **vault.yml missing entirely** → wizard creates it with the preset entries as the only content of a new `schedule:` block.
+- **vault.yml has `schedule:` as a comment or YAML null** → treat as empty; proceed with preset selector.
+- **Atomic write failure** → rollback (do not leave partial state); report the YAML error and exit.
+
 ### Step 1: Pick skill
 
 List all schedulable skills by reading each SKILL.md frontmatter under `.claude/plugins/onebrain/skills/`. Filter for entries where `schedulable: true` OR `schedulable_with_args: true`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -187,6 +187,22 @@ schedule:
 
 Command mode matches the Claude Code hook shape — single source of pattern across event-driven (hooks) and time-driven (schedules) automation.
 
+### Updating preset bundles
+
+The canonical preset tier definitions live at `.claude/plugins/onebrain/skills/_shared/schedule-presets.md`. To add or modify a tier:
+
+1. Edit `_shared/schedule-presets.md` — that file is the single source of truth.
+2. Do NOT duplicate tier definitions in `/schedule-add` or `/onboarding`; both read from `_shared`.
+3. Schedule entries may use skill mode (`skill: /name`) for OneBrain skills with `schedulable:` frontmatter, OR command mode (`command: binary`, `args: [...]`) for direct CLI invocations matching the Claude Code hook shape.
+
+Reasonable cadences:
+- Daily skills → 9am briefings; 6am pre-work refreshes
+- Weekly workday-end (wrap work cycle) → Friday 17:00
+- Weekly weekend (reflection / maintenance) → Sunday mid-day or pre-dawn
+- Monthly → 1st of month 09:00 (calendar-based)
+
+Stagger times across the day to avoid simultaneous launchd job spawns.
+
 ## Editing an Existing Skill
 
 - Keep the frontmatter intact

--- a/PLUGIN-CHANGELOG.md
+++ b/PLUGIN-CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-latest_version: 2.4.8
+latest_version: 2.4.9
 released: 2026-05-12
 ---
 
@@ -10,6 +10,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 > **Versioning:** Plugin version is tracked in `plugin.json`. Bump when ANY harness config changes — skills, agents, hooks, INSTRUCTIONS, Gemini settings, slash commands, etc.
 > For CLI binary (`@onebrain-ai/cli`) changes, see [CHANGELOG.md](CHANGELOG.md).
+
+## 2.4.9 — 2026-05-12
+
+- `/schedule-add` Step 0 first-run preset selector — Minimal / Essentials / Maintenance Plus / Custom (E15-B)
+- `/onboarding` adds preset selection step after agent identity setup (default = Essentials)
+- Canonical preset tier definitions at `_shared/schedule-presets.md` — single source of truth
+- Tier 3 preset mixes skill-mode and command-mode entries (live example of E15-A schema)
+- INSTRUCTIONS.md + README + CONTRIBUTING document preset bundles
 
 ## 2.4.8 — 2026-05-12
 

--- a/README.md
+++ b/README.md
@@ -544,6 +544,16 @@ schedule:
 
 This matches the same shape Claude Code uses for `hooks` in `settings.json` — direct binary invocation with positional argv. No wrapper skill needed.
 
+### Quick start — preset bundles
+
+Don't want to hand-craft cron entries? OneBrain ships three preset tiers. New vaults are prompted during `/onboarding`; existing vaults can trigger the selector by running `/schedule-add` when the `schedule:` block is empty.
+
+- **Minimal** — `/daily` briefing only
+- **Essentials (default)** — `/daily` + `/weekly` Friday + `/recap` Sunday
+- **Maintenance Plus** — Essentials + `/doctor` monthly + `/tasks` daily + `onebrain qmd-reindex` Sunday (mixes skill + command modes)
+
+Canonical tier definitions live at `.claude/plugins/onebrain/skills/_shared/schedule-presets.md`.
+
 CLI flags:
 
 | Flag | Purpose |


### PR DESCRIPTION
## Summary

Three opinionated preset tiers (Minimal / Essentials / Maintenance Plus) + Custom escape hatch. Shown to users with empty `schedule:` block during `/onboarding` (default = Essentials) and `/schedule-add` Step 0. Idempotent + non-destructive — never re-prompts users with existing schedules.

- Plugin v2.4.8 → v2.4.9 · CLI unchanged at v2.3.1
- Tier 3 demonstrates skill + command modes coexisting (uses E15-A schema)
- Single source of truth at `_shared/schedule-presets.md`

## Depends on

PR #173 (E15-A — hook-style command mode) merged to `main`. Tier 3 includes a `command: onebrain` entry that requires PR A's `ScheduleEntry.command` schema.

## Preset tiers

```yaml
# Tier 1: Minimal (1)
- cron: "0 9 * * *"
  skill: /daily

# Tier 2: Essentials Recommended (3)
- /daily 09:00 (every day)
- /weekly Friday 17:00 (workday-end)
- /recap Sunday 12:00 (weekend reflection)

# Tier 3: Maintenance Plus (6 — mixes skill + command modes)
- Essentials +
- /doctor 1st of month 09:00
- /tasks daily 06:00 (pre-work refresh)
- onebrain qmd-reindex Sunday 03:00 (command-mode, hook-style)

# Tier 4: Custom — drops to wizard
```

## Workday vs weekend cadence

- All-day: `/daily` 09:00, `/tasks` 06:00
- Workday-end: `/weekly` Friday 17:00
- Weekend: `/recap` Sunday 12:00, `onebrain qmd-reindex` Sunday 03:00
- Calendar-pinned: `/doctor` 1st of month 09:00

Times staggered across the day (03/06/09/12/17) so launchd never spawns multiple OneBrain jobs simultaneously.

## 3-round review consensus

All 3 reviewers approved without required fixes:
- R1 (skill content) — single-source pattern holds; tier YAML in `_shared/` only; idempotency contract clean
- R2 (docs + versioning) — placements correct; 5-bullet changelog within 8-cap; CLI unchanged at 2.3.1; memory rules pass
- R3 (spec compliance) — 10/10 acceptance criteria met; no src/ touched; English-only clean

## Test plan

- [ ] `/schedule-add` with empty `schedule:` block prompts preset selector
- [ ] `/schedule-add` with non-empty `schedule:` block skips preset prompt (straight to wizard)
- [ ] Picking Tier 2 writes 3 entries and registers via `onebrain register-schedule`
- [ ] Picking Tier 3 writes 5 skill entries + 1 command entry (Tier 3 needs E15-A schema)
- [ ] `/onboarding` shows preset step with Essentials as default
- [ ] Skip in `/onboarding` writes no schedule entries
- [ ] `_shared/schedule-presets.md` is the only file containing tier YAML — no duplication

## Out of scope

- Workday-only cron (Mon-Fri × 5 entries — too heavy for default)
- Customize-times-before-install flow (defer)
- Wizard support for constructing command-mode entries (defer; users hand-edit vault.yml)

Spec: \`01-projects/onebrain/shared/2026-05-12-schedule-presets-design.md\` (E15-B)
Plan: \`01-projects/onebrain/shared/2026-05-12-schedule-presets-plan.md\`
Depends on: #173 (E15-A scheduler command mode)