### PR TITLE
assets: coevo-loop as true-circle geometry

### DIFF
--- a/assets/diagrams/coevo-loop-dark.svg
+++ b/assets/diagrams/coevo-loop-dark.svg
@@ -1,21 +1,7 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 450 420" width="450" height="420" role="img" aria-labelledby="ttl desc">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 450 372" width="450" height="372" role="img" aria-labelledby="ttl desc">
   <title id="ttl">The path to co-evolution — three-step loop</title>
-  <desc id="desc">Three panels in a triangle around the OneBrain mark: 01 CAPTURE (/braindump) at top, 02 EVOLVE (/distill, /learn) at bottom-right, 03 WRAPUP (/wrapup, /recap) at bottom-left. Dashed arrows flow clockwise between them — the recurring co-evolution loop.</desc>
+  <desc id="desc">Three panels on a circle: 01 CAPTURE (/braindump) at twelve o'clock, 02 EVOLVE (/distill, /learn) at four o'clock, 03 WRAPUP (/wrapup, /recap) at eight o'clock. Dashed arrows travel clockwise along the circle between them — the recurring co-evolution loop.</desc>
   <defs>
-    <linearGradient id="ob-brain-grad" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#ff2d92"/>
-      <stop offset="55%" stop-color="#ff5aa3"/>
-      <stop offset="100%" stop-color="#00f3ff"/>
-    </linearGradient>
-    <radialGradient id="ob-spark-glow">
-      <stop offset="0%" stop-color="#ffffff"/>
-      <stop offset="35%" stop-color="#ffffff" stop-opacity=".7"/>
-      <stop offset="100%" stop-color="#00f3ff" stop-opacity="0"/>
-    </radialGradient>
-    <linearGradient id="grad-button" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#bc13fe"/>
-      <stop offset="100%" stop-color="#00f3ff"/>
-    </linearGradient>
     <marker id="arrow" viewBox="0 0 3 2" refX="0" refY="1" markerWidth="3" markerHeight="2" orient="auto">
       <path d="M0 0 L3 1 L0 2 Z" fill="#a8d000"/>
     </marker>
@@ -23,12 +9,9 @@
     <symbol id="i-learn" viewBox="0 0 24 24"><path d="M9 18h6"/><path d="M10 22h4"/><path d="M15.09 14c.18-.98.65-1.74 1.41-2.5A4.65 4.65 0 0 0 18 8 6 6 0 0 0 6 8c0 1 .23 2.23 1.5 3.5A4.6 4.6 0 0 1 8.91 14"/></symbol>
     <symbol id="i-recap" viewBox="0 0 24 24"><polyline points="1 4 1 10 7 10"/><path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10"/></symbol>
     <path id="gc41" d="M340 -700H464L597 0H459L431 -155H185L99 0H-39ZM418 -267 373 -533H371L233 -267Z"/>
-    <path id="gc42" d="M145 -700H575L665 -592L631 -404L584 -363L642 -291L608 -98L493 0H22ZM462 -407 504 -443 523 -551 494 -586H258L227 -407ZM434 -114 485 -157 502 -255 467 -298H208L175 -114Z"/>
     <path id="gc43" d="M33 -124 116 -593 241 -700H582L683 -579L665 -480H529L539 -537L501 -584H301L241 -533L176 -167L218 -116H418L473 -163L484 -220H620L599 -105L476 0H135Z"/>
     <path id="gc45" d="M145 -700H650L630 -585H261L230 -408H570L550 -295H210L178 -115H547L527 0H22Z"/>
-    <path id="gc49" d="M150 -700H286L162 0H26Z"/>
     <path id="gc4c" d="M145 -700H281L178 -115H527L507 0H22Z"/>
-    <path id="gc4e" d="M145 -700H267L496 -225H498L581 -700H712L588 0H466L239 -474H237L153 0H22Z"/>
     <path id="gc4f" d="M33 -124 116 -593 241 -700H601L703 -577L619 -103L497 0H135ZM434 -116 494 -167 559 -533 517 -584H302L242 -533L176 -167L218 -116Z"/>
     <path id="gc50" d="M145 -700H575L670 -584L626 -336L511 -238H200L158 0H22ZM460 -352 501 -387 530 -551 501 -586H261L220 -352Z"/>
     <path id="gc52" d="M633 -372 557 -307 612 -232 571 0H435L471 -207L427 -268H205L158 0H22L145 -700H575L670 -584ZM225 -380H465L506 -415L530 -551L501 -586H261Z"/>
@@ -65,89 +48,36 @@
   </defs>
   <style>
     .ico { fill: none; stroke-width: 1.75; stroke-linecap: round; stroke-linejoin: round; }
