### PR TITLE
ci: add config-validity + markdown-link checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  config:
+    name: config validity
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: python3 scripts/check-config.py
+
+  links:
+    name: markdown links
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: python3 scripts/check-links.py

--- a/scripts/check-config.py
+++ b/scripts/check-config.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""CI: validate every tracked JSON and TOML file parses, and that the plugin's
+manifest files carry their required keys. Pure stdlib — no third-party deps.
+
+A syntax error in plugin.json / marketplace.json / hooks.json / .mcp.json ships
+a broken plugin to users, so this is the cheapest high-value gate we have.
+"""
+import json
+import subprocess
+import sys
+
+try:
+    import tomllib  # py3.11+
+except ModuleNotFoundError:  # pragma: no cover
+    tomllib = None
+
+REQUIRED = {
+    ".claude/plugins/onebrain/.claude-plugin/plugin.json": ["name", "version", "description"],
+    ".claude-plugin/marketplace.json": ["name", "plugins"],
+}
+
+
+def tracked(*globs):
+    out = subprocess.run(
+        ["git", "ls-files", *globs], capture_output=True, text=True, check=True
+    ).stdout
+    return [p for p in out.splitlines() if p]
+
+
+def main():
+    errors = []
+
+    for path in tracked("*.json"):
+        try:
+            with open(path, encoding="utf-8") as fh:
+                data = json.load(fh)
+        except (json.JSONDecodeError, OSError) as exc:
+            errors.append(f"{path}: invalid JSON — {exc}")
+            continue
+        for key in REQUIRED.get(path, []):
+            if key not in data:
+                errors.append(f"{path}: missing required key '{key}'")
+
+    toml_files = tracked("*.toml")
+    if toml_files:
+        if tomllib is None:
+            errors.append("tomllib unavailable (need Python 3.11+) — cannot validate TOML")
+        else:
+            for path in toml_files:
+                try:
+                    with open(path, "rb") as fh:
+                        tomllib.load(fh)
+                except (tomllib.TOMLDecodeError, OSError) as exc:
+                    errors.append(f"{path}: invalid TOML — {exc}")
+
+    if errors:
+        print("Config validation failed:")
+        for e in errors:
+            print(f"  ✗ {e}")
+        sys.exit(1)
+    print("Config OK — all tracked JSON/TOML parse; manifest keys present.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/check-links.py
+++ b/scripts/check-links.py
@@ -1,9 +1,13 @@
 #!/usr/bin/env python3
 """CI: verify relative file links in Markdown resolve to a real file.
 
-Conservative by design — only inline `[text](target)` links are checked:
+Checks two link forms and verifies each relative target resolves to a real file:
+  * inline Markdown `[text](target)` links, and
+  * HTML `src="…"` / `srcset="…"` attributes (so `<picture>`/`<img>` banners are
+    guarded — the only relative link many READMEs actually carry).
+Conservative by design:
   * `[[wikilinks]]` (Obsidian) have no parens, so they are never matched.
