### PR TITLE
feat(mcp): native MCP backend — .mcp.json qmd → onebrain mcp (v3.1.10)

### DIFF
--- a/.claude/plugins/onebrain/.claude-plugin/plugin.json
+++ b/.claude/plugins/onebrain/.claude-plugin/plugin.json
@@ -1,12 +1,12 @@
 {
   "name": "onebrain",
-  "version": "3.1.9",
+  "version": "3.1.10",
   "description": "OneBrain — Your AI Thinking Partner",
   "author": {
     "name": "OneBrain Contributors"
   },
   "license": "MIT OR Apache-2.0",
   "requires": {
-    "cli": ">=3.1.0"
+    "cli": ">=3.4.1"
   }
 }

--- a/.claude/plugins/onebrain/.mcp.json
+++ b/.claude/plugins/onebrain/.mcp.json
@@ -1,6 +1,6 @@
 {
   "qmd": {
-    "command": "qmd",
+    "command": "onebrain",
     "args": ["mcp"]
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ---
-latest_version: 3.1.9
-released: 2026-06-29
+latest_version: 3.1.10
+released: 2026-07-03
 ---
 
 # Changelog
@@ -10,6 +10,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 > **Versioning:** Plugin version is tracked in `plugin.json`. Bump when ANY harness config changes — skills, agents, hooks, INSTRUCTIONS, Gemini settings, slash commands, etc.
 > For CLI binary changes, see the [`onebrain-ai/onebrain-cli`](https://github.com/onebrain-ai/onebrain-cli/blob/main/CHANGELOG.md) repository.
+
+## v3.1.10 — 2026-07-03 — native MCP backend (`onebrain mcp` replaces `qmd mcp`)
+
+- **feat(mcp): `.mcp.json` now launches `onebrain mcp` instead of `qmd mcp`.** Agent-session vault search is served by the native OneBrain engine (`onebrain-search`, hybrid lex+vector, RRF-fused) over the same `query`/`get`/`multi_get`/`status` tools qmd exposed. The server key stays `qmd`, so the tool namespace (`mcp__plugin_onebrain_qmd__*`) and every INSTRUCTIONS.md reference are unchanged — a pure backend swap.
+- **Requires CLI ≥ 3.4.1** (`requires.cli` raised from `>=3.1.0`): the top-level `onebrain mcp` command first shipped in onebrain-cli v3.4.1; older CLIs lack it and the server would fail to start.
+- No skill/agent/INSTRUCTIONS changes — qmd stays installed and usable via `/qmd`; full qmd removal + `/qmd`→`/search` cutover land later in the v3.4.5 epic.
 
 ## v3.1.9 — 2026-06-29 — fence-aware task scan via `onebrain task list`
 


### PR DESCRIPTION
## What

Swap the plugin's MCP server backend from `qmd mcp` to the native `onebrain mcp` engine.

```diff
 {
   "qmd": {
-    "command": "qmd",
+    "command": "onebrain",
     "args": ["mcp"]
   }
 }
```

The server key stays **`qmd`**, so the tool namespace (`mcp__plugin_onebrain_qmd__*`) and every `INSTRUCTIONS.md` reference are **unchanged** — this is a pure backend swap. Agent-session vault search is now served by the native `onebrain-search` engine (hybrid lex+vector, RRF-fused) over the same `query`/`get`/`multi_get`/`status` tool surface qmd exposed.

## Why

`onebrain mcp` (onebrain-cli v3.4.1+) is qmd-compatible and removes the external qmd process as the search backend for agent sessions. Verified live over this vault: native index has 724 docs (collection `ob-1-441565`), lexical + status queries return real results.

## Changes

- `.mcp.json`: `command` `qmd` → `onebrain`
- `plugin.json`: `requires.cli` `>=3.1.0` → `>=3.4.1` (top-level `onebrain mcp` first shipped in onebrain-cli **v3.4.1**), version `3.1.9` → **`3.1.10`**
- `CHANGELOG.md`: v3.1.10 entry

## Version note

**Patch** (`3.1.10`), not minor: this is a backend swap under an **unchanged tool interface** (`query`/`get`/`multi_get`/`status` names and the `qmd` server key are all preserved) — no new command, no API break. Raising the CLI floor is metadata. (Correctness reviewer + the repo's version-granularity rule both point to patch.)

## Scope

Config-only. qmd stays installed and usable via `/qmd`. Full qmd removal + `/qmd`→`/search` skill cutover + #114 cache relocation land later in the v3.4.5 epic. Activates for the running agent only after `/update` pulls the new plugin into the vault.

## Test

- [x] `scripts/check-config.py` — pass (JSON/TOML valid, manifest keys present)
- [x] `scripts/check-links.py` — pass
- [x] `onebrain mcp --help` present in installed cli v3.4.4
- [x] `onebrain search status` / lexical query return real hits over this vault
- [x] 3-round review (correctness / completeness / adversarial) — see review comment