### PR TITLE
feat(hooks): Vault-read Ledger Gate PreToolUse hook (v3.4.10 Track 8)

### DIFF
--- a/.claude/plugins/onebrain/.claude-plugin/plugin.json
+++ b/.claude/plugins/onebrain/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "onebrain",
-  "version": "3.2.1",
+  "version": "3.3.0",
   "description": "OneBrain — Your AI Thinking Partner",
   "author": {
     "name": "OneBrain Contributors"

--- a/.claude/plugins/onebrain/INSTRUCTIONS.md
+++ b/.claude/plugins/onebrain/INSTRUCTIONS.md
@@ -341,6 +341,19 @@ OneBrain registers the Stop checkpoint hook, plus — when a search collection i
 
 **Session logs are NOT created from the Stop hook.** They are created only by `/wrapup` (manual) or AUTO-SUMMARY (end-of-session signal); both consolidate accumulated checkpoint files into one session log per call. This preserves the "1 session = 1 session log" invariant.
 
+### Vault-read Ledger Gate (PreToolUse Hook)
+
+The plugin statically registers a PreToolUse hook (`hooks/hooks.json`, matcher `Read`, script `hooks/read-hook.sh`, 5s timeout) that gates repeat `Read` calls on vault `.md` files already delivered unchanged this session — the token-optimization "already-sent ledger" (CLI v3.4.10+, design §5b). It calls `onebrain token check <path>` and translates the CLI's exit-code protocol straight through: exit 0 = allow (first-time read, or the doc changed since it was last sent) — the Read proceeds untouched; exit 2 = deny — stdout carries a reference envelope (`{doc_path, hash, sent_earlier: true, bytes_saved, rematerialize: "onebrain search get <path> --force"}`) that the hook surfaces as the block reason. When a Read is denied this way, use the `--force` re-materialize command from the envelope instead of retrying the same Read — the content was already delivered this session and is unchanged.
+
+This hook is separate from the CLI-registered PostToolUse **search-reindex** / Stop **embed** hooks mentioned above — those are dynamically written into the vault's own `.claude/settings.json` by the CLI. The Ledger Gate hook ships statically in this plugin's `hooks/hooks.json` and is always *present* once the plugin loads; what's conditional is its *behavior*, not its registration.
+
+**Default: OFF.** The CLI answers `allow` immediately unless the vault's `onebrain.yml` sets `token_optimization.read_hook: ledger` (default `off`) — no plugin-side config parsing is needed; the CLI is the single source of truth for whether the gate is active.
+
+**Three ways it stays harmless:**
+1. **Off by default** — `read_hook: off` in onebrain.yml means every check is an instant allow.
+2. **`ONEBRAIN_HOOK_BYPASS=1`** — set this env var to skip the hook entirely for the session, regardless of onebrain.yml.
+3. **Fail-open** — a missing or too-old `onebrain` CLI, a missing `jq`, a non-`.md` path, malformed hook input, the 5s hook timeout, or any exit code other than 0/2 all resolve to "allow, do nothing." The hook only ever blocks on a genuine repeat-send verdict from the CLI — never on its own trouble.
+
 ---
 
 <!-- ═══════════════════════════════════════════════════════════

--- a/.claude/plugins/onebrain/hooks/hooks.json
+++ b/.claude/plugins/onebrain/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "OneBrain plugin v3 — SessionStart hook that refuses to load against an incompatible OneBrain CLI (< v3.0.0). Pairs with the `requires.cli` field in plugin.json.",
+  "description": "OneBrain plugin v3 — SessionStart hook that refuses to load against an incompatible OneBrain CLI (< v3.0.0), pairs with `requires.cli` in plugin.json. PreToolUse hook gates repeat Read calls on vault .md docs already sent this session (token-optimization Ledger Gate, CLI v3.4.10+, design §5b) — off by default (onebrain.yml `token_optimization.read_hook: off`), always fail-open. See INSTRUCTIONS.md \"Vault-read Ledger Gate (PreToolUse Hook)\".",
   "hooks": {
     "SessionStart": [
       {
@@ -8,6 +8,18 @@
             "type": "command",
             "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/check-cli-version.sh\"",
             "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Read",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/read-hook.sh\"",
+            "timeout": 5
           }
         ]
       }

--- a/.claude/plugins/onebrain/hooks/read-hook.sh
+++ b/.claude/plugins/onebrain/hooks/read-hook.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# OneBrain plugin v3 — Vault-read Ledger Gate (PreToolUse hook, v3.4.10 Track 8).
+#
+# Gates repeat `Read` calls on vault `.md` files that were already delivered
+# to this session's context unchanged — the token-optimization "already-sent
+# ledger" (design doc §5b). First-time reads and reads of an edited doc
+# always pass through untouched.
+#
+# Default posture: OFF and fail-open everywhere.
+#   - `onebrain token check` itself answers "allow" immediately unless the
+#     vault's onebrain.yml sets `token_optimization.read_hook: ledger`
+#     (default: off) — no config parsing needed on the plugin side, the CLI
+#     is the single source of truth for whether the gate is active.
+#   - ONEBRAIN_HOOK_BYPASS=1 skips this hook entirely for the session.
+#   - Any trouble at all (CLI missing/old, no `jq`, non-.md path, malformed
+#     hook input, unexpected exit code, the 5s hook timeout below) fails
+#     OPEN — the Read always proceeds. This hook only ever blocks on a
+#     genuine repeat-send verdict from the CLI.
+#
+# Contract with `onebrain token check <path>` (CLI v3.4.10+):
+#   exit 0 = allow (first send, or the doc's content changed since last
+#            send) — nothing to do, let the Read proceed.
+#   exit 2 = deny — stdout carries a reference envelope JSON (the doc was
+#            already sent, unchanged, earlier this session). The envelope
+#            always embeds a `rematerialize` instruction
+#            (`onebrain search get <path> --force`) so the agent can pull
+#            the full content back on purpose instead of retrying the Read.
+#
+# Translation to Claude Code's own PreToolUse protocol is a straight
+# passthrough: exit 0 = allow, exit 2 with a reason on stderr = block the
+# tool call and feed that reason back to Claude as context. The two
+# protocols already line up, so no `hookSpecificOutput` JSON is needed.
+#
+# See INSTRUCTIONS.md → "Vault-read Ledger Gate (PreToolUse Hook)" for the
+# user-facing explanation, the config key, and all three bypasses.
+
+set -u
+
+# Bypass 2 (see INSTRUCTIONS.md): explicit per-session opt-out, independent
+# of onebrain.yml.
+if [ "${ONEBRAIN_HOOK_BYPASS:-}" = "1" ]; then
+  exit 0
+fi
+
+input=$(cat)
+
+# `jq` is the only reliable way to unescape the JSON string correctly —
+# this matters on Windows, where `tool_input.file_path` carries
+# JSON-escaped backslashes (`C:\\Users\\...`) that a regex/sed extraction
+# would pass through un-unescaped, corrupting the path. No jq -> fail open
+# rather than hand-roll a lossy parse.
+if ! command -v jq >/dev/null 2>&1; then
+  exit 0
+fi
+
+tool_name=$(printf '%s' "$input" | jq -r '.tool_name // empty' 2>/dev/null)
+if [ "${tool_name}" != "Read" ]; then
+  exit 0
+fi
+
+file_path=$(printf '%s' "$input" | jq -r '.tool_input.file_path // empty' 2>/dev/null)
+if [ -z "${file_path}" ]; then
+  exit 0
+fi
+
+# Only gate markdown vault docs. A plain trailing-glob match is
+# Windows-safe (backslash path separators don't affect a suffix match) and
+# covers the common case variants without relying on bash 4+ case-folding
+# (${var,,}) — macOS ships bash 3.2 by default.
+case "${file_path}" in
+  *.md | *.MD | *.Md | *.mD) ;;
+  *) exit 0 ;;
+esac
+
+if ! command -v onebrain >/dev/null 2>&1; then
+  exit 0
+fi
+
+envelope=$(onebrain token check "${file_path}" 2>/dev/null)
+status=$?
+
+if [ "${status}" -eq 2 ] && [ -n "${envelope}" ]; then
+  # Deny: surface the reference envelope to Claude as the block reason.
+  printf '%s\n' "${envelope}" >&2
+  exit 2
+fi
+
+# status 0 (allow), or any unexpected status — fail open.
+exit 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ---
-latest_version: 3.2.1
-released: 2026-07-05
+latest_version: 3.3.0
+released: 2026-07-11
 ---
 
 # Changelog