-    /* MOTION RULE: cards never animate — motion is ONLY this connector dash-flow + the brain-mark neuron spark. */
+    /* MOTION RULE: cards never animate — motion is ONLY this connector dash-flow. */
     .plug { fill: none; stroke: #a8d000; stroke-width: 1.5; stroke-linecap: round; stroke-dasharray: 5 7; }
     .plug-flow { animation: plug-flow 1200ms linear infinite; }
     @keyframes plug-flow { to { stroke-dashoffset: -24; } }
-    .sparks .halo { fill: url(#ob-spark-glow); }
-    .sparks .core { fill: #fff; transform-box: fill-box; transform-origin: center; }
-    .sparks .spark { opacity: .16; animation: ob-spk var(--d) ease-in-out var(--dl) infinite; }
-    .sparks .core { animation: ob-spkpop var(--d) ease-in-out var(--dl) infinite; }
-    @keyframes ob-spk { 0%,16%,100% { opacity: .16; } 5% { opacity: 1; } 10% { opacity: .42; } }
-    @keyframes ob-spkpop { 0%,16%,100% { transform: scale(1); } 5% { transform: scale(1.65); } }
     @media (prefers-reduced-motion: reduce) {
-      .plug-flow, .sparks .spark, .sparks .core { animation: none; }
-      .sparks .spark { opacity: .22; }
+      .plug-flow { animation: none; }
     }
   </style>
-  <path class="plug" d="M312 76 Q400 130 372 291" opacity="0.22"/>
-  <path class="plug plug-flow" d="M312 76 Q400 130 372 291" style="animation-delay:0ms" marker-end="url(#arrow)"/>
-  <path class="plug" d="M300 372 Q225 404 150 372" opacity="0.22"/>
-  <path class="plug plug-flow" d="M300 372 Q225 404 150 372" style="animation-delay:400ms" marker-end="url(#arrow)"/>
-  <path class="plug" d="M78 292 Q50 130 138 76" opacity="0.22"/>
-  <path class="plug plug-flow" d="M78 292 Q50 130 138 76" style="animation-delay:800ms" marker-end="url(#arrow)"/>
-  <rect x="146" y="28" width="158" height="66" fill="#08080e" stroke="#ffffff0f" stroke-width="1"/>
-  <rect x="145.5" y="27.5" width="2" height="67" fill="#a8d000"/>
-<g transform="translate(244.76 45.14) scale(0.00829)" fill="#ffffff2e"><use href="#gm53" x="0"/><use href="#gm54" x="860"/><use href="#gm45" x="1720"/><use href="#gm50" x="2580"/><use href="#gm5f" x="3440"/><use href="#gm30" x="4300"/><use href="#gm31" x="5160"/></g>
-  <svg x="162" y="50" width="18" height="18"><use href="#i-capture" class="ico" stroke="#a8d000"/></svg>
-<g transform="translate(189.29 65.00) scale(0.02143)" fill="#ffffff"><use href="#gc43" x="0"/><use href="#gc41" x="675"/><use href="#gc50" x="1341"/><use href="#gc54" x="2007"/><use href="#gc55" x="2611"/><use href="#gc52" x="3331"/><use href="#gc45" x="4026"/></g>
-<g transform="translate(189.38 81.99) scale(0.00842)" fill="#ffffff9e"><use href="#gm2f" x="0"/><use href="#gm62" x="660"/><use href="#gm72" x="1320"/><use href="#gm61" x="1980"/><use href="#gm69" x="2640"/><use href="#gm6e" x="3300"/><use href="#gm64" x="3960"/><use href="#gm75" x="4620"/><use href="#gm6d" x="5280"/><use href="#gm70" x="5940"/></g>
-  <rect x="268" y="300" width="158" height="66" fill="#08080e" stroke="#ffffff0f" stroke-width="1"/>
-  <rect x="267.5" y="299.5" width="2" height="67" fill="#a8d000"/>
-<g transform="translate(366.88 317.14) scale(0.00829)" fill="#ffffff2e"><use href="#gm53" x="0"/><use href="#gm54" x="860"/><use href="#gm45" x="1720"/><use href="#gm50" x="2580"/><use href="#gm5f" x="3440"/><use href="#gm30" x="4300"/><use href="#gm32" x="5160"/></g>
-  <svg x="284" y="322" width="18" height="18"><use href="#i-learn" class="ico" stroke="#a8d000"/></svg>
-<g transform="translate(311.53 337.00) scale(0.02143)" fill="#ffffff"><use href="#gc45" x="0"/><use href="#gc56" x="626"/><use href="#gc4f" x="1296"/><use href="#gc4c" x="2016"/><use href="#gc56" x="2597"/><use href="#gc45" x="3267"/></g>
-<g transform="translate(311.34 354.51) scale(0.00904)" fill="#ffffff9e"><use href="#gm2f" x="0"/><use href="#gm64" x="660"/><use href="#gm69" x="1320"/><use href="#gm73" x="1980"/><use href="#gm74" x="2640"/><use href="#gm69" x="3300"/><use href="#gm6c" x="3960"/><use href="#gm6c" x="4620"/><use href="#gmb7" x="5940"/><use href="#gm2f" x="7260"/><use href="#gm6c" x="7920"/><use href="#gm65" x="8580"/><use href="#gm61" x="9240"/><use href="#gm72" x="9900"/><use href="#gm6e" x="10560"/></g>
-  <rect x="24" y="300" width="158" height="66" fill="#08080e" stroke="#ffffff0f" stroke-width="1"/>
-  <rect x="23.5" y="299.5" width="2" height="67" fill="#a8d000"/>
-<g transform="translate(123.01 317.14) scale(0.00829)" fill="#ffffff2e"><use href="#gm53" x="0"/><use href="#gm54" x="860"/><use href="#gm45" x="1720"/><use href="#gm50" x="2580"/><use href="#gm5f" x="3440"/><use href="#gm30" x="4300"/><use href="#gm33" x="5160"/></g>
-  <svg x="40" y="322" width="18" height="18"><use href="#i-recap" class="ico" stroke="#a8d000"/></svg>
-<g transform="translate(65.75 337.00) scale(0.02143)" fill="#ffffff"><use href="#gc57" x="0"/><use href="#gc52" x="899"/><use href="#gc41" x="1594"/><use href="#gc50" x="2260"/><use href="#gc55" x="2926"/><use href="#gc50" x="3646"/></g>
-<g transform="translate(67.38 353.99) scale(0.00842)" fill="#ffffff9e"><use href="#gm2f" x="0"/><use href="#gm77" x="660"/><use href="#gm72" x="1320"/><use href="#gm61" x="1980"/><use href="#gm70" x="2640"/><use href="#gm75" x="3300"/><use href="#gm70" x="3960"/><use href="#gmb7" x="5280"/><use href="#gm2f" x="6600"/><use href="#gm72" x="7260"/><use href="#gm65" x="7920"/><use href="#gm63" x="8580"/><use href="#gm61" x="9240"/><use href="#gm70" x="9900"/></g>
-  <path d="M160 186 H302 V228 L290 240 H148 V198 Z" fill="url(#grad-button)"/>
-  <path d="M161.5 187.5 H300.5 V226.5 L288.5 238.5 H149.5 V199.5 Z" fill="#050507"/>
-  <svg x="168" y="204.94" width="19.25" height="16.12" viewBox="4.5 0.0 428.0 358.5" overflow="visible" aria-hidden="true">
-    <g transform="translate(433,466) scale(-0.1,-0.1)" fill="url(#ob-brain-grad)" stroke="none">
-    <path d="M1774 4637 c-19 -17 -29 -37 -33 -67 -6 -43 -7 -45 -149 -141 l-143 -97 -54 5 c-50 5 -56 4 -84 -25 -21 -20 -31 -40 -31 -60 l0 -29 -247 -78 c-238 -75 -247 -77 -274 -61 -56 33 -114 -4 -112 -71 2 -36 -9 -53 -123 -201 -103 -133 -130 -162 -150 -162 -58 0 -103 -45 -104 -105 -1 -37 -6 -45 -79 -107 -65 -56 -85 -68 -114 -68 -73 0 -105 -97 -47 -142 28 -22 31 -32 47 -139 l17 -117 -28 -33 c-39 -46 -33 -111 13 -150 l31 -25 0 -237 c0 -224 -1 -238 -20 -257 -64 -64 15 -176 88 -124 22 15 125 -6 515 -107 21 -6 37 -16 37 -25 0 -16 56 -54 82 -54 9 0 50 -41 92 -91 66 -78 76 -96 76 -129 0 -73 68 -102 120 -51 28 27 37 29 146 35 64 4 120 4 125 -1 5 -5 -32 -144 -86 -320 -52 -172 -95 -317 -95 -322 0 -29 42 7 266 229 215 213 246 240 274 240 19 0 43 10 60 24 42 35 151 45 187 16 52 -41 105 -11 109 62 3 58 99 241 129 246 11 2 31 14 45 27 l25 23 160 -14 c88 -7 177 -13 197 -14 24 0 47 -9 66 -25 50 -42 105 -29 120 30 12 43 255 219 291 210 32 -8 76 11 89 39 8 18 25 26 89 39 43 9 182 39 308 67 172 38 241 49 273 44 60 -9 92 13 92 65 0 56 196 301 250 312 18 4 40 15 47 25 20 28 16 88 -7 109 -31 28 -31 432 0 460 43 39 21 119 -39 139 -22 8 -79 64 -186 185 -145 164 -153 175 -148 207 16 99 -91 160 -163 93 l-23 -21 -103 21 c-200 42 -197 41 -213 72 -10 18 -27 32 -48 37 -28 7 -35 16 -53 68 -15 39 -19 65 -13 76 14 26 11 71 -7 96 -16 24 -81 31 -100 12 -15 -15 -288 139 -292 165 -10 66 -42 95 -103 95 -40 0 -89 -48 -89 -87 0 -27 -7 -32 -91 -68 -88 -38 -91 -38 -119 -22 -35 21 -74 22 -103 2 -33 -21 -426 157 -427 193 -1 87 -101 135 -166 79z m26 -184 c28 -14 38 -14 64 -4 59 24 71 21 260 -68 187 -88 190 -89 201 -128 l11 -38 -181 -229 -181 -229 -48 -1 -48 -1 -199 210 -198 210 -1 50 0 51 142 97 c78 53 143 97 144 97 0 0 16 -7 34 -17z m929 -107 c9 -10 2 -63 -29 -222 -23 -115 -49 -249 -57 -299 -9 -49 -19 -93 -23 -98 -4 -4 -37 98 -74 226 -59 204 -67 237 -56 257 7 13 16 35 19 48 5 18 27 33 91 62 94 43 112 46 129 26z m266 -63 c91 -52 140 -86 146 -101 5 -12 24 -31 42 -42 25 -15 37 -32 50 -73 35 -112 53 -95 -255 -255 -150 -77 -280 -142 -288 -144 -24 -5 -18 44 45 366 56 281 60 298 84 311 36 19 24 23 176 -62z m-567 -118 c4 -4 132 -453 132 -465 0 -5 -9 -19 -20 -30 -24 -24 -28 -114 -6 -145 12 -18 3 -40 -88 -215 -140 -268 -120 -271 -299 35 -125 212 -138 238 -131 268 4 17 6 49 6 70 -2 34 13 56 180 267 181 228 195 241 226 215z m-1118 -272 l-26 -238 -46 -8 -47 -9 -198 173 c-109 95 -199 176 -201 180 -2 4 21 14 50 23 29 9 143 44 253 79 175 56 203 62 220 51 l21 -13 -26 -238z m328 27 c198 -209 199 -210 198 -253 -1 -24 5 -55 12 -69 13 -23 9 -34 -47 -145 -80 -160 -78 -159 -256 -55 -71 41 -142 83 -157 91 -22 12 -28 24 -28 49 0 18 -6 45 -13 60 -14 27 28 490 47 520 19 31 53 3 244 -198z m-684 -160 c113 -99 206 -187 206 -195 0 -30 -675 -9 -697 21 -18 25 -20 21 117 198 94 122 126 156 144 156 16 0 89 -58 230 -180z m2576 104 c153 -32 170 -38 170 -63 0 -17 -431 -538 -458 -555 -35 -21 -30 15 58 504 29 156 29 156 230 114z m-266 -1 c-6 -24 -104 -588 -104 -597 0 -3 -9 -6 -20 -6 -12 0 -34 -7 -50 -15 l-29 -15 -181 166 c-100 93 -180 173 -178 181 3 15 56 44 368 207 202 105 200 104 194 79z m726 -287 c146 -165 168 -199 133 -210 -47 -13 -810 -196 -821 -196 -34 0 7 56 214 300 217 255 228 265 268 271 22 3 44 5 49 5 4 -1 75 -77 157 -170z m-1890 -266 l138 -235 -11 -45 -11 -46 -195 -103 c-148 -79 -198 -101 -210 -94 -22 14 -49 361 -32 408 6 17 11 47 11 67 0 22 22 81 61 162 85 178 75 183 249 -114z m-1200 174 c260 -6 266 -7 293 -30 16 -13 38 -24 49 -24 17 0 19 -5 15 -32 -4 -18 -12 -95 -18 -170 -12 -136 -13 -138 -37 -138 -13 0 -41 -9 -61 -21 l-37 -21 -305 213 c-377 263 -355 243 -249 235 47 -3 204 -8 350 -12z m1879 -81 c214 -195 241 -224 234 -252 -3 -14 -6 -27 -7 -28 -2 -3 -572 -73 -592 -73 -34 0 -20 39 81 234 107 205 110 209 164 215 7 0 61 -43 120 -96z m-2399 32 l56 0 294 -206 c358 -251 344 -240 336 -265 -6 -20 -22 -21 -417 -39 l-411 -19 -25 32 c-13 18 -31 32 -38 32 -22 0 -28 17 -46 135 -15 94 -15 112 -3 126 8 8 14 29 14 45 0 36 145 178 170 166 8 -3 40 -7 70 -7z m1148 -108 c67 -39 122 -77 122 -83 0 -6 -69 -57 -154 -113 l-154 -103 -31 23 c-36 27 -36 18 -15 219 20 198 15 187 66 155 24 -14 98 -58 166 -98z m2477 -129 c-85 -80 -90 -83 -136 -83 -38 0 -53 -5 -76 -27 l-28 -27 -180 21 c-99 11 -187 23 -195 25 -8 3 48 20 125 39 77 19 230 56 340 83 110 27 209 50 219 50 13 1 -11 -27 -69 -81z m155 -358 c-13 -13 -20 -33 -20 -60 0 -36 -11 -54 -102 -170 -57 -71 -109 -129 -115 -129 -9 -1 -13 15 -14 47 0 26 -4 121 -8 212 l-8 164 28 27 c31 29 44 68 35 102 -5 18 11 39 106 129 l113 106 3 -204 c2 -193 1 -205 -18 -224z m-2453 318 c15 -18 38 -368 26 -377 -17 -11 -33 -48 -33 -78 0 -22 -21 -49 -102 -130 l-102 -102 -42 6 c-52 7 -104 -35 -104 -84 0 -27 -13 -34 -240 -151 l-239 -122 47 97 c26 54 100 203 165 331 l117 232 34 0 c62 0 126 73 126 145 0 35 3 37 158 140 164 108 173 113 189 93z m1313 -117 c0 -5 12 -23 26 -40 l26 -31 -128 -300 c-93 -220 -131 -300 -143 -300 -10 0 -43 37 -77 88 -337 489 -346 504 -311 517 14 6 538 72 580 74 15 0 27 -3 27 -8z m743 -50 c4 -1 7 -7 7 -15 0 -8 15 -27 34 -43 l34 -28 11 -215 c6 -118 8 -216 6 -218 -5 -5 -282 258 -454 431 -70 71 -112 121 -109 129 5 12 43 9 234 -14 126 -15 232 -27 237 -27z m-233 -303 c159 -155 287 -284 284 -288 -3 -3 -141 -35 -307 -71 -275 -61 -304 -66 -319 -51 -20 17 -23 207 -9 522 6 141 7 145 31 157 14 7 26 13 28 13 2 0 134 -127 292 -282z m-410 -77 c-6 -304 -7 -324 -26 -338 -10 -8 -28 -12 -39 -9 -11 3 -50 10 -86 17 -56 10 -68 16 -82 41 -17 29 -16 30 109 324 70 162 127 294 129 292 1 -2 -1 -149 -5 -327z m-873 297 c-112 -264 -330 -765 -336 -771 -6 -6 -36 146 -83 428 -20 123 -14 130 215 252 196 105 213 112 204 91z m290 -283 c213 -312 199 -286 182 -327 -19 -46 -433 -251 -490 -242 -25 4 -46 1 -66 -10 -45 -27 -159 -11 -186 26 l-20 27 146 338 c80 186 158 366 173 401 45 103 46 101 261 -213z m-1457 238 c0 -5 -105 -76 -233 -159 -294 -191 -258 -191 -467 -9 -82 72 -146 133 -142 136 16 15 842 46 842 32z m50 -75 c0 -24 -325 -658 -335 -655 -5 2 -45 71 -87 153 -66 128 -76 154 -69 179 6 25 46 55 242 182 241 157 249 162 249 141z m-780 -153 c103 -92 135 -125 135 -144 0 -20 -23 -39 -150 -118 -82 -51 -154 -92 -160 -90 -15 5 -19 465 -4 483 14 17 2 26 179 -131z m1457 -250 c45 -259 48 -278 34 -273 -5 2 -75 56 -155 122 -188 152 -186 144 -49 292 55 59 104 103 112 102 12 -2 26 -61 58 -243z m-1244 16 c23 -9 176 -285 164 -297 -3 -3 -116 23 -251 58 -135 34 -242 66 -238 70 18 18 277 178 288 178 7 0 24 -4 37 -9z m836 -120 l23 -18 -7 -196 c-7 -189 -9 -197 -31 -218 -13 -12 -24 -28 -24 -36 0 -7 -8 -13 -17 -13 -10 -1 -63 -5 -118 -9 -90 -7 -102 -6 -124 10 -13 11 -33 19 -45 19 -29 0 -32 3 -115 102 -43 52 -71 94 -69 105 2 15 474 273 498 273 3 0 16 -9 29 -19z m259 -107 c132 -109 142 -119 142 -151 0 -19 6 -46 14 -61 13 -25 11 -35 -32 -140 -25 -61 -51 -112 -58 -112 -29 0 -64 -42 -64 -78 -1 -35 -12 -48 -180 -210 -99 -96 -180 -171 -180 -168 0 25 134 442 143 445 54 20 75 103 36 142 -21 21 -21 24 -11 224 10 205 13 225 35 225 7 0 77 -52 155 -116z m1335 35 c31 -7 57 -15 57 -18 -1 -3 -53 -43 -117 -88 -109 -78 -118 -82 -155 -77 -33 6 -43 3 -66 -19 l-27 -25 -160 14 c-88 8 -164 15 -168 17 -5 1 75 44 178 95 l186 92 29 -20 c42 -30 90 -26 125 10 32 34 39 35 118 19z m-886 -245 c48 -7 47 -27 -10 -132 -47 -87 -55 -97 -82 -99 -17 -1 -39 -13 -52 -27 -16 -19 -36 -27 -90 -34 -101 -14 -101 -13 -40 131 40 94 44 100 82 113 22 7 48 25 58 39 20 26 20 26 134 9z"/>
-  </g>
-  <g class="sparks" aria-hidden="true">
-    <g class="spark" style="--d:2.6s;--dl:-0.0s"><circle class="halo" cx="248.6" cy="11.1" r="15"/><circle class="core" cx="248.6" cy="11.1" r="3.2"/></g>
-    <g class="spark" style="--d:3.6s;--dl:-0.27s"><circle class="halo" cx="155.2" cy="22.6" r="15"/><circle class="core" cx="155.2" cy="22.6" r="3.2"/></g>
-    <g class="spark" style="--d:4.6s;--dl:-0.54s"><circle class="halo" cx="191.6" cy="38.4" r="15"/><circle class="core" cx="191.6" cy="38.4" r="3.2"/></g>
-    <g class="spark" style="--d:2.9s;--dl:-0.81s"><circle class="halo" cx="294.4" cy="42.9" r="14.2"/><circle class="core" cx="294.4" cy="42.9" r="3.2"/></g>
-    <g class="spark" style="--d:3.9s;--dl:-1.08s"><circle class="halo" cx="112.5" cy="44.7" r="11.2"/><circle class="core" cx="112.5" cy="44.7" r="3.2"/></g>
-    <g class="spark" style="--d:4.9s;--dl:-1.35s"><circle class="halo" cx="360.8" cy="64.9" r="11"/><circle class="core" cx="360.8" cy="64.9" r="3.2"/></g>
-    <g class="spark" style="--d:3.2s;--dl:-1.62s"><circle class="halo" cx="101.4" cy="71.0" r="13.1"/><circle class="core" cx="101.4" cy="71.0" r="3.2"/></g>
-    <g class="spark" style="--d:4.2s;--dl:-1.89s"><circle class="halo" cx="53.8" cy="82.4" r="14.6"/><circle class="core" cx="53.8" cy="82.4" r="3.2"/></g>
-    <g class="spark" style="--d:5.2s;--dl:-2.16s"><circle class="halo" cx="239.9" cy="100.4" r="13.9"/><circle class="core" cx="239.9" cy="100.4" r="3.2"/></g>
-    <g class="spark" style="--d:3.5s;--dl:-2.43s"><circle class="halo" cx="171.4" cy="105.4" r="14.6"/><circle class="core" cx="171.4" cy="105.4" r="3.2"/></g>
-    <g class="spark" style="--d:4.5s;--dl:-2.7s"><circle class="halo" cx="307.2" cy="111.7" r="15"/><circle class="core" cx="307.2" cy="111.7" r="3.2"/></g>
-    <g class="spark" style="--d:2.8s;--dl:-2.97s"><circle class="halo" cx="395.1" cy="112.3" r="15"/><circle class="core" cx="395.1" cy="112.3" r="3.2"/></g>
-    <g class="spark" style="--d:3.8s;--dl:-3.24s"><circle class="halo" cx="15.0" cy="131.9" r="12.0"/><circle class="core" cx="15.0" cy="131.9" r="3.2"/></g>
-    <g class="spark" style="--d:4.8s;--dl:-3.51s"><circle class="halo" cx="425.0" cy="136.3" r="11"/><circle class="core" cx="425.0" cy="136.3" r="3.2"/></g>
-    <g class="spark" style="--d:3.1s;--dl:-3.78s"><circle class="halo" cx="261.0" cy="141.1" r="11"/><circle class="core" cx="261.0" cy="141.1" r="3.2"/></g>
-    <g class="spark" style="--d:4.1s;--dl:-4.05s"><circle class="halo" cx="114.7" cy="155.6" r="15"/><circle class="core" cx="114.7" cy="155.6" r="3.2"/></g>
-    <g class="spark" style="--d:5.1s;--dl:-4.32s"><circle class="halo" cx="46.3" cy="164.0" r="14.2"/><circle class="core" cx="46.3" cy="164.0" r="3.2"/></g>
-    <g class="spark" style="--d:3.4s;--dl:-4.59s"><circle class="halo" cx="201.5" cy="165.5" r="14.6"/><circle class="core" cx="201.5" cy="165.5" r="3.2"/></g>
-    <g class="spark" style="--d:2.6s;--dl:-4.86s"><circle class="halo" cx="312.3" cy="172.6" r="15"/><circle class="core" cx="312.3" cy="172.6" r="3.2"/></g>
-    <g class="spark" style="--d:3.6s;--dl:-0.13s"><circle class="halo" cx="418.3" cy="179.0" r="15"/><circle class="core" cx="418.3" cy="179.0" r="3.2"/></g>
-    <g class="spark" style="--d:4.6s;--dl:-0.4s"><circle class="halo" cx="12.3" cy="188.4" r="11"/><circle class="core" cx="12.3" cy="188.4" r="3.2"/></g>
-    <g class="spark" style="--d:2.9s;--dl:-0.67s"><circle class="halo" cx="255.4" cy="195.0" r="11.6"/><circle class="core" cx="255.4" cy="195.0" r="3.2"/></g>
-    <g class="spark" style="--d:3.9s;--dl:-0.94s"><circle class="halo" cx="376.5" cy="217.5" r="11.6"/><circle class="core" cx="376.5" cy="217.5" r="3.2"/></g>
-    <g class="spark" style="--d:4.9s;--dl:-1.21s"><circle class="halo" cx="43.7" cy="225.4" r="12.4"/><circle class="core" cx="43.7" cy="225.4" r="3.2"/></g>
-    <g class="spark" style="--d:3.2s;--dl:-1.48s"><circle class="halo" cx="288.0" cy="228.4" r="14.2"/><circle class="core" cx="288.0" cy="228.4" r="3.2"/></g>
-    <g class="spark" style="--d:4.2s;--dl:-1.75s"><circle class="halo" cx="152.3" cy="238.9" r="15"/><circle class="core" cx="152.3" cy="238.9" r="3.2"/></g>
-    <g class="spark" style="--d:5.2s;--dl:-2.02s"><circle class="halo" cx="416.8" cy="244.2" r="12.4"/><circle class="core" cx="416.8" cy="244.2" r="3.2"/></g>
-    <g class="spark" style="--d:3.5s;--dl:-2.29s"><circle class="halo" cx="119.8" cy="245.0" r="11.6"/><circle class="core" cx="119.8" cy="245.0" r="3.2"/></g>
-    <g class="spark" style="--d:4.5s;--dl:-2.56s"><circle class="halo" cx="352.3" cy="260.4" r="13.5"/><circle class="core" cx="352.3" cy="260.4" r="3.2"/></g>
-    <g class="spark" style="--d:2.8s;--dl:-2.83s"><circle class="halo" cx="243.6" cy="263.3" r="14.2"/><circle class="core" cx="243.6" cy="263.3" r="3.2"/></g>
-    <g class="spark" style="--d:3.8s;--dl:-3.1s"><circle class="halo" cx="208.7" cy="267.0" r="11"/><circle class="core" cx="208.7" cy="267.0" r="3.2"/></g>
-    <g class="spark" style="--d:4.8s;--dl:-3.37s"><circle class="halo" cx="156.2" cy="270.3" r="11"/><circle class="core" cx="156.2" cy="270.3" r="3.2"/></g>
-    <g class="spark" style="--d:3.1s;--dl:-3.64s"><circle class="halo" cx="290.4" cy="288.1" r="11.2"/><circle class="core" cx="290.4" cy="288.1" r="3.2"/></g>
-    <g class="spark" style="--d:4.1s;--dl:-3.91s"><circle class="halo" cx="328.1" cy="291.0" r="11"/><circle class="core" cx="328.1" cy="291.0" r="3.2"/></g>
-    <g class="spark" style="--d:5.1s;--dl:-4.18s"><circle class="halo" cx="231.3" cy="300.1" r="11"/><circle class="core" cx="231.3" cy="300.1" r="3.2"/></g>
-    <g class="spark" style="--d:3.4s;--dl:-4.45s"><circle class="halo" cx="259.7" cy="303.2" r="11.2"/><circle class="core" cx="259.7" cy="303.2" r="3.2"/></g>
-  </g>
-  </svg>
-<g transform="translate(195.68 219.00) scale(0.01714)" fill="#ffffff"><use href="#gc4f" x="0"/><use href="#gc4e" x="720"/><use href="#gc45" x="1437"/><use href="#gc42" x="2063"/><use href="#gc52" x="2753"/><use href="#gc41" x="3448"/><use href="#gc49" x="4114"/><use href="#gc4e" x="4410"/></g>
+  <path class="plug" d="M310.0 94.5 A145 145 0 0 1 367.0 241.4" opacity="0.22"/>
+  <path class="plug plug-flow" d="M310.0 94.5 A145 145 0 0 1 367.0 241.4" style="animation-delay:0ms" marker-end="url(#arrow)"/>
+  <path class="plug" d="M317.6 323.6 A145 145 0 0 1 137.4 327.6" opacity="0.22"/>
+  <path class="plug plug-flow" d="M317.6 323.6 A145 145 0 0 1 137.4 327.6" style="animation-delay:400ms" marker-end="url(#arrow)"/>
+  <path class="plug" d="M83.9 245.5 A145 145 0 0 1 135.9 97.6" opacity="0.22"/>
+  <path class="plug plug-flow" d="M83.9 245.5 A145 145 0 0 1 135.9 97.6" style="animation-delay:800ms" marker-end="url(#arrow)"/>
+  <rect x="146.0" y="34.0" width="158" height="66" fill="#08080e" stroke="#ffffff0f" stroke-width="1"/>
+  <rect x="145.5" y="33.5" width="2" height="67" fill="#a8d000"/>
+<g transform="translate(244.76 51.14) scale(0.00829)" fill="#ffffff2e"><use href="#gm53" x="0"/><use href="#gm54" x="860"/><use href="#gm45" x="1720"/><use href="#gm50" x="2580"/><use href="#gm5f" x="3440"/><use href="#gm30" x="4300"/><use href="#gm31" x="5160"/></g>
+  <svg x="162.0" y="56.0" width="18" height="18"><use href="#i-capture" class="ico" stroke="#a8d000"/></svg>
+<g transform="translate(189.29 71.00) scale(0.02143)" fill="#ffffff"><use href="#gc43" x="0"/><use href="#gc41" x="675"/><use href="#gc50" x="1341"/><use href="#gc54" x="2007"/><use href="#gc55" x="2611"/><use href="#gc52" x="3331"/><use href="#gc45" x="4026"/></g>
+<g transform="translate(189.38 87.99) scale(0.00842)" fill="#ffffff9e"><use href="#gm2f" x="0"/><use href="#gm62" x="660"/><use href="#gm72" x="1320"/><use href="#gm61" x="1980"/><use href="#gm69" x="2640"/><use href="#gm6e" x="3300"/><use href="#gm64" x="3960"/><use href="#gm75" x="4620"/><use href="#gm6d" x="5280"/><use href="#gm70" x="5940"/></g>
+  <rect x="271.6" y="251.5" width="158" height="66" fill="#08080e" stroke="#ffffff0f" stroke-width="1"/>
+  <rect x="271.1" y="251.0" width="2" height="67" fill="#a8d000"/>
+<g transform="translate(370.48 268.64) scale(0.00829)" fill="#ffffff2e"><use href="#gm53" x="0"/><use href="#gm54" x="860"/><use href="#gm45" x="1720"/><use href="#gm50" x="2580"/><use href="#gm5f" x="3440"/><use href="#gm30" x="4300"/><use href="#gm32" x="5160"/></g>
+  <svg x="287.6" y="273.5" width="18" height="18"><use href="#i-learn" class="ico" stroke="#a8d000"/></svg>
+<g transform="translate(315.13 288.50) scale(0.02143)" fill="#ffffff"><use href="#gc45" x="0"/><use href="#gc56" x="626"/><use href="#gc4f" x="1296"/><use href="#gc4c" x="2016"/><use href="#gc56" x="2597"/><use href="#gc45" x="3267"/></g>
+<g transform="translate(314.94 306.01) scale(0.00904)" fill="#ffffff9e"><use href="#gm2f" x="0"/><use href="#gm64" x="660"/><use href="#gm69" x="1320"/><use href="#gm73" x="1980"/><use href="#gm74" x="2640"/><use href="#gm69" x="3300"/><use href="#gm6c" x="3960"/><use href="#gm6c" x="4620"/><use href="#gmb7" x="5940"/><use href="#gm2f" x="7260"/><use href="#gm6c" x="7920"/><use href="#gm65" x="8580"/><use href="#gm61" x="9240"/><use href="#gm72" x="9900"/><use href="#gm6e" x="10560"/></g>
+  <rect x="20.4" y="251.5" width="158" height="66" fill="#08080e" stroke="#ffffff0f" stroke-width="1"/>
+  <rect x="19.9" y="251.0" width="2" height="67" fill="#a8d000"/>
+<g transform="translate(119.41 268.64) scale(0.00829)" fill="#ffffff2e"><use href="#gm53" x="0"/><use href="#gm54" x="860"/><use href="#gm45" x="1720"/><use href="#gm50" x="2580"/><use href="#gm5f" x="3440"/><use href="#gm30" x="4300"/><use href="#gm33" x="5160"/></g>
+  <svg x="36.4" y="273.5" width="18" height="18"><use href="#i-recap" class="ico" stroke="#a8d000"/></svg>
+<g transform="translate(62.15 288.50) scale(0.02143)" fill="#ffffff"><use href="#gc57" x="0"/><use href="#gc52" x="899"/><use href="#gc41" x="1594"/><use href="#gc50" x="2260"/><use href="#gc55" x="2926"/><use href="#gc50" x="3646"/></g>
+<g transform="translate(63.78 305.49) scale(0.00842)" fill="#ffffff9e"><use href="#gm2f" x="0"/><use href="#gm77" x="660"/><use href="#gm72" x="1320"/><use href="#gm61" x="1980"/><use href="#gm70" x="2640"/><use href="#gm75" x="3300"/><use href="#gm70" x="3960"/><use href="#gmb7" x="5280"/><use href="#gm2f" x="6600"/><use href="#gm72" x="7260"/><use href="#gm65" x="7920"/><use href="#gm63" x="8580"/><use href="#gm61" x="9240"/><use href="#gm70" x="9900"/></g>
 </svg>

--- a/assets/diagrams/coevo-loop-light.svg
+++ b/assets/diagrams/coevo-loop-light.svg
@@ -1,21 +1,7 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 450 420" width="450" height="420" role="img" aria-labelledby="ttl desc">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 450 372" width="450" height="372" role="img" aria-labelledby="ttl desc">
   <title id="ttl">The path to co-evolution — three-step loop</title>
-  <desc id="desc">Three panels in a triangle around the OneBrain mark: 01 CAPTURE (/braindump) at top, 02 EVOLVE (/distill, /learn) at bottom-right, 03 WRAPUP (/wrapup, /recap) at bottom-left. Dashed arrows flow clockwise between them — the recurring co-evolution loop.</desc>
+  <desc id="desc">Three panels on a circle: 01 CAPTURE (/braindump) at twelve o'clock, 02 EVOLVE (/distill, /learn) at four o'clock, 03 WRAPUP (/wrapup, /recap) at eight o'clock. Dashed arrows travel clockwise along the circle between them — the recurring co-evolution loop.</desc>
   <defs>
-    <linearGradient id="ob-brain-grad" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#ff2d92"/>
-      <stop offset="55%" stop-color="#ff5aa3"/>
-      <stop offset="100%" stop-color="#00f3ff"/>
-    </linearGradient>
-    <radialGradient id="ob-spark-glow">
-      <stop offset="0%" stop-color="#ffffff"/>
-      <stop offset="35%" stop-color="#ffffff" stop-opacity=".7"/>
-      <stop offset="100%" stop-color="#00f3ff" stop-opacity="0"/>
-    </radialGradient>
-    <linearGradient id="grad-button" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#9500c7"/>
-      <stop offset="100%" stop-color="#007a90"/>
-    </linearGradient>
     <marker id="arrow" viewBox="0 0 3 2" refX="0" refY="1" markerWidth="3" markerHeight="2" orient="auto">
       <path d="M0 0 L3 1 L0 2 Z" fill="#5f7d00"/>
     </marker>
@@ -23,12 +9,9 @@
     <symbol id="i-learn" viewBox="0 0 24 24"><path d="M9 18h6"/><path d="M10 22h4"/><path d="M15.09 14c.18-.98.65-1.74 1.41-2.5A4.65 4.65 0 0 0 18 8 6 6 0 0 0 6 8c0 1 .23 2.23 1.5 3.5A4.6 4.6 0 0 1 8.91 14"/></symbol>
     <symbol id="i-recap" viewBox="0 0 24 24"><polyline points="1 4 1 10 7 10"/><path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10"/></symbol>
     <path id="gc41" d="M340 -700H464L597 0H459L431 -155H185L99 0H-39ZM418 -267 373 -533H371L233 -267Z"/>
-    <path id="gc42" d="M145 -700H575L665 -592L631 -404L584 -363L642 -291L608 -98L493 0H22ZM462 -407 504 -443 523 -551 494 -586H258L227 -407ZM434 -114 485 -157 502 -255 467 -298H208L175 -114Z"/>
     <path id="gc43" d="M33 -124 116 -593 241 -700H582L683 -579L665 -480H529L539 -537L501 -584H301L241 -533L176 -167L218 -116H418L473 -163L484 -220H620L599 -105L476 0H135Z"/>
     <path id="gc45" d="M145 -700H650L630 -585H261L230 -408H570L550 -295H210L178 -115H547L527 0H22Z"/>
-    <path id="gc49" d="M150 -700H286L162 0H26Z"/>
     <path id="gc4c" d="M145 -700H281L178 -115H527L507 0H22Z"/>
-    <path id="gc4e" d="M145 -700H267L496 -225H498L581 -700H712L588 0H466L239 -474H237L153 0H22Z"/>
     <path id="gc4f" d="M33 -124 116 -593 241 -700H601L703 -577L619 -103L497 0H135ZM434 -116 494 -167 559 -533 517 -584H302L242 -533L176 -167L218 -116Z"/>
     <path id="gc50" d="M145 -700H575L670 -584L626 -336L511 -238H200L158 0H22ZM460 -352 501 -387 530 -551 501 -586H261L220 -352Z"/>
     <path id="gc52" d="M633 -372 557 -307 612 -232 571 0H435L471 -207L427 -268H205L158 0H22L145 -700H575L670 -584ZM225 -380H465L506 -415L530 -551L501 -586H261Z"/>
@@ -65,89 +48,36 @@
   </defs>
   <style>
     .ico { fill: none; stroke-width: 1.75; stroke-linecap: round; stroke-linejoin: round; }
-    /* MOTION RULE: cards never animate — motion is ONLY this connector dash-flow + the brain-mark neuron spark. */
+    /* MOTION RULE: cards never animate — motion is ONLY this connector dash-flow. */
     .plug { fill: none; stroke: #5f7d00; stroke-width: 1.5; stroke-linecap: round; stroke-dasharray: 5 7; }
     .plug-flow { animation: plug-flow 1200ms linear infinite; }
     @keyframes plug-flow { to { stroke-dashoffset: -24; } }
-    .sparks .halo { fill: url(#ob-spark-glow); }
-    .sparks .core { fill: #fff; transform-box: fill-box; transform-origin: center; }
-    .sparks .spark { opacity: .16; animation: ob-spk var(--d) ease-in-out var(--dl) infinite; }
-    .sparks .core { animation: ob-spkpop var(--d) ease-in-out var(--dl) infinite; }
-    @keyframes ob-spk { 0%,16%,100% { opacity: .16; } 5% { opacity: 1; } 10% { opacity: .42; } }
-    @keyframes ob-spkpop { 0%,16%,100% { transform: scale(1); } 5% { transform: scale(1.65); } }
     @media (prefers-reduced-motion: reduce) {
-      .plug-flow, .sparks .spark, .sparks .core { animation: none; }
-      .sparks .spark { opacity: .22; }
+      .plug-flow { animation: none; }
     }
   </style>
-  <path class="plug" d="M312 76 Q400 130 372 291" opacity="0.22"/>
-  <path class="plug plug-flow" d="M312 76 Q400 130 372 291" style="animation-delay:0ms" marker-end="url(#arrow)"/>
-  <path class="plug" d="M300 372 Q225 404 150 372" opacity="0.22"/>
-  <path class="plug plug-flow" d="M300 372 Q225 404 150 372" style="animation-delay:400ms" marker-end="url(#arrow)"/>
-  <path class="plug" d="M78 292 Q50 130 138 76" opacity="0.22"/>
-  <path class="plug plug-flow" d="M78 292 Q50 130 138 76" style="animation-delay:800ms" marker-end="url(#arrow)"/>
-  <rect x="146" y="28" width="158" height="66" fill="#fafafe" stroke="#08081014" stroke-width="1"/>
-  <rect x="145.5" y="27.5" width="2" height="67" fill="#5f7d00"/>
-<g transform="translate(244.76 45.14) scale(0.00829)" fill="#0a0a1299"><use href="#gm53" x="0"/><use href="#gm54" x="860"/><use href="#gm45" x="1720"/><use href="#gm50" x="2580"/><use href="#gm5f" x="3440"/><use href="#gm30" x="4300"/><use href="#gm31" x="5160"/></g>
-  <svg x="162" y="50" width="18" height="18"><use href="#i-capture" class="ico" stroke="#5f7d00"/></svg>
-<g transform="translate(189.29 65.00) scale(0.02143)" fill="#0a0a12"><use href="#gc43" x="0"/><use href="#gc41" x="675"/><use href="#gc50" x="1341"/><use href="#gc54" x="2007"/><use href="#gc55" x="2611"/><use href="#gc52" x="3331"/><use href="#gc45" x="4026"/></g>
-<g transform="translate(189.38 81.99) scale(0.00842)" fill="#0a0a1299"><use href="#gm2f" x="0"/><use href="#gm62" x="660"/><use href="#gm72" x="1320"/><use href="#gm61" x="1980"/><use href="#gm69" x="2640"/><use href="#gm6e" x="3300"/><use href="#gm64" x="3960"/><use href="#gm75" x="4620"/><use href="#gm6d" x="5280"/><use href="#gm70" x="5940"/></g>
-  <rect x="268" y="300" width="158" height="66" fill="#fafafe" stroke="#08081014" stroke-width="1"/>
-  <rect x="267.5" y="299.5" width="2" height="67" fill="#5f7d00"/>
-<g transform="translate(366.88 317.14) scale(0.00829)" fill="#0a0a1299"><use href="#gm53" x="0"/><use href="#gm54" x="860"/><use href="#gm45" x="1720"/><use href="#gm50" x="2580"/><use href="#gm5f" x="3440"/><use href="#gm30" x="4300"/><use href="#gm32" x="5160"/></g>
-  <svg x="284" y="322" width="18" height="18"><use href="#i-learn" class="ico" stroke="#5f7d00"/></svg>
-<g transform="translate(311.53 337.00) scale(0.02143)" fill="#0a0a12"><use href="#gc45" x="0"/><use href="#gc56" x="626"/><use href="#gc4f" x="1296"/><use href="#gc4c" x="2016"/><use href="#gc56" x="2597"/><use href="#gc45" x="3267"/></g>
-<g transform="translate(311.34 354.51) scale(0.00904)" fill="#0a0a1299"><use href="#gm2f" x="0"/><use href="#gm64" x="660"/><use href="#gm69" x="1320"/><use href="#gm73" x="1980"/><use href="#gm74" x="2640"/><use href="#gm69" x="3300"/><use href="#gm6c" x="3960"/><use href="#gm6c" x="4620"/><use href="#gmb7" x="5940"/><use href="#gm2f" x="7260"/><use href="#gm6c" x="7920"/><use href="#gm65" x="8580"/><use href="#gm61" x="9240"/><use href="#gm72" x="9900"/><use href="#gm6e" x="10560"/></g>
-  <rect x="24" y="300" width="158" height="66" fill="#fafafe" stroke="#08081014" stroke-width="1"/>
-  <rect x="23.5" y="299.5" width="2" height="67" fill="#5f7d00"/>
-<g transform="translate(123.01 317.14) scale(0.00829)" fill="#0a0a1299"><use href="#gm53" x="0"/><use href="#gm54" x="860"/><use href="#gm45" x="1720"/><use href="#gm50" x="2580"/><use href="#gm5f" x="3440"/><use href="#gm30" x="4300"/><use href="#gm33" x="5160"/></g>
-  <svg x="40" y="322" width="18" height="18"><use href="#i-recap" class="ico" stroke="#5f7d00"/></svg>
-<g transform="translate(65.75 337.00) scale(0.02143)" fill="#0a0a12"><use href="#gc57" x="0"/><use href="#gc52" x="899"/><use href="#gc41" x="1594"/><use href="#gc50" x="2260"/><use href="#gc55" x="2926"/><use href="#gc50" x="3646"/></g>
-<g transform="translate(67.38 353.99) scale(0.00842)" fill="#0a0a1299"><use href="#gm2f" x="0"/><use href="#gm77" x="660"/><use href="#gm72" x="1320"/><use href="#gm61" x="1980"/><use href="#gm70" x="2640"/><use href="#gm75" x="3300"/><use href="#gm70" x="3960"/><use href="#gmb7" x="5280"/><use href="#gm2f" x="6600"/><use href="#gm72" x="7260"/><use href="#gm65" x="7920"/><use href="#gm63" x="8580"/><use href="#gm61" x="9240"/><use href="#gm70" x="9900"/></g>
-  <path d="M160 186 H302 V228 L290 240 H148 V198 Z" fill="url(#grad-button)"/>
-  <path d="M161.5 187.5 H300.5 V226.5 L288.5 238.5 H149.5 V199.5 Z" fill="#f4f4f7"/>
-  <svg x="168" y="204.94" width="19.25" height="16.12" viewBox="4.5 0.0 428.0 358.5" overflow="visible" aria-hidden="true">
-    <g transform="translate(433,466) scale(-0.1,-0.1)" fill="url(#ob-brain-grad)" stroke="none">
-    <path d="M1774 4637 c-19 -17 -29 -37 -33 -67 -6 -43 -7 -45 -149 -141 l-143 -97 -54 5 c-50 5 -56 4 -84 -25 -21 -20 -31 -40 -31 -60 l0 -29 -247 -78 c-238 -75 -247 -77 -274 -61 -56 33 -114 -4 -112 -71 2 -36 -9 -53 -123 -201 -103 -133 -130 -162 -150 -162 -58 0 -103 -45 -104 -105 -1 -37 -6 -45 -79 -107 -65 -56 -85 -68 -114 -68 -73 0 -105 -97 -47 -142 28 -22 31 -32 47 -139 l17 -117 -28 -33 c-39 -46 -33 -111 13 -150 l31 -25 0 -237 c0 -224 -1 -238 -20 -257 -64 -64 15 -176 88 -124 22 15 125 -6 515 -107 21 -6 37 -16 37 -25 0 -16 56 -54 82 -54 9 0 50 -41 92 -91 66 -78 76 -96 76 -129 0 -73 68 -102 120 -51 28 27 37 29 146 35 64 4 120 4 125 -1 5 -5 -32 -144 -86 -320 -52 -172 -95 -317 -95 -322 0 -29 42 7 266 229 215 213 246 240 274 240 19 0 43 10 60 24 42 35 151 45 187 16 52 -41 105 -11 109 62 3 58 99 241 129 246 11 2 31 14 45 27 l25 23 160 -14 c88 -7 177 -13 197 -14 24 0 47 -9 66 -25 50 -42 105 -29 120 30 12 43 255 219 291 210 32 -8 76 11 89 39 8 18 25 26 89 39 43 9 182 39 308 67 172 38 241 49 273 44 60 -9 92 13 92 65 0 56 196 301 250 312 18 4 40 15 47 25 20 28 16 88 -7 109 -31 28 -31 432 0 460 43 39 21 119 -39 139 -22 8 -79 64 -186 185 -145 164 -153 175 -148 207 16 99 -91 160 -163 93 l-23 -21 -103 21 c-200 42 -197 41 -213 72 -10 18 -27 32 -48 37 -28 7 -35 16 -53 68 -15 39 -19 65 -13 76 14 26 11 71 -7 96 -16 24 -81 31 -100 12 -15 -15 -288 139 -292 165 -10 66 -42 95 -103 95 -40 0 -89 -48 -89 -87 0 -27 -7 -32 -91 -68 -88 -38 -91 -38 -119 -22 -35 21 -74 22 -103 2 -33 -21 -426 157 -427 193 -1 87 -101 135 -166 79z m26 -184 c28 -14 38 -14 64 -4 59 24 71 21 260 -68 187 -88 190 -89 201 -128 l11 -38 -181 -229 -181 -229 -48 -1 -48 -1 -199 210 -198 210 -1 50 0 51 142 97 c78 53 143 97 144 97 0 0 16 -7 34 -17z m929 -107 c9 -10 2 -63 -29 -222 -23 -115 -49 -249 -57 -299 -9 -49 -19 -93 -23 -98 -4 -4 -37 98 -74 226 -59 204 -67 237 -56 257 7 13 16 35 19 48 5 18 27 33 91 62 94 43 112 46 129 26z m266 -63 c91 -52 140 -86 146 -101 5 -12 24 -31 42 -42 25 -15 37 -32 50 -73 35 -112 53 -95 -255 -255 -150 -77 -280 -142 -288 -144 -24 -5 -18 44 45 366 56 281 60 298 84 311 36 19 24 23 176 -62z m-567 -118 c4 -4 132 -453 132 -465 0 -5 -9 -19 -20 -30 -24 -24 -28 -114 -6 -145 12 -18 3 -40 -88 -215 -140 -268 -120 -271 -299 35 -125 212 -138 238 -131 268 4 17 6 49 6 70 -2 34 13 56 180 267 181 228 195 241 226 215z m-1118 -272 l-26 -238 -46 -8 -47 -9 -198 173 c-109 95 -199 176 -201 180 -2 4 21 14 50 23 29 9 143 44 253 79 175 56 203 62 220 51 l21 -13 -26 -238z m328 27 c198 -209 199 -210 198 -253 -1 -24 5 -55 12 -69 13 -23 9 -34 -47 -145 -80 -160 -78 -159 -256 -55 -71 41 -142 83 -157 91 -22 12 -28 24 -28 49 0 18 -6 45 -13 60 -14 27 28 490 47 520 19 31 53 3 244 -198z m-684 -160 c113 -99 206 -187 206 -195 0 -30 -675 -9 -697 21 -18 25 -20 21 117 198 94 122 126 156 144 156 16 0 89 -58 230 -180z m2576 104 c153 -32 170 -38 170 -63 0 -17 -431 -538 -458 -555 -35 -21 -30 15 58 504 29 156 29 156 230 114z m-266 -1 c-6 -24 -104 -588 -104 -597 0 -3 -9 -6 -20 -6 -12 0 -34 -7 -50 -15 l-29 -15 -181 166 c-100 93 -180 173 -178 181 3 15 56 44 368 207 202 105 200 104 194 79z m726 -287 c146 -165 168 -199 133 -210 -47 -13 -810 -196 -821 -196 -34 0 7 56 214 300 217 255 228 265 268 271 22 3 44 5 49 5 4 -1 75 -77 157 -170z m-1890 -266 l138 -235 -11 -45 -11 -46 -195 -103 c-148 -79 -198 -101 -210 -94 -22 14 -49 361 -32 408 6 17 11 47 11 67 0 22 22 81 61 162 85 178 75 183 249 -114z m-1200 174 c260 -6 266 -7 293 -30 16 -13 38 -24 49 -24 17 0 19 -5 15 -32 -4 -18 -12 -95 -18 -170 -12 -136 -13 -138 -37 -138 -13 0 -41 -9 -61 -21 l-37 -21 -305 213 c-377 263 -355 243 -249 235 47 -3 204 -8 350 -12z m1879 -81 c214 -195 241 -224 234 -252 -3 -14 -6 -27 -7 -28 -2 -3 -572 -73 -592 -73 -34 0 -20 39 81 234 107 205 110 209 164 215 7 0 61 -43 120 -96z m-2399 32 l56 0 294 -206 c358 -251 344 -240 336 -265 -6 -20 -22 -21 -417 -39 l-411 -19 -25 32 c-13 18 -31 32 -38 32 -22 0 -28 17 -46 135 -15 94 -15 112 -3 126 8 8 14 29 14 45 0 36 145 178 170 166 8 -3 40 -7 70 -7z m1148 -108 c67 -39 122 -77 122 -83 0 -6 -69 -57 -154 -113 l-154 -103 -31 23 c-36 27 -36 18 -15 219 20 198 15 187 66 155 24 -14 98 -58 166 -98z m2477 -129 c-85 -80 -90 -83 -136 -83 -38 0 -53 -5 -76 -27 l-28 -27 -180 21 c-99 11 -187 23 -195 25 -8 3 48 20 125 39 77 19 230 56 340 83 110 27 209 50 219 50 13 1 -11 -27 -69 -81z m155 -358 c-13 -13 -20 -33 -20 -60 0 -36 -11 -54 -102 -170 -57 -71 -109 -129 -115 -129 -9 -1 -13 15 -14 47 0 26 -4 121 -8 212 l-8 164 28 27 c31 29 44 68 35 102 -5 18 11 39 106 129 l113 106 3 -204 c2 -193 1 -205 -18 -224z m-2453 318 c15 -18 38 -368 26 -377 -17 -11 -33 -48 -33 -78 0 -22 -21 -49 -102 -130 l-102 -102 -42 6 c-52 7 -104 -35 -104 -84 0 -27 -13 -34 -240 -151 l-239 -122 47 97 c26 54 100 203 165 331 l117 232 34 0 c62 0 126 73 126 145 0 35 3 37 158 140 164 108 173 113 189 93z m1313 -117 c0 -5 12 -23 26 -40 l26 -31 -128 -300 c-93 -220 -131 -300 -143 -300 -10 0 -43 37 -77 88 -337 489 -346 504 -311 517 14 6 538 72 580 74 15 0 27 -3 27 -8z m743 -50 c4 -1 7 -7 7 -15 0 -8 15 -27 34 -43 l34 -28 11 -215 c6 -118 8 -216 6 -218 -5 -5 -282 258 -454 431 -70 71 -112 121 -109 129 5 12 43 9 234 -14 126 -15 232 -27 237 -27z m-233 -303 c159 -155 287 -284 284 -288 -3 -3 -141 -35 -307 -71 -275 -61 -304 -66 -319 -51 -20 17 -23 207 -9 522 6 141 7 145 31 157 14 7 26 13 28 13 2 0 134 -127 292 -282z m-410 -77 c-6 -304 -7 -324 -26 -338 -10 -8 -28 -12 -39 -9 -11 3 -50 10 -86 17 -56 10 -68 16 -82 41 -17 29 -16 30 109 324 70 162 127 294 129 292 1 -2 -1 -149 -5 -327z m-873 297 c-112 -264 -330 -765 -336 -771 -6 -6 -36 146 -83 428 -20 123 -14 130 215 252 196 105 213 112 204 91z m290 -283 c213 -312 199 -286 182 -327 -19 -46 -433 -251 -490 -242 -25 4 -46 1 -66 -10 -45 -27 -159 -11 -186 26 l-20 27 146 338 c80 186 158 366 173 401 45 103 46 101 261 -213z m-1457 238 c0 -5 -105 -76 -233 -159 -294 -191 -258 -191 -467 -9 -82 72 -146 133 -142 136 16 15 842 46 842 32z m50 -75 c0 -24 -325 -658 -335 -655 -5 2 -45 71 -87 153 -66 128 -76 154 -69 179 6 25 46 55 242 182 241 157 249 162 249 141z m-780 -153 c103 -92 135 -125 135 -144 0 -20 -23 -39 -150 -118 -82 -51 -154 -92 -160 -90 -15 5 -19 465 -4 483 14 17 2 26 179 -131z m1457 -250 c45 -259 48 -278 34 -273 -5 2 -75 56 -155 122 -188 152 -186 144 -49 292 55 59 104 103 112 102 12 -2 26 -61 58 -243z m-1244 16 c23 -9 176 -285 164 -297 -3 -3 -116 23 -251 58 -135 34 -242 66 -238 70 18 18 277 178 288 178 7 0 24 -4 37 -9z m836 -120 l23 -18 -7 -196 c-7 -189 -9 -197 -31 -218 -13 -12 -24 -28 -24 -36 0 -7 -8 -13 -17 -13 -10 -1 -63 -5 -118 -9 -90 -7 -102 -6 -124 10 -13 11 -33 19 -45 19 -29 0 -32 3 -115 102 -43 52 -71 94 -69 105 2 15 474 273 498 273 3 0 16 -9 29 -19z m259 -107 c132 -109 142 -119 142 -151 0 -19 6 -46 14 -61 13 -25 11 -35 -32 -140 -25 -61 -51 -112 -58 -112 -29 0 -64 -42 -64 -78 -1 -35 -12 -48 -180 -210 -99 -96 -180 -171 -180 -168 0 25 134 442 143 445 54 20 75 103 36 142 -21 21 -21 24 -11 224 10 205 13 225 35 225 7 0 77 -52 155 -116z m1335 35 c31 -7 57 -15 57 -18 -1 -3 -53 -43 -117 -88 -109 -78 -118 -82 -155 -77 -33 6 -43 3 -66 -19 l-27 -25 -160 14 c-88 8 -164 15 -168 17 -5 1 75 44 178 95 l186 92 29 -20 c42 -30 90 -26 125 10 32 34 39 35 118 19z m-886 -245 c48 -7 47 -27 -10 -132 -47 -87 -55 -97 -82 -99 -17 -1 -39 -13 -52 -27 -16 -19 -36 -27 -90 -34 -101 -14 -101 -13 -40 131 40 94 44 100 82 113 22 7 48 25 58 39 20 26 20 26 134 9z"/>
-  </g>
-  <g class="sparks" aria-hidden="true">
-    <g class="spark" style="--d:2.6s;--dl:-0.0s"><circle class="halo" cx="248.6" cy="11.1" r="15"/><circle class="core" cx="248.6" cy="11.1" r="3.2"/></g>
-    <g class="spark" style="--d:3.6s;--dl:-0.27s"><circle class="halo" cx="155.2" cy="22.6" r="15"/><circle class="core" cx="155.2" cy="22.6" r="3.2"/></g>
-    <g class="spark" style="--d:4.6s;--dl:-0.54s"><circle class="halo" cx="191.6" cy="38.4" r="15"/><circle class="core" cx="191.6" cy="38.4" r="3.2"/></g>
-    <g class="spark" style="--d:2.9s;--dl:-0.81s"><circle class="halo" cx="294.4" cy="42.9" r="14.2"/><circle class="core" cx="294.4" cy="42.9" r="3.2"/></g>
-    <g class="spark" style="--d:3.9s;--dl:-1.08s"><circle class="halo" cx="112.5" cy="44.7" r="11.2"/><circle class="core" cx="112.5" cy="44.7" r="3.2"/></g>
-    <g class="spark" style="--d:4.9s;--dl:-1.35s"><circle class="halo" cx="360.8" cy="64.9" r="11"/><circle class="core" cx="360.8" cy="64.9" r="3.2"/></g>
-    <g class="spark" style="--d:3.2s;--dl:-1.62s"><circle class="halo" cx="101.4" cy="71.0" r="13.1"/><circle class="core" cx="101.4" cy="71.0" r="3.2"/></g>
-    <g class="spark" style="--d:4.2s;--dl:-1.89s"><circle class="halo" cx="53.8" cy="82.4" r="14.6"/><circle class="core" cx="53.8" cy="82.4" r="3.2"/></g>
-    <g class="spark" style="--d:5.2s;--dl:-2.16s"><circle class="halo" cx="239.9" cy="100.4" r="13.9"/><circle class="core" cx="239.9" cy="100.4" r="3.2"/></g>
-    <g class="spark" style="--d:3.5s;--dl:-2.43s"><circle class="halo" cx="171.4" cy="105.4" r="14.6"/><circle class="core" cx="171.4" cy="105.4" r="3.2"/></g>
-    <g class="spark" style="--d:4.5s;--dl:-2.7s"><circle class="halo" cx="307.2" cy="111.7" r="15"/><circle class="core" cx="307.2" cy="111.7" r="3.2"/></g>
-    <g class="spark" style="--d:2.8s;--dl:-2.97s"><circle class="halo" cx="395.1" cy="112.3" r="15"/><circle class="core" cx="395.1" cy="112.3" r="3.2"/></g>
-    <g class="spark" style="--d:3.8s;--dl:-3.24s"><circle class="halo" cx="15.0" cy="131.9" r="12.0"/><circle class="core" cx="15.0" cy="131.9" r="3.2"/></g>
-    <g class="spark" style="--d:4.8s;--dl:-3.51s"><circle class="halo" cx="425.0" cy="136.3" r="11"/><circle class="core" cx="425.0" cy="136.3" r="3.2"/></g>
-    <g class="spark" style="--d:3.1s;--dl:-3.78s"><circle class="halo" cx="261.0" cy="141.1" r="11"/><circle class="core" cx="261.0" cy="141.1" r="3.2"/></g>
-    <g class="spark" style="--d:4.1s;--dl:-4.05s"><circle class="halo" cx="114.7" cy="155.6" r="15"/><circle class="core" cx="114.7" cy="155.6" r="3.2"/></g>
-    <g class="spark" style="--d:5.1s;--dl:-4.32s"><circle class="halo" cx="46.3" cy="164.0" r="14.2"/><circle class="core" cx="46.3" cy="164.0" r="3.2"/></g>
-    <g class="spark" style="--d:3.4s;--dl:-4.59s"><circle class="halo" cx="201.5" cy="165.5" r="14.6"/><circle class="core" cx="201.5" cy="165.5" r="3.2"/></g>
-    <g class="spark" style="--d:2.6s;--dl:-4.86s"><circle class="halo" cx="312.3" cy="172.6" r="15"/><circle class="core" cx="312.3" cy="172.6" r="3.2"/></g>
-    <g class="spark" style="--d:3.6s;--dl:-0.13s"><circle class="halo" cx="418.3" cy="179.0" r="15"/><circle class="core" cx="418.3" cy="179.0" r="3.2"/></g>
-    <g class="spark" style="--d:4.6s;--dl:-0.4s"><circle class="halo" cx="12.3" cy="188.4" r="11"/><circle class="core" cx="12.3" cy="188.4" r="3.2"/></g>
-    <g class="spark" style="--d:2.9s;--dl:-0.67s"><circle class="halo" cx="255.4" cy="195.0" r="11.6"/><circle class="core" cx="255.4" cy="195.0" r="3.2"/></g>
-    <g class="spark" style="--d:3.9s;--dl:-0.94s"><circle class="halo" cx="376.5" cy="217.5" r="11.6"/><circle class="core" cx="376.5" cy="217.5" r="3.2"/></g>
-    <g class="spark" style="--d:4.9s;--dl:-1.21s"><circle class="halo" cx="43.7" cy="225.4" r="12.4"/><circle class="core" cx="43.7" cy="225.4" r="3.2"/></g>
-    <g class="spark" style="--d:3.2s;--dl:-1.48s"><circle class="halo" cx="288.0" cy="228.4" r="14.2"/><circle class="core" cx="288.0" cy="228.4" r="3.2"/></g>
-    <g class="spark" style="--d:4.2s;--dl:-1.75s"><circle class="halo" cx="152.3" cy="238.9" r="15"/><circle class="core" cx="152.3" cy="238.9" r="3.2"/></g>
-    <g class="spark" style="--d:5.2s;--dl:-2.02s"><circle class="halo" cx="416.8" cy="244.2" r="12.4"/><circle class="core" cx="416.8" cy="244.2" r="3.2"/></g>
-    <g class="spark" style="--d:3.5s;--dl:-2.29s"><circle class="halo" cx="119.8" cy="245.0" r="11.6"/><circle class="core" cx="119.8" cy="245.0" r="3.2"/></g>
-    <g class="spark" style="--d:4.5s;--dl:-2.56s"><circle class="halo" cx="352.3" cy="260.4" r="13.5"/><circle class="core" cx="352.3" cy="260.4" r="3.2"/></g>
-    <g class="spark" style="--d:2.8s;--dl:-2.83s"><circle class="halo" cx="243.6" cy="263.3" r="14.2"/><circle class="core" cx="243.6" cy="263.3" r="3.2"/></g>
-    <g class="spark" style="--d:3.8s;--dl:-3.1s"><circle class="halo" cx="208.7" cy="267.0" r="11"/><circle class="core" cx="208.7" cy="267.0" r="3.2"/></g>
-    <g class="spark" style="--d:4.8s;--dl:-3.37s"><circle class="halo" cx="156.2" cy="270.3" r="11"/><circle class="core" cx="156.2" cy="270.3" r="3.2"/></g>
-    <g class="spark" style="--d:3.1s;--dl:-3.64s"><circle class="halo" cx="290.4" cy="288.1" r="11.2"/><circle class="core" cx="290.4" cy="288.1" r="3.2"/></g>
-    <g class="spark" style="--d:4.1s;--dl:-3.91s"><circle class="halo" cx="328.1" cy="291.0" r="11"/><circle class="core" cx="328.1" cy="291.0" r="3.2"/></g>
-    <g class="spark" style="--d:5.1s;--dl:-4.18s"><circle class="halo" cx="231.3" cy="300.1" r="11"/><circle class="core" cx="231.3" cy="300.1" r="3.2"/></g>
-    <g class="spark" style="--d:3.4s;--dl:-4.45s"><circle class="halo" cx="259.7" cy="303.2" r="11.2"/><circle class="core" cx="259.7" cy="303.2" r="3.2"/></g>
-  </g>
-  </svg>
-<g transform="translate(195.68 219.00) scale(0.01714)" fill="#0a0a12"><use href="#gc4f" x="0"/><use href="#gc4e" x="720"/><use href="#gc45" x="1437"/><use href="#gc42" x="2063"/><use href="#gc52" x="2753"/><use href="#gc41" x="3448"/><use href="#gc49" x="4114"/><use href="#gc4e" x="4410"/></g>
+  <path class="plug" d="M310.0 94.5 A145 145 0 0 1 367.0 241.4" opacity="0.22"/>
+  <path class="plug plug-flow" d="M310.0 94.5 A145 145 0 0 1 367.0 241.4" style="animation-delay:0ms" marker-end="url(#arrow)"/>
+  <path class="plug" d="M317.6 323.6 A145 145 0 0 1 137.4 327.6" opacity="0.22"/>
+  <path class="plug plug-flow" d="M317.6 323.6 A145 145 0 0 1 137.4 327.6" style="animation-delay:400ms" marker-end="url(#arrow)"/>
+  <path class="plug" d="M83.9 245.5 A145 145 0 0 1 135.9 97.6" opacity="0.22"/>
+  <path class="plug plug-flow" d="M83.9 245.5 A145 145 0 0 1 135.9 97.6" style="animation-delay:800ms" marker-end="url(#arrow)"/>
+  <rect x="146.0" y="34.0" width="158" height="66" fill="#fafafe" stroke="#08081014" stroke-width="1"/>
+  <rect x="145.5" y="33.5" width="2" height="67" fill="#5f7d00"/>
+<g transform="translate(244.76 51.14) scale(0.00829)" fill="#0a0a1299"><use href="#gm53" x="0"/><use href="#gm54" x="860"/><use href="#gm45" x="1720"/><use href="#gm50" x="2580"/><use href="#gm5f" x="3440"/><use href="#gm30" x="4300"/><use href="#gm31" x="5160"/></g>
+  <svg x="162.0" y="56.0" width="18" height="18"><use href="#i-capture" class="ico" stroke="#5f7d00"/></svg>
+<g transform="translate(189.29 71.00) scale(0.02143)" fill="#0a0a12"><use href="#gc43" x="0"/><use href="#gc41" x="675"/><use href="#gc50" x="1341"/><use href="#gc54" x="2007"/><use href="#gc55" x="2611"/><use href="#gc52" x="3331"/><use href="#gc45" x="4026"/></g>
+<g transform="translate(189.38 87.99) scale(0.00842)" fill="#0a0a1299"><use href="#gm2f" x="0"/><use href="#gm62" x="660"/><use href="#gm72" x="1320"/><use href="#gm61" x="1980"/><use href="#gm69" x="2640"/><use href="#gm6e" x="3300"/><use href="#gm64" x="3960"/><use href="#gm75" x="4620"/><use href="#gm6d" x="5280"/><use href="#gm70" x="5940"/></g>
+  <rect x="271.6" y="251.5" width="158" height="66" fill="#fafafe" stroke="#08081014" stroke-width="1"/>
+  <rect x="271.1" y="251.0" width="2" height="67" fill="#5f7d00"/>
+<g transform="translate(370.48 268.64) scale(0.00829)" fill="#0a0a1299"><use href="#gm53" x="0"/><use href="#gm54" x="860"/><use href="#gm45" x="1720"/><use href="#gm50" x="2580"/><use href="#gm5f" x="3440"/><use href="#gm30" x="4300"/><use href="#gm32" x="5160"/></g>
+  <svg x="287.6" y="273.5" width="18" height="18"><use href="#i-learn" class="ico" stroke="#5f7d00"/></svg>
+<g transform="translate(315.13 288.50) scale(0.02143)" fill="#0a0a12"><use href="#gc45" x="0"/><use href="#gc56" x="626"/><use href="#gc4f" x="1296"/><use href="#gc4c" x="2016"/><use href="#gc56" x="2597"/><use href="#gc45" x="3267"/></g>
+<g transform="translate(314.94 306.01) scale(0.00904)" fill="#0a0a1299"><use href="#gm2f" x="0"/><use href="#gm64" x="660"/><use href="#gm69" x="1320"/><use href="#gm73" x="1980"/><use href="#gm74" x="2640"/><use href="#gm69" x="3300"/><use href="#gm6c" x="3960"/><use href="#gm6c" x="4620"/><use href="#gmb7" x="5940"/><use href="#gm2f" x="7260"/><use href="#gm6c" x="7920"/><use href="#gm65" x="8580"/><use href="#gm61" x="9240"/><use href="#gm72" x="9900"/><use href="#gm6e" x="10560"/></g>
+  <rect x="20.4" y="251.5" width="158" height="66" fill="#fafafe" stroke="#08081014" stroke-width="1"/>
+  <rect x="19.9" y="251.0" width="2" height="67" fill="#5f7d00"/>
+<g transform="translate(119.41 268.64) scale(0.00829)" fill="#0a0a1299"><use href="#gm53" x="0"/><use href="#gm54" x="860"/><use href="#gm45" x="1720"/><use href="#gm50" x="2580"/><use href="#gm5f" x="3440"/><use href="#gm30" x="4300"/><use href="#gm33" x="5160"/></g>
+  <svg x="36.4" y="273.5" width="18" height="18"><use href="#i-recap" class="ico" stroke="#5f7d00"/></svg>
+<g transform="translate(62.15 288.50) scale(0.02143)" fill="#0a0a12"><use href="#gc57" x="0"/><use href="#gc52" x="899"/><use href="#gc41" x="1594"/><use href="#gc50" x="2260"/><use href="#gc55" x="2926"/><use href="#gc50" x="3646"/></g>
+<g transform="translate(63.78 305.49) scale(0.00842)" fill="#0a0a1299"><use href="#gm2f" x="0"/><use href="#gm77" x="660"/><use href="#gm72" x="1320"/><use href="#gm61" x="1980"/><use href="#gm70" x="2640"/><use href="#gm75" x="3300"/><use href="#gm70" x="3960"/><use href="#gmb7" x="5280"/><use href="#gm2f" x="6600"/><use href="#gm72" x="7260"/><use href="#gm65" x="7920"/><use href="#gm63" x="8580"/><use href="#gm61" x="9240"/><use href="#gm70" x="9900"/></g>
 </svg>


### PR DESCRIPTION
Redraws the coevo-loop pair with true-circle geometry per owner feedback on the previous bezier arcs (lumpy/uneven): one circle centered on the ONEBRAIN hero (center 225,212 · R 145), the three step cards centered exactly on the circle at 120° spacing (12/4/8 o'clock), and the dashed arcs are segments of that same circle with gaps computed by circle-rect intersection for even clearance — arrowheads sit tangent on-circle via the family marker (orient=auto). Canvas tightens 450×420 → 450×372. Both variants regenerated from the family generator; all structural gates pass (XML, no <text>, no external refs, <120KB, reduced-motion) and the virtual-time animation proof shows dash-flow moving (432 px) with zero changed pixels in card regions. Synced from the canonical copy in design-system PR onebrain-ai/onebrain-design-system#15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)