### PR TITLE
fix(startup): support qmd_unembedded: null in session-init status (v3.1.7)

### DIFF
--- a/.claude/plugins/onebrain/.claude-plugin/plugin.json
+++ b/.claude/plugins/onebrain/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "onebrain",
-  "version": "3.1.6",
+  "version": "3.1.7",
   "description": "OneBrain — Your AI Thinking Partner",
   "author": {
     "name": "OneBrain Contributors"

--- a/.claude/plugins/onebrain/INSTRUCTIONS.md
+++ b/.claude/plugins/onebrain/INSTRUCTIONS.md
@@ -217,7 +217,7 @@ Run before responding to any user message.
 **Step 1 — Critical path (greeting blocks on these):** Run in parallel:
 - Read `onebrain.yml` → load Configuration variables; override defaults once resolved. If `onebrain.yml` is missing, fall back to legacy `vault.yml` (v3.0 name) — same schema; surface a one-line deprecation note in the startup status so the user knows to run `onebrain doctor --fix` to migrate.
 - Read `[agent_folder]/MEMORY.md` → load identity, personality, active projects
-- Run `onebrain session init --json` (from vault root) → parse JSON output; store `DATETIME` (for greeting), `session_token` (for checkpoints), `qmd_unembedded`, and `headless` in context. JSON shape: `{"datetime":"Ddd · DD Mon YYYY · HH:MM","session_token":"XXXXX","qmd_unembedded":N,"headless":true|false}`. **CLI v3.1+ requires `--json` because the default output flipped to text.** The v3.0 alias `onebrain session-init` still works and now auto-rewrites to include `--json` when `onebrain plugin update` runs. If the command fails or is unavailable, fall back to running `date '+%a · %d %b %Y · %H:%M'` for `DATETIME`, treating `session_token` as `99999`, `qmd_unembedded` as `0`, and `headless` as `false`. If JSON output contains `{"decision":"block","reason":"onebrain-vault-not-found"}` (CLI v3.1+) or `"reason":"onebrain-init-required"` (CLI v3.0 back-compat), skip Steps 2–4; instead output a single message: "OneBrain vault not initialized. Run `/onboarding` to set up your vault."
+- Run `onebrain session init --json` (from vault root) → parse JSON output; store `DATETIME` (for greeting), `session_token` (for checkpoints), `qmd_unembedded`, and `headless` in context. JSON shape: `{"datetime":"Ddd · DD Mon YYYY · HH:MM","session_token":"XXXXX","qmd_unembedded":N|null,"headless":true|false}`. `qmd_unembedded` is a count `N`, or **`null`** (CLI v3.3.3+) when the qmd probe couldn't determine it (qmd missing / timed out / unparseable) — treat `null` as **unknown**, distinct from a genuine `0` (a real index with nothing pending). **CLI v3.1+ requires `--json` because the default output flipped to text.** The v3.0 alias `onebrain session-init` still works and now auto-rewrites to include `--json` when `onebrain plugin update` runs. If the command fails or is unavailable, fall back to running `date '+%a · %d %b %Y · %H:%M'` for `DATETIME`, treating `session_token` as `99999`, `qmd_unembedded` as `0`, and `headless` as `false`. If JSON output contains `{"decision":"block","reason":"onebrain-vault-not-found"}` (CLI v3.1+) or `"reason":"onebrain-init-required"` (CLI v3.0 back-compat), skip Steps 2–4; instead output a single message: "OneBrain vault not initialized. Run `/onboarding` to set up your vault."
   - **If `headless` is `true`** (CLI v3.2.6+, set by `onebrain skill run`): this is an unattended one-shot run, so **skip Steps 2–4 entirely** — no greeting, no startup status, and none of Step 3's memory/inbox/task/orphan/pause scans — and proceed directly to the invoked skill. The `headless` field is absent on older CLIs; treat absent as `false` (normal interactive startup).
 
 **Step 2 — Send greeting immediately:**
@@ -257,14 +257,15 @@ On weekends: lighter, less task-focused tone. **No-repeat rule:** don't ask abou
 
 **Step 4 — Send startup status (after Step 3 completes):**
 
-If inbox_count = 0 and orphan_count = 0 and qmd_unembedded = 0 and active_pause_slug is null and vault_structure_legacy = false and no tasks found: show nothing after the greeting.
+If inbox_count = 0 and orphan_count = 0 and qmd_unembedded = 0 (a definite zero — **not** `null`) and active_pause_slug is null and vault_structure_legacy = false and no tasks found: show nothing after the greeting. (When `qmd_unembedded` is `null` the qmd status line below is shown, so the status block is not silent.)
 
 Otherwise, append after the greeting:
 
 ```
 📥 inbox [N]                               ← omit if inbox_count = 0
 📋 [N] orphan session(s) — /wrapup?        ← omit if orphan_count = 0
-⚠️ qmd: [N] doc(s) need embedding — /qmd embed   ← omit if qmd_unembedded = 0
+⚠️ qmd: [N] doc(s) need embedding — /qmd embed   ← when qmd_unembedded = N > 0; omit entirely when = 0
+⚠️ qmd: index status unknown (qmd unavailable) — /qmd status   ← when qmd_unembedded is null (probe couldn't check)
 📂 active pause: {active_pause_slug} ({active_pause_count} snapshots, last {active_pause_last_date}) — /resume?   ← omit if active_pause_slug is null
 ⚠️ vault structure outdated — run /update to migrate   ← omit if vault_structure_legacy = false
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ---
-latest_version: 3.1.6
-released: 2026-05-30
+latest_version: 3.1.7
+released: 2026-06-26
 ---
 
 # Changelog
@@ -11,8 +11,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 > **Versioning:** Plugin version is tracked in `plugin.json`. Bump when ANY harness config changes — skills, agents, hooks, INSTRUCTIONS, Gemini settings, slash commands, etc.
 > For CLI binary changes, see the [`onebrain-ai/onebrain-cli`](https://github.com/onebrain-ai/onebrain-cli/blob/main/CHANGELOG.md) repository.
 
-## Unreleased
+## v3.1.7 — 2026-06-26 — startup: qmd_unembedded null support
 
+- **fix(startup): support `qmd_unembedded: null` in the session-init status.** onebrain-cli v3.3.3+ returns `qmd_unembedded: null` (instead of a false `0`) when the qmd probe can't determine the count — qmd missing, timed out, or unparseable. Startup (Step 1 / Step 4) now treats `null` as **unknown**, distinct from a genuine `0`, and surfaces `⚠️ qmd: index status unknown (qmd unavailable) — /qmd status` rather than silently hiding it. Companion to the CLI change; backward-compatible (older CLIs never emit `null`, so the new branch simply never fires — `requires.cli` stays `>=3.1.0`).
 - **Relicensed from `AGPL-3.0-only` to `MIT OR Apache-2.0`** — permissive dual license, applied org-wide. Sole-author relicense; effective from here on. (The v3.0.1 MIT→AGPL entries below are kept as historical record.)
 
 ## v3.1.6 — 2026-05-30


### PR DESCRIPTION
## What

Follow-up to **onebrain-cli v3.3.3** (qmd probe unification). The CLI's `onebrain session init --json` now returns `qmd_unembedded: null` (instead of a false `0`) when the qmd probe can't determine the count — qmd missing, timed out, or unparseable. This updates the plugin's startup contract to handle that.

## Changes (`INSTRUCTIONS.md`)

- **Step 1** — JSON shape documents `qmd_unembedded:N|null`; `null` (CLI v3.3.3+) = **unknown**, distinct from a genuine `0`.
- **Step 4 silence rule** — only a *definite* `0` (not `null`) contributes to "show nothing"; `null` surfaces the qmd line.
- **Step 4 output** — adds `⚠️ qmd: index status unknown (qmd unavailable) — /qmd status` for the `null` case (the `[N] need embedding` line stays for `N>0`, omitted for `0`).

## Versioning

- `plugin.json` 3.1.6 → **3.1.7** (INSTRUCTIONS change → bump per the CHANGELOG's versioning note).
- CHANGELOG cuts **v3.1.7**, folding the already-pending relicense `Unreleased` entry.
- **Backward-compatible**: older CLIs never emit `null`, so the new branch simply never fires — `requires.cli` stays `>=3.1.0`.

The vault-installed copy syncs via `/update` after merge.