@@ -10,6 +10,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 > **Versioning:** Plugin version is tracked in `plugin.json`. Bump when ANY harness config changes — skills, agents, hooks, INSTRUCTIONS, Gemini settings, slash commands, etc.
 > For CLI binary changes, see the [`onebrain-ai/onebrain-cli`](https://github.com/onebrain-ai/onebrain-cli/blob/main/CHANGELOG.md) repository.
+
+## v3.3.0 — 2026-07-11 — Vault-read Ledger Gate hook (v3.4.10 Track 8)
+
+Plugin side of the token-optimization epic (onebrain-ai/onebrain-cli v3.4.10). Registers, but does not enable, the read-hook mechanism the CLI's `onebrain token check` command answers.
+
+- **New PreToolUse hook** (`hooks/hooks.json`, matcher `Read`, 5s timeout) runs `hooks/read-hook.sh` on every `Read` tool call. For vault `.md` paths it calls `onebrain token check <path>` and passes the CLI's exit code straight through to Claude Code's own PreToolUse protocol: exit 0 = allow, exit 2 = block with the reference envelope (JSON on stdout from the CLI) surfaced on stderr as the block reason, telling the agent to re-materialize via `onebrain search get <path> --force` instead of re-reading.
+- **Off by default, three-layer harmless-by-construction:** (1) the CLI itself answers `allow` immediately unless `onebrain.yml` sets `token_optimization.read_hook: ledger` — no plugin-side config parsing; (2) `ONEBRAIN_HOOK_BYPASS=1` skips the hook for the session; (3) fail-open on any trouble (CLI missing/old, no `jq`, non-`.md` path, malformed input, timeout, unexpected exit code) — never blocks a Read on its own error.
+- **INSTRUCTIONS.md**: new "Vault-read Ledger Gate (PreToolUse Hook)" subsection under Session Behavior documenting the mechanism, the config key, and all three bypasses.
+- No `requires.cli` floor bump — the hook fails open against any CLI that lacks `token check`, so it stays safe on older installs.
 
 ## v3.2.1 — 2026-07-05 — adopt search_unembedded + search hook naming (v3.4.5 Track 3b, plugin follow-up)
 


### PR DESCRIPTION
## Summary

Plugin side of the `onebrain-ai/onebrain-cli` v3.4.10 Token Optimization epic — Track 8 (read-hook registration). Registers a **PreToolUse** hook on the `Read` tool that gates repeat reads of vault `.md` docs already delivered unchanged this session (the "already-sent ledger", design §5b), by calling the CLI's `onebrain token check <path>` and passing its exit code straight through to Claude Code's own PreToolUse protocol.

This PR only **registers** the mechanism — it does **not** enable it. `token_optimization.read_hook` defaults to `off` on the CLI side, so every check answers `allow` immediately until a vault opts in via `onebrain.yml`.

Part of onebrain-ai/onebrain-cli v3.4.10 epic (Track 8). (This is a separate plugin repo with its own issues/milestones — no CLI-repo issue to close from here.)

## What changed

- **`hooks/read-hook.sh`** (new): PreToolUse command hook. Extracts `tool_name`/`tool_input.file_path` from stdin JSON via `jq` (needed for correct unescaping of Windows-style backslash paths), gates on `.md` suffix, calls `onebrain token check <path>`, and translates its exit code 1:1 into Claude Code's own PreToolUse exit-code protocol (0 = allow, 2 = block + reference envelope surfaced on stderr as the reason).
- **`hooks/hooks.json`**: new `PreToolUse` entry, matcher `Read`, 5s timeout, `${CLAUDE_PLUGIN_ROOT}` convention (matches the existing `SessionStart` entry's style).
- **`INSTRUCTIONS.md`**: new "Vault-read Ledger Gate (PreToolUse Hook)" subsection under Session Behavior — what it gates, the `read_hook: ledger` config key, and all three bypasses.
- **`plugin.json`**: `3.2.1` → `3.3.0` (minor — new hook, per `CONTRIBUTING.md` versioning table).
- **`CHANGELOG.md`**: new `v3.3.0` entry.

## Bypass / safety mechanisms (design §5b — must be harmless if it misbehaves)

1. **Config off by default** — CLI answers `allow` immediately unless the vault's `onebrain.yml` sets `token_optimization.read_hook: ledger`. No plugin-side config parsing needed — the CLI is the single source of truth.
2. **`ONEBRAIN_HOOK_BYPASS=1`** — skips the hook entirely for the session, independent of `onebrain.yml`.
3. **Fail-open** — missing/old `onebrain` CLI, missing `jq`, non-`.md` path, malformed hook input, the 5s hook timeout, or any exit code other than 0/2 all resolve to "allow, do nothing." Verified locally (see Manual test checklist) with a stub CLI covering allow / deny / unexpected-exit-code / CLI-missing paths.

No `requires.cli` floor bump: the hook fails open against any CLI lacking `token check`, so it's safe to ship ahead of a hard version pin.

## Windows note

The hook does two small pieces of path handling:
- **Extension match** is a plain trailing-glob (`*.md`/`*.MD`/`*.Md`/`*.mD`) — unaffected by backslash path separators, and avoids `${var,,}` case-folding (bash 4+ only; macOS ships bash 3.2).
- **Path unescaping** relies on `jq -r '.tool_input.file_path'` rather than a regex/sed extraction, because Windows paths arrive JSON-escaped (`C:\\Users\\...`) and a naive extraction would pass the doubled backslashes through uncorrected. Verified locally that `jq` round-trips `C:\Users\keng\vault\note.md` correctly (see checklist). If `jq` is unavailable the hook fails open rather than risk a corrupted path.
- The `onebrain` binary itself receives the raw (already-unescaped) path string unmodified — no further manipulation.

## Manual test checklist (this repo has no Rust CI to exercise the hook end-to-end)

Ran locally against a stub `onebrain` binary on `PATH` (bash logic, not the real CLI — real-CLI end-to-end still needs a vault on CLI ≥3.4.10):

- [x] `ONEBRAIN_HOOK_BYPASS=1` → hook exits 0 (allow) without invoking `onebrain` at all.
- [x] Non-`Read` tool_name → exits 0.
- [x] Non-`.md` file_path → exits 0.
- [x] Malformed stdin JSON → exits 0 (fails open before ever reaching `onebrain`).
- [x] `onebrain` missing from `PATH` → exits 0.
- [x] Stub `onebrain token check` exit 0 → hook exits 0 (allow).
- [x] Stub `onebrain token check` exit 2 + envelope on stdout → hook exits 2, envelope forwarded verbatim on stderr.
- [x] Stub `onebrain token check` unexpected exit code (7) → hook exits 0 (fail open).
- [x] Windows-style escaped path (`C:\\Users\\keng\\vault\\note.md` in the JSON) → `jq` unescapes to `C:\Users\keng\vault\note.md` before it reaches the CLI call.
- [x] `hooks.json` validated with `python3 scripts/check-config.py` (repo CI job).
- [x] `python3 scripts/check-links.py` / `python3 scripts/check-skill-count.py` still green (no regressions).

**Still to verify manually once a real vault is on CLI ≥3.4.10** (can't be exercised in this sandbox — no live daemon/vault):
- [ ] Enable `token_optimization.read_hook: ledger` in a real vault's `onebrain.yml`, set opt level to `balanced`+ (ledger activates at level 2), then `Read` the same vault `.md` doc twice in one session — first Read succeeds normally, second Read is denied with the reference envelope surfaced to the agent.
- [ ] Confirm the agent naturally follows the envelope's `rematerialize` instruction (`onebrain search get <path> --force`) rather than retrying the plain Read.
- [ ] `ONEBRAIN_HOOK_BYPASS=1` set in the real session env disables the gate even with `read_hook: ledger` on.
- [ ] A vault on an older/missing CLI (no `token check` subcommand) never blocks a Read (fail-open in practice, not just in the stub).

## Test plan

- [x] `python3 scripts/check-config.py` — green
- [x] `python3 scripts/check-links.py` — green
- [x] `python3 scripts/check-skill-count.py` — green
- [x] `bash -n hooks/read-hook.sh` — syntax OK
- [x] Stub-CLI behavioral tests above — all pass
- [ ] Real-CLI manual verification checklist above (post-merge, once ob-1 or another vault is on CLI ≥3.4.10)
