### PR TITLE
v3.1.3 — gemini hardening: kill activate_skill error + tool-quirk guidance

### DIFF
--- a/.claude/plugins/onebrain/.claude-plugin/plugin.json
+++ b/.claude/plugins/onebrain/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "onebrain",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "OneBrain — Your AI Thinking Partner",
   "author": {
     "name": "OneBrain Contributors"

--- a/.claude/plugins/onebrain/references/gemini-tools.md
+++ b/.claude/plugins/onebrain/references/gemini-tools.md
@@ -21,6 +21,14 @@ Skills and INSTRUCTIONS.md use Claude Code tool names. When you encounter these,
 
 Gemini CLI has no equivalent to Claude Code's `Agent` tool. Skills that dispatch sub-agents (inbox-classifier, tag-suggester, link-suggester, task-extractor) run their logic inline instead. Results may be slightly slower but functionally equivalent.
 
+## Tool behaviour differences (handle gracefully)
+
+Gemini's tools differ from Claude Code's in ways that can interrupt a skill if handled naively. Apply these rules so a workflow never aborts on a tool quirk:
+
+- **`glob` / `grep_search` on a non-existent path**: Gemini errors with "Search path does not exist", where Claude's `Glob` / `Grep` quietly return zero matches. Treat the error as **zero matches and continue** — never abort the skill. When a path may not exist (e.g. a `YYYY/MM` session-log folder for a month with no sessions yet), check with `list_directory` first or tolerate the error and proceed.
+- **Never call `activate_skill` for OneBrain skills**: OneBrain skills are NOT registered Gemini agent-skills, so `activate_skill` fails with "params/name must be equal to one of the allowed values". Skills are followed by reading their `SKILL.md` (see the Skills row in the mapping above) — that is the only correct activation path.
+- **"Ripgrep is not available. Falling back to GrepTool."**: harmless — the fallback works. Ignore it.
+
 ## Additional Gemini CLI tools
 
 | Tool | Purpose |

--- a/.gemini/commands/onebrain/bookmark.toml
+++ b/.gemini/commands/onebrain/bookmark.toml
@@ -1,2 +1,2 @@
-description = "Activate OneBrain bookmark skill"
-prompt = "Please activate the 'bookmark' skill and follow its procedural workflow."
+description = "Run the OneBrain bookmark skill"
+prompt = "Run the OneBrain 'bookmark' skill by reading .claude/plugins/onebrain/skills/bookmark/SKILL.md and following its workflow. Do not call activate_skill — OneBrain skills are not Gemini agent-skills; follow the SKILL.md directly."

--- a/.gemini/commands/onebrain/braindump.toml
+++ b/.gemini/commands/onebrain/braindump.toml
@@ -1,2 +1,2 @@
-description = "Activate OneBrain braindump skill"
-prompt = "Please activate the 'braindump' skill and follow its procedural workflow."
+description = "Run the OneBrain braindump skill"
+prompt = "Run the OneBrain 'braindump' skill by reading .claude/plugins/onebrain/skills/braindump/SKILL.md and following its workflow. Do not call activate_skill — OneBrain skills are not Gemini agent-skills; follow the SKILL.md directly."

--- a/.gemini/commands/onebrain/capture.toml
+++ b/.gemini/commands/onebrain/capture.toml
@@ -1,2 +1,2 @@
-description = "Activate OneBrain capture skill"
-prompt = "Please activate the 'capture' skill and follow its procedural workflow."
+description = "Run the OneBrain capture skill"
+prompt = "Run the OneBrain 'capture' skill by reading .claude/plugins/onebrain/skills/capture/SKILL.md and following its workflow. Do not call activate_skill — OneBrain skills are not Gemini agent-skills; follow the SKILL.md directly."

--- a/.gemini/commands/onebrain/clone.toml
+++ b/.gemini/commands/onebrain/clone.toml
@@ -1,2 +1,2 @@
-description = "Activate OneBrain clone skill"
-prompt = "Please activate the 'clone' skill and follow its procedural workflow."
+description = "Run the OneBrain clone skill"
+prompt = "Run the OneBrain 'clone' skill by reading .claude/plugins/onebrain/skills/clone/SKILL.md and following its workflow. Do not call activate_skill — OneBrain skills are not Gemini agent-skills; follow the SKILL.md directly."

--- a/.gemini/commands/onebrain/connect.toml
+++ b/.gemini/commands/onebrain/connect.toml
@@ -1,2 +1,2 @@
-description = "Activate OneBrain connect skill"
-prompt = "Please activate the 'connect' skill and follow its procedural workflow."
+description = "Run the OneBrain connect skill"
+prompt = "Run the OneBrain 'connect' skill by reading .claude/plugins/onebrain/skills/connect/SKILL.md and following its workflow. Do not call activate_skill — OneBrain skills are not Gemini agent-skills; follow the SKILL.md directly."

--- a/.gemini/commands/onebrain/consolidate.toml
+++ b/.gemini/commands/onebrain/consolidate.toml
@@ -1,2 +1,2 @@
-description = "Activate OneBrain consolidate skill"
-prompt = "Please activate the 'consolidate' skill and follow its procedural workflow."
+description = "Run the OneBrain consolidate skill"
+prompt = "Run the OneBrain 'consolidate' skill by reading .claude/plugins/onebrain/skills/consolidate/SKILL.md and following its workflow. Do not call activate_skill — OneBrain skills are not Gemini agent-skills; follow the SKILL.md directly."

--- a/.gemini/commands/onebrain/daily.toml
+++ b/.gemini/commands/onebrain/daily.toml
@@ -1,2 +1,2 @@
-description = "Activate OneBrain daily skill"
-prompt = "Please activate the 'daily' skill and follow its procedural workflow."
+description = "Run the OneBrain daily skill"
+prompt = "Run the OneBrain 'daily' skill by reading .claude/plugins/onebrain/skills/daily/SKILL.md and following its workflow. Do not call activate_skill — OneBrain skills are not Gemini agent-skills; follow the SKILL.md directly."

--- a/.gemini/commands/onebrain/distill.toml
+++ b/.gemini/commands/onebrain/distill.toml
@@ -1,2 +1,2 @@
-description = "Activate OneBrain distill skill"
-prompt = "Please activate the 'distill' skill and follow its procedural workflow."
+description = "Run the OneBrain distill skill"
+prompt = "Run the OneBrain 'distill' skill by reading .claude/plugins/onebrain/skills/distill/SKILL.md and following its workflow. Do not call activate_skill — OneBrain skills are not Gemini agent-skills; follow the SKILL.md directly."

--- a/.gemini/commands/onebrain/doctor.toml
+++ b/.gemini/commands/onebrain/doctor.toml
@@ -1,2 +1,2 @@
-description = "Activate OneBrain doctor skill"
-prompt = "Please activate the 'doctor' skill and follow its procedural workflow."
+description = "Run the OneBrain doctor skill"
+prompt = "Run the OneBrain 'doctor' skill by reading .claude/plugins/onebrain/skills/doctor/SKILL.md and following its workflow. Do not call activate_skill — OneBrain skills are not Gemini agent-skills; follow the SKILL.md directly."

--- a/.gemini/commands/onebrain/help.toml
+++ b/.gemini/commands/onebrain/help.toml
@@ -1,2 +1,2 @@
-description = "Activate OneBrain help skill"
-prompt = "Please activate the 'help' skill and follow its procedural workflow."
+description = "Run the OneBrain help skill"
+prompt = "Run the OneBrain 'help' skill by reading .claude/plugins/onebrain/skills/help/SKILL.md and following its workflow. Do not call activate_skill — OneBrain skills are not Gemini agent-skills; follow the SKILL.md directly."

--- a/.gemini/commands/onebrain/import.toml
+++ b/.gemini/commands/onebrain/import.toml
@@ -1,2 +1,2 @@
-description = "Activate OneBrain import skill"
-prompt = "Please activate the 'import' skill and follow its procedural workflow."
+description = "Run the OneBrain import skill"
+prompt = "Run the OneBrain 'import' skill by reading .claude/plugins/onebrain/skills/import/SKILL.md and following its workflow. Do not call activate_skill — OneBrain skills are not Gemini agent-skills; follow the SKILL.md directly."

--- a/.gemini/commands/onebrain/learn.toml
+++ b/.gemini/commands/onebrain/learn.toml
@@ -1,2 +1,2 @@
-description = "Activate OneBrain learn skill"
-prompt = "Please activate the 'learn' skill and follow its procedural workflow."
+description = "Run the OneBrain learn skill"
+prompt = "Run the OneBrain 'learn' skill by reading .claude/plugins/onebrain/skills/learn/SKILL.md and following its workflow. Do not call activate_skill — OneBrain skills are not Gemini agent-skills; follow the SKILL.md directly."

--- a/.gemini/commands/onebrain/memory-review.toml
+++ b/.gemini/commands/onebrain/memory-review.toml
@@ -1,2 +1,2 @@
-description = "Activate OneBrain memory-review skill"
-prompt = "Please activate the 'memory-review' skill and follow its procedural workflow."
+description = "Run the OneBrain memory-review skill"
+prompt = "Run the OneBrain 'memory-review' skill by reading .claude/plugins/onebrain/skills/memory-review/SKILL.md and following its workflow. Do not call activate_skill — OneBrain skills are not Gemini agent-skills; follow the SKILL.md directly."

--- a/.gemini/commands/onebrain/moc.toml
+++ b/.gemini/commands/onebrain/moc.toml
@@ -1,2 +1,2 @@
-description = "Activate OneBrain moc skill"
-prompt = "Please activate the 'moc' skill and follow its procedural workflow."
+description = "Run the OneBrain moc skill"
+prompt = "Run the OneBrain 'moc' skill by reading .claude/plugins/onebrain/skills/moc/SKILL.md and following its workflow. Do not call activate_skill — OneBrain skills are not Gemini agent-skills; follow the SKILL.md directly."

--- a/.gemini/commands/onebrain/onboarding.toml
+++ b/.gemini/commands/onebrain/onboarding.toml
@@ -1,2 +1,2 @@
-description = "Activate OneBrain onboarding skill"
-prompt = "Please activate the 'onboarding' skill and follow its procedural workflow."
+description = "Run the OneBrain onboarding skill"
+prompt = "Run the OneBrain 'onboarding' skill by reading .claude/plugins/onebrain/skills/onboarding/SKILL.md and following its workflow. Do not call activate_skill — OneBrain skills are not Gemini agent-skills; follow the SKILL.md directly."

--- a/.gemini/commands/onebrain/qmd.toml
+++ b/.gemini/commands/onebrain/qmd.toml
@@ -1,2 +1,2 @@
-description = "Activate OneBrain qmd skill"
-prompt = "Please activate the 'qmd' skill and follow its procedural workflow."
+description = "Run the OneBrain qmd skill"
+prompt = "Run the OneBrain 'qmd' skill by reading .claude/plugins/onebrain/skills/qmd/SKILL.md and following its workflow. Do not call activate_skill — OneBrain skills are not Gemini agent-skills; follow the SKILL.md directly."

--- a/.gemini/commands/onebrain/reading-notes.toml
+++ b/.gemini/commands/onebrain/reading-notes.toml
@@ -1,2 +1,2 @@
-description = "Activate OneBrain reading-notes skill"
-prompt = "Please activate the 'reading-notes' skill and follow its procedural workflow."
+description = "Run the OneBrain reading-notes skill"
+prompt = "Run the OneBrain 'reading-notes' skill by reading .claude/plugins/onebrain/skills/reading-notes/SKILL.md and following its workflow. Do not call activate_skill — OneBrain skills are not Gemini agent-skills; follow the SKILL.md directly."

--- a/.gemini/commands/onebrain/recap.toml
+++ b/.gemini/commands/onebrain/recap.toml
@@ -1,2 +1,2 @@
-description = "Activate OneBrain recap skill"
-prompt = "Please activate the 'recap' skill and follow its procedural workflow."
+description = "Run the OneBrain recap skill"
+prompt = "Run the OneBrain 'recap' skill by reading .claude/plugins/onebrain/skills/recap/SKILL.md and following its workflow. Do not call activate_skill — OneBrain skills are not Gemini agent-skills; follow the SKILL.md directly."

--- a/.gemini/commands/onebrain/reorganize.toml
+++ b/.gemini/commands/onebrain/reorganize.toml
@@ -1,2 +1,2 @@
-description = "Activate OneBrain reorganize skill"
-prompt = "Please activate the 'reorganize' skill and follow its procedural workflow."
+description = "Run the OneBrain reorganize skill"
+prompt = "Run the OneBrain 'reorganize' skill by reading .claude/plugins/onebrain/skills/reorganize/SKILL.md and following its workflow. Do not call activate_skill — OneBrain skills are not Gemini agent-skills; follow the SKILL.md directly."

--- a/.gemini/commands/onebrain/research.toml
+++ b/.gemini/commands/onebrain/research.toml
@@ -1,2 +1,2 @@
-description = "Activate OneBrain research skill"
-prompt = "Please activate the 'research' skill and follow its procedural workflow."
+description = "Run the OneBrain research skill"
+prompt = "Run the OneBrain 'research' skill by reading .claude/plugins/onebrain/skills/research/SKILL.md and following its workflow. Do not call activate_skill — OneBrain skills are not Gemini agent-skills; follow the SKILL.md directly."

--- a/.gemini/commands/onebrain/summarize.toml
+++ b/.gemini/commands/onebrain/summarize.toml
@@ -1,2 +1,2 @@
-description = "Activate OneBrain summarize skill"
-prompt = "Please activate the 'summarize' skill and follow its procedural workflow."
+description = "Run the OneBrain summarize skill"
+prompt = "Run the OneBrain 'summarize' skill by reading .claude/plugins/onebrain/skills/summarize/SKILL.md and following its workflow. Do not call activate_skill — OneBrain skills are not Gemini agent-skills; follow the SKILL.md directly."

--- a/.gemini/commands/onebrain/tasks.toml
+++ b/.gemini/commands/onebrain/tasks.toml
@@ -1,2 +1,2 @@
-description = "Activate OneBrain tasks skill"
-prompt = "Please activate the 'tasks' skill and follow its procedural workflow."
+description = "Run the OneBrain tasks skill"
+prompt = "Run the OneBrain 'tasks' skill by reading .claude/plugins/onebrain/skills/tasks/SKILL.md and following its workflow. Do not call activate_skill — OneBrain skills are not Gemini agent-skills; follow the SKILL.md directly."

--- a/.gemini/commands/onebrain/update.toml
+++ b/.gemini/commands/onebrain/update.toml
@@ -1,2 +1,2 @@
-description = "Activate OneBrain update skill"
-prompt = "Please activate the 'update' skill and follow its procedural workflow."
+description = "Run the OneBrain update skill"
+prompt = "Run the OneBrain 'update' skill by reading .claude/plugins/onebrain/skills/update/SKILL.md and following its workflow. Do not call activate_skill — OneBrain skills are not Gemini agent-skills; follow the SKILL.md directly."

--- a/.gemini/commands/onebrain/weekly.toml
+++ b/.gemini/commands/onebrain/weekly.toml
@@ -1,2 +1,2 @@
-description = "Activate OneBrain weekly skill"
-prompt = "Please activate the 'weekly' skill and follow its procedural workflow."
+description = "Run the OneBrain weekly skill"
+prompt = "Run the OneBrain 'weekly' skill by reading .claude/plugins/onebrain/skills/weekly/SKILL.md and following its workflow. Do not call activate_skill — OneBrain skills are not Gemini agent-skills; follow the SKILL.md directly."

--- a/.gemini/commands/onebrain/wrapup.toml
+++ b/.gemini/commands/onebrain/wrapup.toml
@@ -1,2 +1,2 @@
-description = "Activate OneBrain wrapup skill"
-prompt = "Please activate the 'wrapup' skill and follow its procedural workflow."
+description = "Run the OneBrain wrapup skill"
+prompt = "Run the OneBrain 'wrapup' skill by reading .claude/plugins/onebrain/skills/wrapup/SKILL.md and following its workflow. Do not call activate_skill — OneBrain skills are not Gemini agent-skills; follow the SKILL.md directly."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-latest_version: 3.1.2
+latest_version: 3.1.3
 released: 2026-05-28
 ---
 
@@ -10,6 +10,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 > **Versioning:** Plugin version is tracked in `plugin.json`. Bump when ANY harness config changes — skills, agents, hooks, INSTRUCTIONS, Gemini settings, slash commands, etc.
 > For CLI binary changes, see the [`onebrain-ai/onebrain-cli`](https://github.com/onebrain-ai/onebrain-cli/blob/main/CHANGELOG.md) repository.
+
+## v3.1.3 — 2026-05-28
+
+- **Fix: kill the gemini `activate_skill` error + double-output on `onebrain skill run --harness gemini`.** All 25 `.gemini/commands/onebrain/*.toml` templates used "Please activate the '<skill>' skill" — the word "activate" made gemini call its native `activate_skill` tool with `name="<skill>"`, which failed ("params/name must be equal to one of the allowed values") because OneBrain skills aren't Gemini agent-skills. The agent retried via the SKILL.md fallback, which produced the briefing twice. Reworded all 25 templates to "Run the OneBrain '<name>' skill by reading `skills/<name>/SKILL.md` and following its workflow. Do not call activate_skill" — gemini now goes straight to the SKILL.md, no retry, no double output.
+- **`references/gemini-tools.md` gains a "Tool behaviour differences" section** so skills tolerate gemini's quirks: (1) `glob` / `grep_search` errors on a non-existent path → treat as zero matches and continue (Claude's `Glob`/`Grep` return empty silently); (2) never call `activate_skill` for OneBrain skills; (3) "Ripgrep is not available. Falling back to GrepTool." is harmless — ignore.
+- No `requires.cli` bump.
 
 ## v3.1.2 — 2026-05-28
 


### PR DESCRIPTION
## Problem

Real `onebrain skill run --harness gemini` runs surfaced three issues:

1. **`Error executing tool activate_skill: params/name must be equal to one of the allowed values`** — every run.
2. **Output rendered twice** — the briefing + "I have completed" + the briefing again.
3. **`Error executing tool glob: Search path does not exist <...>/07-logs/session/2026/06`** — when a skill globs a maybe-missing path.

## Root cause

All 25 `.gemini/commands/onebrain/*.toml` had `prompt = "Please activate the '<skill>' skill..."`. The word **"activate"** made gemini call its native `activate_skill` tool with `name="<skill>"` — but OneBrain skills aren't registered Gemini agent-skills (allowed values are `find-skills`/`remotion-best-practices`), so the call failed. The agent then retried via the SKILL.md fallback documented in GEMINI.md, which produced the briefing twice. The glob error is a separate gemini-vs-claude tool semantic: gemini errors on a missing path; Claude returns empty.

## Fix

- **Reword all 25 templates** to "Run the OneBrain '<name>' skill by reading `skills/<name>/SKILL.md` and following its workflow. Do not call activate_skill — OneBrain skills are not Gemini agent-skills." Direct path, no retry, no double output.
- **`references/gemini-tools.md` gains a "Tool behaviour differences" section** so skills tolerate gemini's other quirks: glob/grep_search on a non-existent path → treat as zero matches; never call activate_skill; ripgrep-fallback is harmless.

No `requires.cli` bump — plugin/instructions only.

## Test plan
After merge + `onebrain plugin update --branch main` to pull v3.1.3, re-run:
```
onebrain skill run daily --harness gemini
onebrain skill run weekly --harness gemini --model gemini-2.5-flash
```
Expect: no `activate_skill` error, single (not double) briefing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)