### PR TITLE
v3.1.2 — skip startup ceremony on headless runs

### DIFF
--- a/.claude/plugins/onebrain/.claude-plugin/plugin.json
+++ b/.claude/plugins/onebrain/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "onebrain",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "OneBrain — Your AI Thinking Partner",
   "author": {
     "name": "OneBrain Contributors"

--- a/.claude/plugins/onebrain/INSTRUCTIONS.md
+++ b/.claude/plugins/onebrain/INSTRUCTIONS.md
@@ -208,6 +208,8 @@ If qmd tools are NOT available: use Glob/Grep/Read for all vault searches. No sp
 
 Session startup greets the user immediately, then runs a quick inline status check.
 
+> **Headless exception:** when `onebrain session init` reports `headless: true` (set by `onebrain skill run` for an unattended one-shot run), skip the entire startup ceremony — Steps 2–4 below — and go straight to the requested skill. No greeting, no startup status, no memory/inbox/task/orphan scans. See Step 1.
+
 ### Startup : Immediate
 
 Run before responding to any user message.
@@ -215,7 +217,8 @@ Run before responding to any user message.
 **Step 1 — Critical path (greeting blocks on these):** Run in parallel:
 - Read `onebrain.yml` → load Configuration variables; override defaults once resolved. If `onebrain.yml` is missing, fall back to legacy `vault.yml` (v3.0 name) — same schema; surface a one-line deprecation note in the startup status so the user knows to run `onebrain doctor --fix` to migrate.
 - Read `[agent_folder]/MEMORY.md` → load identity, personality, active projects
-- Run `onebrain session init --json` (from vault root) → parse JSON output; store `DATETIME` (for greeting), `session_token` (for checkpoints), and `qmd_unembedded` in context. JSON shape: `{"datetime":"Ddd · DD Mon YYYY · HH:MM","session_token":"XXXXX","qmd_unembedded":N}`. **CLI v3.1+ requires `--json` because the default output flipped to text.** The v3.0 alias `onebrain session-init` still works and now auto-rewrites to include `--json` when `onebrain plugin update` runs. If the command fails or is unavailable, fall back to running `date '+%a · %d %b %Y · %H:%M'` for `DATETIME`, treating `session_token` as `99999`, and `qmd_unembedded` as `0`. If JSON output contains `{"decision":"block","reason":"onebrain-vault-not-found"}` (CLI v3.1+) or `"reason":"onebrain-init-required"` (CLI v3.0 back-compat), skip Steps 2–4; instead output a single message: "OneBrain vault not initialized. Run `/onboarding` to set up your vault."
+- Run `onebrain session init --json` (from vault root) → parse JSON output; store `DATETIME` (for greeting), `session_token` (for checkpoints), `qmd_unembedded`, and `headless` in context. JSON shape: `{"datetime":"Ddd · DD Mon YYYY · HH:MM","session_token":"XXXXX","qmd_unembedded":N,"headless":true|false}`. **CLI v3.1+ requires `--json` because the default output flipped to text.** The v3.0 alias `onebrain session-init` still works and now auto-rewrites to include `--json` when `onebrain plugin update` runs. If the command fails or is unavailable, fall back to running `date '+%a · %d %b %Y · %H:%M'` for `DATETIME`, treating `session_token` as `99999`, `qmd_unembedded` as `0`, and `headless` as `false`. If JSON output contains `{"decision":"block","reason":"onebrain-vault-not-found"}` (CLI v3.1+) or `"reason":"onebrain-init-required"` (CLI v3.0 back-compat), skip Steps 2–4; instead output a single message: "OneBrain vault not initialized. Run `/onboarding` to set up your vault."
+  - **If `headless` is `true`** (CLI v3.2.6+, set by `onebrain skill run`): this is an unattended one-shot run, so **skip Steps 2–4 entirely** — no greeting, no startup status, and none of Step 3's memory/inbox/task/orphan/pause scans — and proceed directly to the invoked skill. The `headless` field is absent on older CLIs; treat absent as `false` (normal interactive startup).
 
 **Step 2 — Send greeting immediately:**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ---
-latest_version: 3.1.1
-released: 2026-05-27
+latest_version: 3.1.2
+released: 2026-05-28
 ---
 
 # Changelog
@@ -10,6 +10,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 > **Versioning:** Plugin version is tracked in `plugin.json`. Bump when ANY harness config changes — skills, agents, hooks, INSTRUCTIONS, Gemini settings, slash commands, etc.
 > For CLI binary changes, see the [`onebrain-ai/onebrain-cli`](https://github.com/onebrain-ai/onebrain-cli/blob/main/CHANGELOG.md) repository.
+
+## v3.1.2 — 2026-05-28
+
+- INSTRUCTIONS.md (Session Startup): skip the interactive startup ceremony when running headless. Step 1 now parses a `headless` field from `onebrain session init --json` (CLI v3.2.6+, set by `onebrain skill run` via `ONEBRAIN_HEADLESS=1`); when `true`, Steps 2–4 (greeting + status + memory/inbox/task/orphan/pause scans) are skipped and the agent runs only the invoked skill — faster, cleaner headless runs. The field is absent on older CLIs and treated as `false` (normal interactive startup), so no `requires.cli` bump is needed.
 
 ## v3.1.1 — 2026-05-27
 


### PR DESCRIPTION
Consumes the `headless` flag added in CLI v3.2.6.

`onebrain skill run` sets `ONEBRAIN_HEADLESS=1` on the harness child → `onebrain session init` reports `headless: true`. INSTRUCTIONS.md Session Startup now parses that field; when `true`, it **skips Steps 2–4** (greeting + status + memory/inbox/task/orphan/pause scans) and runs only the invoked skill — faster, cleaner unattended runs.

- The field is absent on older CLIs and treated as `false` (normal interactive startup), so **no `requires.cli` bump** — works with any CLI, the skip just activates once the CLI emits the flag.
- plugin.json 3.1.1 → 3.1.2 · CHANGELOG entry · INSTRUCTIONS.md Step 1 JSON shape updated to include `headless`.

Doc/instruction only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)