### PR TITLE
feat(doctor): detect & de-link auto-memory wikilinks (plugin v3.1.4)

### DIFF
--- a/.claude/plugins/onebrain/.claude-plugin/plugin.json
+++ b/.claude/plugins/onebrain/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "onebrain",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "description": "OneBrain — Your AI Thinking Partner",
   "author": {
     "name": "OneBrain Contributors"

--- a/.claude/plugins/onebrain/skills/doctor/SKILL.md
+++ b/.claude/plugins/onebrain/skills/doctor/SKILL.md
@@ -70,7 +70,15 @@ The CLI doctor does NOT cover the following — they remain in the skill:
 - Grep `[projects_folder]`, `[areas_folder]`, `[knowledge_folder]`, `[resources_folder]`, `[agent_folder]` for `\[\[.*?\]\]` in `.md` files.
 - **Skip** wikilinks inside fenced code blocks (between ` ``` ` fences), blockquote lines (lines beginning with `>`), inline code spans (the entire `[[...]]` enclosed in backticks on that line), or YAML frontmatter (between the leading `---` and the closing `---`).
 - For each wikilink, extract note name: strip `|display text` suffix AND `#anchor` fragment. Preserve original text for accurate replacement.
-- Check if a `.md` file with that exact name exists anywhere in the vault (case-insensitive). Flag unresolved as `{broken_link, display_text, anchor, source_file, source_line}`.
+- Check if a `.md` file matching the note name exists anywhere in the vault (case-insensitive), testing BOTH the raw slug AND its `_`→`-` normalized form. Flag as unresolved only when neither form matches a vault `.md`. Record as `{broken_link, display_text, anchor, source_file, source_line}`.
+- **Classify each unresolved wikilink** into one of two buckets (auto-memory slugs live in Claude's auto-memory store OUTSIDE the vault, so they never resolve in Obsidian — these are structurally distinct from typos and missing notes):
+  1. **Build the auto-memory slug set, scoped to the CURRENT vault:** derive this vault's project-dir name from the vault root absolute path using Claude Code's encoding — replace every `/` and `.` with `-` (e.g. vault `/Users/keng/Library/Mobile Documents/iCloud~md~obsidian/Documents/ob-1` → project dir `-Users-keng-Library-Mobile-Documents-iCloud~md~obsidian-Documents-ob-1`). Glob `~/.claude/projects/<derived-dir>/memory/*.md` (on Unix expand `$HOME`, don't pass a literal `~` to file tools). Take basenames without the `.md` extension. Scoping to the current vault avoids cross-vault false positives — globbing all projects would pull in unrelated vaults' auto-memory slugs and misclassify links. **If the derived project dir is absent, skip classification entirely** — leave the unresolved links as a single undifferentiated broken-link list and emit nothing for the buckets below. Do NOT fall back to globbing all projects (that reintroduces cross-vault pollution).
+  2. For each unresolved wikilink, take its slug (strip any `memory/` prefix, `|display` suffix, and `#anchor` fragment). Also compute a hyphen-normalized form (`_` → `-`).
+  3. Bucket (VAULT-NOTE-WINS is invariant — a wikilink only reaches this step when NO vault `.md` matches its raw slug OR its `_`→`-` normalized form, per the resolution check above):
+     - (raw slug OR normalized slug) ∈ auto-memory slug set → **🔴 auto-memory mislink** — points outside the vault; fixable via the de-link pass in Step 4.
+     - else → **🟡 missing note / typo** — report only; needs human judgment (existing behavior).
+  4. **The 🔴 bucket must never claim a link that a vault note could satisfy (raw or `_`→`-` normalized).** Any link whose raw or normalized slug resolves to a vault `.md` is NOT 🔴 — it is already resolved (not flagged at all), or, if only a fuzzy near-match exists, it belongs in the 🟡 missing-note / fuzzy-fix bucket (Pass C territory), never in 🔴 auto-de-link.
+- Report the two buckets separately under 📁 Vault, each with a count. The 🔴 auto-memory bucket lists `file:line — [[slug]]`; the 🟡 missing-note bucket keeps the existing broken-link reporting.
 
 **Orphan notes**
 - Find notes in `[knowledge_folder]/` and `[resources_folder]/` with zero inbound wikilinks from any other note. Report only — no auto-fix (linking requires semantic judgment; use `/connect`).
@@ -175,9 +183,9 @@ Two-stream fix:
 
 1. **CLI fixes** — already executed by `onebrain doctor --fix --json` in Step 2a. The JSON `fix[]` array reports outcomes (`fixed`, `failed`, `skip`). Render under each affected check.
 
-2. **Skill fixes** — Read `references/autofix-procedures.md` and run Pass A, B, C, D in order. Each pass confirms with the user before writing. After all passes, run `onebrain qmd reindex` as the Final step.
+2. **Skill fixes** — Read `references/autofix-procedures.md` and run Pass A, B, C, D, E in order. Each pass confirms with the user before writing. After all passes, run `onebrain qmd reindex` as the Final step. Pass E de-links the 🔴 auto-memory mislinks detected in Step 2b (the 🟡 missing-note bucket is never auto-fixed).
 
-The CLI fix recipes cover: settings-hooks, plugin-files, onebrain.yml-keys, claude-settings, qmd. The skill fix passes cover: stale confidence-score updates, broken-wikilink fuzzy-match repair, MEMORY.md structure migration. Together: CLI handles config, skill handles content.
+The CLI fix recipes cover: settings-hooks, plugin-files, onebrain.yml-keys, claude-settings, qmd. The skill fix passes cover: stale confidence-score updates, broken-wikilink fuzzy-match repair, auto-memory wikilink de-linking, MEMORY.md structure migration. Together: CLI handles config, skill handles content.
 
 ---
 

--- a/.claude/plugins/onebrain/skills/doctor/references/autofix-procedures.md
+++ b/.claude/plugins/onebrain/skills/doctor/references/autofix-procedures.md
@@ -103,14 +103,39 @@ If `timezone` was not found: skip this pass, note "No deprecated keys to clean u
 
 ---
 
+## Pass E: De-link auto-memory wikilinks
+
+Fixes: wikilinks that point at Claude auto-memory slugs (`[[feedback-code-review]]`, `[[user-rust-learning]]`, `[[memory/...]]`) which live in `~/.claude/projects/<vault>/memory/` — OUTSIDE the vault — so they never resolve in Obsidian.
+Applies when: /doctor Step 2b flagged 🔴 auto-memory mislinks.
+
+If 0 auto-memory mislinks were found in Step 2b: skip this pass, note "No auto-memory wikilinks to de-link."
+
+**Group by source file** so one confirmation can cover all occurrences in that file (the same slug may appear in several files; the same file may contain several slugs).
+
+Confirm with AskUserQuestion before writing (if user declines, skip this pass — no changes written):
+> Found N auto-memory wikilink(s) across M files. These point at Claude's auto-memory store outside the vault, so they never resolve in Obsidian. De-link them to backticked plain text?
+
+On confirmation, for each auto-memory mislink, replace the `[[...]]` token in place with backticked plain text:
+
+- `[[slug]]` → `` `slug` `` (normalize `_`→`-` to the real auto-memory key, e.g. `[[user_rust_learning]]` → `` `user-rust-learning` ``).
+- `[[slug|display]]` → keep `display` as plain text, drop the `[[ ]]`.
+- `[[slug#anchor]]` → `` `slug` `` (drop the anchor — de-linked plain text has no navigable target; detection already strips `#anchor`, so this keeps detection and transform symmetric).
+- `[[memory/slug]]` → `` `slug` `` (strip the `memory/` prefix, then normalize `_`→`-`).
+
+**Skip** (leave untouched) the same contexts the Step 2b broken-wikilink check skips (fenced code blocks, inline-code spans, YAML frontmatter, blockquote lines, and the `[archive_folder]`).
+
+Report each file changed (one line per file). Do NOT touch the 🟡 missing-note / typo bucket — that is reported only, never auto-fixed.
+
+---
+
 ## Final step
 
-After all fix passes complete, if any files were written to disk (Pass B or Pass C made confirmed changes — Pass A writes to `installed_plugins.json` outside vault, not indexed by qmd; Pass D edits onebrain.yml which is not indexed by qmd):
+After all fix passes complete, if any files were written to disk (Pass B, Pass C, or Pass E made confirmed changes — Pass A writes to `installed_plugins.json` outside vault, not indexed by qmd; Pass D edits onebrain.yml which is not indexed by qmd):
 ```
 onebrain qmd reindex
 ```
 
-Do NOT delete any content, modify files outside `[agent_folder]/MEMORY.md` and the files containing broken wikilinks, or restructure vault folders automatically.
+Do NOT delete any content, modify files outside `[agent_folder]/MEMORY.md` and the files containing broken or auto-memory wikilinks, or restructure vault folders automatically.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ---
-latest_version: 3.1.3
-released: 2026-05-28
+latest_version: 3.1.4
+released: 2026-05-29
 ---
 
 # Changelog
@@ -10,6 +10,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 > **Versioning:** Plugin version is tracked in `plugin.json`. Bump when ANY harness config changes — skills, agents, hooks, INSTRUCTIONS, Gemini settings, slash commands, etc.
 > For CLI binary changes, see the [`onebrain-ai/onebrain-cli`](https://github.com/onebrain-ai/onebrain-cli/blob/main/CHANGELOG.md) repository.
+
+## v3.1.4 — 2026-05-29
+
+- **feat(doctor): detect & de-link auto-memory wikilinks.** Step 2b classifies each unresolved `[[...]]` into 🔴 auto-memory mislink (slug, or its `_`→`-` form, exists in the current vault's `~/.claude/.../memory/`) vs 🟡 missing note / typo (report only). Vault-note-wins is invariant — a link is flagged only when neither its raw nor `_`→`-` normalized slug resolves to a vault `.md`, so a fixable typo is never destroyed. Slug set scoped to the current vault (no cross-vault pollution); skipped if the dir is absent.
+- **feat(doctor --fix): Pass E de-links the auto-memory bucket** — `[[slug]]` → `` `slug` `` (normalizing `_`→`-`), `[[slug|display]]` → plain `display`, `[[slug#anchor]]` → `` `slug` ``, `[[memory/slug]]` → `` `slug` ``. Skips the same contexts as Step 2b detection. Confirms before writing; the 🟡 missing-note bucket is never auto-fixed.
+- Doctor-skill-only change (no CLI dependency); patch bump.
 
 ## v3.1.3 — 2026-05-28
 


### PR DESCRIPTION
## Summary

Vault docs sometimes wikilink **Claude auto-memory slugs** (`[[feedback-code-review]]`, `[[user-rust-learning]]`, `[[memory/...]]`) that live in `~/.claude/projects/<vault>/memory/` — OUTSIDE the vault — so they never resolve in Obsidian. This recurs structurally (Claude writes auto-memory while the agent writes vault notes referencing it). `/doctor` now detects + fixes them.

- **Detection (SKILL.md Step 2b):** classifies each *unresolved* wikilink into 🔴 **auto-memory mislink** (slug — or its `_`→`-` form — exists in the current vault's auto-memory dir) vs 🟡 **missing note / typo** (report only). Reported as separate buckets with counts.
- **`--fix` (autofix-procedures.md Pass E):** de-links the 🔴 bucket → backticked plain text (`[[slug]]` → `` `slug` ``); 🟡 is never auto-fixed.

## Safety invariants (from review)
- **Vault-note-wins:** a link is bucketed 🔴 only when *neither* its raw nor `_`→`-` normalized slug resolves to a vault `.md`. A fixable typo whose real target exists in the vault is routed to the 🟡 fuzzy-fix path (Pass C), never silently de-linked.
- **Slug set scoped to the current vault** (`~/.claude/projects/<derived-dir>/memory/`), not all projects — avoids cross-vault false positives. If the dir is absent, classification is skipped.
- Pass E skips the same contexts as Step 2b detection (fenced code, inline-code spans, frontmatter, blockquotes, archive).

## Review
3-round review via workflow (spec-compliance / detection-logic / doc-quality). Caught + fixed: a data-loss BLOCKER (one-sided `_`→`-` normalization), all-projects glob pollution, a self-contradictory Pass E rule, and a CHANGELOG history regression. All must-fixes applied + verified. English-only. Patch bump (enhances existing skill).

Design: `01-projects/onebrain/plugin/2026-05-29-doctor-automemory-check-design.md` (vault).

🤖 Generated with [Claude Code](https://claude.com/claude-code)