### PR TITLE
feat: pin plugin to CLI v3.0 (Rust)

### DIFF
--- a/.claude/plugins/onebrain/.claude-plugin/plugin.json
+++ b/.claude/plugins/onebrain/.claude-plugin/plugin.json
@@ -1,8 +1,11 @@
 {
   "name": "onebrain",
-  "version": "2.4.13",
+  "version": "3.0.0-alpha.1",
   "description": "OneBrain — Where human and AI thinking become one. A powerful thinking partner powered by AI synergy.",
   "author": {
     "name": "OneBrain Contributors"
+  },
+  "requires": {
+    "cli": ">=3.0.0-alpha.1"
   }
 }

--- a/PLUGIN-CHANGELOG.md
+++ b/PLUGIN-CHANGELOG.md
@@ -1,6 +1,6 @@
 ---
-latest_version: 2.4.13
-released: 2026-05-19
+latest_version: 3.0.0-alpha.1
+released: 2026-05-20
 ---
 
 # Plugin Changelog
@@ -10,6 +10,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 > **Versioning:** Plugin version is tracked in `plugin.json`. Bump when ANY harness config changes — skills, agents, hooks, INSTRUCTIONS, Gemini settings, slash commands, etc.
 > For CLI binary (`@onebrain-ai/cli`) changes, see [CHANGELOG.md](CHANGELOG.md).
+
+## v3.0.0-alpha.1 — 2026-05-20
+
+- chore(plugin.json): bump version 2.4.13 → 3.0.0-alpha.1 to mark prerelease compatibility with the Rust CLI rewrite
+- feat(plugin.json): add `requires.cli: ">=3.0.0-alpha.1"` — refuses to load against the Bun-era CLI (v2.x) where the new internal CLI shape would silently misbehave
+- audit(skills): all 13 CLI subcommands referenced by skills (`session-init`, `checkpoint stop`, `checkpoint reset`, `orphan-scan`, `vault-sync`, `register-hooks`, `register-schedule`, `qmd-reindex`, `run-skill`, `update`, plus `--version`) preserved on the Rust side per the v3.0.0-alpha.1 parity smoke test — no skill rewrites required for this bump
+- audit(skills): flagged `node -e "…"` usage in `skills/qmd/SKILL.md`, `skills/update/SKILL.md`, `skills/reorganize/SKILL.md`, `skills/import/**`, and `startup/scripts/open-in-obsidian.sh` as a follow-up — these assume Node is on PATH "because the OneBrain CLI requires it", which the Rust CLI no longer guarantees; deferred per minimal-changes rule, tracked separately
 
 ## v2.4.13 — 2026-05-19
 


### PR DESCRIPTION
## Summary

- Bumps plugin version `2.4.13` → `3.0.0-alpha.1` in `.claude/plugins/onebrain/.claude-plugin/plugin.json`
- Declares hard CLI dependency via new `requires.cli: ">=3.0.0-alpha.1"` field — refuses to load against the Bun-era v2.x CLI
- `PLUGIN-CHANGELOG.md` gains a `v3.0.0-alpha.1` entry naming the CLI rewrite, the parity audit, and the deferred Node-on-PATH follow-up

## Why a major bump (and why `-alpha.1`)

The v3 CLI is a complete Rust rewrite of the previous Bun/TypeScript binary. All 13 subcommands referenced by plugin skills (`session-init`, `checkpoint stop`, `checkpoint reset`, `orphan-scan`, `vault-sync`, `register-hooks`, `register-schedule`, `qmd-reindex`, `run-skill`, `update`, plus `--version`) retain parity per the v3.0.0-alpha.1 smoke test, so existing skill prose continues to work unchanged. The major bump signals to consumers that downgrading the CLI to 2.x is unsupported under this plugin release. The `-alpha.1` suffix mirrors the upstream CLI tag and marks this as a prerelease while v3.0 stabilises — matches the existing convention where the plugin's last v1→v2 jump also rode a CLI transition.

## Audit findings (deferred to follow-up)

`grep -rn "bun \|node " .claude/plugins/onebrain` surfaced:

- **No `bun run`, `bun build`, or `bun test` invocations** in any plugin file. Two references to `bun install -g …` in `skills/qmd/SKILL.md` and `skills/update/SKILL.md` are documentation of user-side install commands, not plugin shell-outs — safe.
- **`node -e "…"` shell-outs in 6 files**, all sharing the same justification comment: *"Node is reliably on PATH because the OneBrain CLI requires it."* The Rust CLI no longer carries Node as a transitive dependency, so this assumption no longer holds:
  - `skills/qmd/SKILL.md` (basename + crypto.randomBytes for collection-name generation)
  - `skills/update/SKILL.md` (mkdir for `07-logs/` subfolders)
  - `skills/reorganize/SKILL.md` (mkdir for target subfolders)
  - `skills/import/SKILL.md` + `skills/import/references/{image,pdf,video}-handler.md` (mkdir + file stat for attachment dirs)
  - `startup/scripts/open-in-obsidian.sh` (URL-encoding the vault path)

Per the minimal-changes rule these are **flagged, not fixed, in this PR**. Each call site has a portable fallback path documented inline (mkdir -p / PowerShell New-Item / cmd mkdir), so most still work on machines where Node happens to be installed — but the "guaranteed" claim needs to be retired and the Node calls replaced with a CLI subcommand (e.g. `onebrain util mkdir`, `onebrain util urlencode`) in a follow-up.

## Test plan

- [ ] Install plugin into a fresh vault with CLI v3.0.0-alpha.1 — verify `plugin.json` parses and the plugin loads
- [ ] Verify `requires.cli` gate: install CLI v2.3.3 alongside this plugin and confirm Claude Code refuses to load it (or warns)
- [ ] Smoke test `/daily`, `/wrapup`, `/doctor`, `/qmd setup` against a v3.0 CLI to confirm parity holds end-to-end
- [ ] Cross-check that no `node`-dependent skill silently fails on a Node-free machine (manual / follow-up PR)