-  * external targets (http, https, mailto, tel, //) are skipped.
+  * external targets (http, https, mailto, tel, data:, //) are skipped.
   * pure `#anchor` targets are skipped; a trailing `#anchor` / `?query` is stripped.
   * fenced ``` code blocks are ignored so documented examples don't false-positive.
 Pure stdlib — no third-party deps.
@@ -14,7 +18,8 @@ import subprocess
 import sys
 
 LINK = re.compile(r"(?<!\!)\[[^\]]*\]\(([^)]+)\)")
-SKIP_SCHEMES = ("http://", "https://", "mailto:", "tel:", "//", "#")
+ATTR = re.compile(r'(?:src|srcset)\s*=\s*"([^"]+)"')
+SKIP_SCHEMES = ("http://", "https://", "mailto:", "tel:", "data:", "//", "#")
 
 
 def tracked_md():
@@ -42,7 +47,12 @@ def main():
         base = os.path.dirname(md)
         with open(md, encoding="utf-8") as fh:
             body = strip_code(fh.read())
-        for target in LINK.findall(body):
+        # Markdown `[text](target)` targets, plus every candidate URL inside an
+        # HTML src / srcset attribute (srcset is comma-separated `url [descriptor]`).
+        candidates = list(LINK.findall(body))
+        for attr in ATTR.findall(body):
+            candidates += [c.strip().split()[0] for c in attr.split(",") if c.strip()]
+        for target in candidates:
             t = target.strip().split()[0]  # drop optional "title"
             if t.startswith(SKIP_SCHEMES) or not t:
                 continue

--- a/scripts/check-links.py
+++ b/scripts/check-links.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""CI: verify relative file links in Markdown resolve to a real file.
+
+Conservative by design — only inline `[text](target)` links are checked:
+  * `[[wikilinks]]` (Obsidian) have no parens, so they are never matched.
+  * external targets (http, https, mailto, tel, //) are skipped.
+  * pure `#anchor` targets are skipped; a trailing `#anchor` / `?query` is stripped.
+  * fenced ``` code blocks are ignored so documented examples don't false-positive.
+Pure stdlib — no third-party deps.
+"""
+import os
+import re
+import subprocess
+import sys
+
+LINK = re.compile(r"(?<!\!)\[[^\]]*\]\(([^)]+)\)")
+SKIP_SCHEMES = ("http://", "https://", "mailto:", "tel:", "//", "#")
+
+
+def tracked_md():
+    out = subprocess.run(
+        ["git", "ls-files", "*.md"], capture_output=True, text=True, check=True
+    ).stdout
+    return [p for p in out.splitlines() if p]
+
+
+def strip_code(text):
+    """Blank out fenced code blocks so example links inside them are ignored."""
+    lines, out, fence = text.splitlines(), [], False
+    for ln in lines:
+        if ln.lstrip().startswith("```"):
+            fence = not fence
+            out.append("")
+            continue
+        out.append("" if fence else ln)
+    return "\n".join(out)
+
+
+def main():
+    errors = []
+    for md in tracked_md():
+        base = os.path.dirname(md)
+        with open(md, encoding="utf-8") as fh:
+            body = strip_code(fh.read())
+        for target in LINK.findall(body):
+            t = target.strip().split()[0]  # drop optional "title"
+            if t.startswith(SKIP_SCHEMES) or not t:
+                continue
+            t = t.split("#", 1)[0].split("?", 1)[0]
+            if not t:
+                continue
+            root = base if not t.startswith("/") else "."
+            resolved = os.path.normpath(os.path.join(root, t.lstrip("/")))
+            if not os.path.exists(resolved):
+                errors.append(f"{md}: broken link → {target}")
+
+    if errors:
+        print("Broken Markdown links:")
+        for e in errors:
+            print(f"  ✗ {e}")
+        sys.exit(1)
+    print("Links OK — all relative Markdown links resolve.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
The plugin repo had **no CI**. This adds a lightweight GitHub Actions workflow (`.github/workflows/ci.yml`) with two pure-stdlib checks — no third-party actions (matches the CLI repo's Python-checker style):

- **config** (`scripts/check-config.py`) — every tracked `*.json` + `*.toml` parses; `plugin.json` and `marketplace.json` carry their required keys. A broken manifest would ship a dead plugin to users.
- **links** (`scripts/check-links.py`) — relative links resolve, for both Markdown `[text](target)` links **and** HTML `src`/`srcset` attributes (guards `<picture>`/`<img>` banners). Conservative: ignores `[[wikilinks]]`, external URLs, `#anchors`, `data:`, and fenced code blocks.

Both verified locally: pass on the current tree; fail correctly on injected bad JSON / broken Markdown link / broken `srcset`. No version bump (CI infra, not a plugin file).

Once green + merged, this repo's branch protection will require these two checks (per the org branch-protection baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)