### PR TITLE
chore: revert PR #180 (pin plugin to CLI v3.0) — redo after CLI GA

### DIFF
--- a/.claude/plugins/onebrain/.claude-plugin/plugin.json
+++ b/.claude/plugins/onebrain/.claude-plugin/plugin.json
@@ -1,11 +1,8 @@
 {
   "name": "onebrain",
-  "version": "3.0.0-alpha.1",
+  "version": "2.4.13",
   "description": "OneBrain — Where human and AI thinking become one. A powerful thinking partner powered by AI synergy.",
   "author": {
     "name": "OneBrain Contributors"
-  },
-  "requires": {
-    "cli": ">=3.0.0-alpha.1"
   }
 }

--- a/PLUGIN-CHANGELOG.md
+++ b/PLUGIN-CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-latest_version: 3.0.0-alpha.1
+latest_version: 2.4.14
 released: 2026-05-20
 ---
 
@@ -11,12 +11,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 > **Versioning:** Plugin version is tracked in `plugin.json`. Bump when ANY harness config changes — skills, agents, hooks, INSTRUCTIONS, Gemini settings, slash commands, etc.
 > For CLI binary (`@onebrain-ai/cli`) changes, see [CHANGELOG.md](CHANGELOG.md).
 
-## v3.0.0-alpha.1 — 2026-05-20
+## v2.4.14 — 2026-05-20
 
-- chore(plugin.json): bump version 2.4.13 → 3.0.0-alpha.1 to mark prerelease compatibility with the Rust CLI rewrite
-- feat(plugin.json): add `requires.cli: ">=3.0.0-alpha.1"` — refuses to load against the Bun-era CLI (v2.x) where the new internal CLI shape would silently misbehave
-- audit(skills): all 13 CLI subcommands referenced by skills (`session-init`, `checkpoint stop`, `checkpoint reset`, `orphan-scan`, `vault-sync`, `register-hooks`, `register-schedule`, `qmd-reindex`, `run-skill`, `update`, plus `--version`) preserved on the Rust side per the v3.0.0-alpha.1 parity smoke test — no skill rewrites required for this bump
-- audit(skills): flagged `node -e "…"` usage in `skills/qmd/SKILL.md`, `skills/update/SKILL.md`, `skills/reorganize/SKILL.md`, `skills/import/**`, and `startup/scripts/open-in-obsidian.sh` as a follow-up — these assume Node is on PATH "because the OneBrain CLI requires it", which the Rust CLI no longer guarantees; deferred per minimal-changes rule, tracked separately
+- chore: revert the "pin plugin to CLI v3.0 (Rust)" PR (#180). Keeping the plugin compatible with both the Bun v2.3.3 CLI and the in-flight v3.0.0-alpha.* line until the Rust port reaches GA. The `requires.cli` pin will be re-applied (likely to `>=3.0.0`) once the CLI GA tag ships.
+- Plugin version stays at 2.4.x; the previous bump to `3.0.0-alpha.1` in PR #180 was a leading-edge signal that turned out to be premature.
 
 ## v2.4.13 — 2026-05-19
 


### PR DESCRIPTION
Reverts #180. Will redo after CLI v3.0.0 GA.

## Why now

PR #180 declared a hard \`requires.cli: '>=3.0.0-alpha.1'\` and bumped the plugin version 2.4.13 → 3.0.0-alpha.1 ahead of the CLI's actual GA. Three issues surfaced in practice:

1. The v3 CLI is still pre-GA (v3.0.0-alpha.5 in flight as of today). Anyone on a clean install picks up the plugin via \`vault-sync\` and then trips the version check until they manually update the CLI.
2. The plugin itself still works against both Bun v2.3.3 and the Rust alpha series — there's no skill that *requires* v3-only behaviour today.
3. Coupling plugin 3.0.0-alpha.1 to CLI 3.0.0-alpha.1 confuses the versioning story: plugin alpha + CLI alpha both at .alpha.1, drifting separately as each repo bumps.

## Plan

- This PR restores the pre-#180 plugin.json shape (no \`requires.cli\` field, no \`version: 3.0.0-alpha.1\`) and bumps the plugin to **v2.4.14** to record the revert.
- The CLI-v3 pin will be re-applied as a follow-up — likely \`requires.cli: '>=3.0.0'\` — once the CLI's v3.0.0 GA tag ships.

## Diff

- \`.claude/plugins/onebrain/.claude-plugin/plugin.json\`: \`version\` back to \`2.4.14\`, \`requires.cli\` field removed.
- \`PLUGIN-CHANGELOG.md\`: drop the \`v3.0.0-alpha.1\` entry, add a v2.4.14 entry documenting the revert.

## Test plan

- [x] \`plugin.json\` parses as valid JSON
- [x] \`PLUGIN-CHANGELOG.md\` frontmatter \`latest_version\` matches \`plugin.json\` \`version\`
- [x] No skill or instruction in the plugin actually requires CLI v3-only behaviour today (verified by audit summarised in PR #180 itself — all 13 subcommand argv shapes are still backwards-compatible with the Bun CLI)