### PR TITLE
chore: bump plugin.json to 2.4.14 (match PLUGIN-CHANGELOG)

### DIFF
--- a/.claude/plugins/onebrain/.claude-plugin/plugin.json
+++ b/.claude/plugins/onebrain/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "onebrain",
-  "version": "2.4.13",
+  "version": "2.4.14",
   "description": "OneBrain — Where human and AI thinking become one. A powerful thinking partner powered by AI synergy.",
   "author": {
     "name": "OneBrain Contributors"


### PR DESCRIPTION
Follow-up to #181 — PLUGIN-CHANGELOG was bumped to v2.4.14 but plugin.json stayed at 2.4.13, so any vault on 2.4.13 hits 'Already up to date' instead of syncing the revert.

One-line bump in plugin.json. No other changes.