### PR TITLE
ci: guard skill-count consistency between skills/ and docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,3 +26,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: python3 scripts/check-links.py
+
+  skill-count:
+    name: skill count
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: python3 scripts/check-skill-count.py

--- a/scripts/check-skill-count.py
+++ b/scripts/check-skill-count.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""CI: verify the documented skill count matches the actual skills/ directory.
+
+Convention: the "skill count" is the number of directories under
+`.claude/plugins/onebrain/skills/` that contain a `SKILL.md`, excluding
+`_shared`, `help`, and `startup` (`/help` is a utility — it is listed in
+docs tables but never counted; `_shared` and `startup` are not skills).
+
+This check has drifted repeatedly (29+/31+/31/30) as skills were added
+without updating every doc that states the count. It enforces:
+  1. Every "<N> skills" / "<N> Skills" mention in README.md and docs/*.md
+     equals the actual count.
+  2. The command table in docs/skills.md has exactly N+1 rows (the extra
+     row is `/help`).
+Pure stdlib — no third-party deps.
+"""
+import glob
+import os
+import re
+import sys
+
+SKILLS_DIR = ".claude/plugins/onebrain/skills"
+EXCLUDED = {"_shared", "help", "startup"}
+DOC_GLOBS = ["README.md", "docs/*.md"]
+COUNT_RE = re.compile(r"(\d+)\+?\s+[Ss]kills\b")
+TABLE_ROW_RE = re.compile(r"^\| `/")
+
+
+def count_skills():
+    n = 0
+    for entry in sorted(os.listdir(SKILLS_DIR)):
+        if entry in EXCLUDED:
+            continue
+        if os.path.isfile(os.path.join(SKILLS_DIR, entry, "SKILL.md")):
+            n += 1
+    return n
+
+
+def doc_files():
+    files = []
+    for pattern in DOC_GLOBS:
+        files.extend(sorted(glob.glob(pattern)))
+    return files
+
+
+def check_doc_counts(actual):
+    errors = []
+    for path in doc_files():
+        with open(path, encoding="utf-8") as fh:
+            for lineno, line in enumerate(fh, start=1):
+                for match in COUNT_RE.finditer(line):
+                    stated = int(match.group(1))
+                    if stated != actual:
+                        errors.append(
+                            f"{path}:{lineno}: says {stated}, actual {actual}"
+                        )
+    return errors
+
+
+def check_skills_table(actual):
+    path = "docs/skills.md"
+    rows = 0
+    with open(path, encoding="utf-8") as fh:
+        for line in fh:
+            if TABLE_ROW_RE.match(line):
+                rows += 1
+    expected = actual + 1
+    errors = []
+    if rows != expected:
+        errors.append(f"{path}: table has {rows} rows, expected {expected} (N+1 incl. /help)")
+    return errors, rows
+
+
+def main():
+    actual = count_skills()
+    errors = check_doc_counts(actual)
+
+    table_errors, rows = check_skills_table(actual)
+    errors.extend(table_errors)
+
+    if errors:
+        print("Skill count mismatches:")
+        for e in errors:
+            print(f"  ✗ {e}")
+        sys.exit(1)
+
+    print(f"Skill count OK — {actual} skills, docs consistent, table rows {rows}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/check-skill-count.py
+++ b/scripts/check-skill-count.py
@@ -13,6 +13,11 @@ without updating every doc that states the count. It enforces:
   2. The command table in docs/skills.md has exactly N+1 rows (the extra
      row is `/help`).
 Pure stdlib — no third-party deps.
+
+Known limitations:
+  - EXCLUDED is exact-name match ({_shared, help, startup}) — a new underscore-prefixed dir WITH a SKILL.md gets counted (fail-safe by design).
+  - Count guard only: a rename (e.g. wrapup -> wrapup-v2) keeps N stable and passes even if docs/skills.md rows go stale — row NAMES are not cross-checked.
+  - Counts inside fenced code blocks are not exempted; avoid literal "<N> skills" strings in code examples.
 """
 import glob
 import os
@@ -46,7 +51,7 @@ def doc_files():
 def check_doc_counts(actual):
     errors = []
     for path in doc_files():
-        with open(path, encoding="utf-8") as fh:
+        with open(path, encoding="utf-8-sig") as fh:
             for lineno, line in enumerate(fh, start=1):
                 for match in COUNT_RE.finditer(line):
                     stated = int(match.group(1))
@@ -60,7 +65,7 @@ def check_doc_counts(actual):
 def check_skills_table(actual):
     path = "docs/skills.md"
     rows = 0
-    with open(path, encoding="utf-8") as fh:
+    with open(path, encoding="utf-8-sig") as fh:
         for line in fh:
             if TABLE_ROW_RE.match(line):
                 rows += 1


### PR DESCRIPTION
## Problem

The documented skill count has drifted repeatedly (29+/31+/31/30) across README.md and docs/*.md as skills were added or removed without updating every reference. Nothing caught the mismatch until a human noticed.

## What this enforces

- `scripts/check-skill-count.py` computes the actual skill count (N) as the number of directories under `.claude/plugins/onebrain/skills/` that contain a `SKILL.md`, excluding `_shared`, `help`, and `startup` (`/help` is a utility — listed in docs tables but never counted toward N).
- Every `<N> skills` / `<N> Skills` mention in README.md and docs/*.md must equal N.
- The command table in `docs/skills.md` must have exactly N+1 rows (the extra row is `/help`).
- New `skill-count` CI job runs the check on every push/PR, mirroring the existing `links` job.

## Updating when adding a skill

When adding or removing a skill directory, update the stated count in README.md, docs/README.md, and docs/skills.md (and add/remove the corresponding row in the docs/skills.md table) alongside the skill directory change — the CI job will fail the PR otherwise.

## Test plan

- [x] `python3 scripts/check-skill-count.py` passes in-repo (30 skills, table rows 31)
- [x] Negative test: bumping a stated "30 skills" to "31 skills" fails naming the file/line
- [x] Negative test: removing a row from the docs/skills.md table fails with both row counts
- [x] `python3 scripts/check-links.py` still passes unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)