### PR TITLE
fix(read-hook): zero-cost when off via config short-circuit (v3.3.1)

### DIFF
--- a/.claude/plugins/onebrain/.claude-plugin/plugin.json
+++ b/.claude/plugins/onebrain/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "onebrain",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "OneBrain — Your AI Thinking Partner",
   "author": {
     "name": "OneBrain Contributors"

--- a/.claude/plugins/onebrain/INSTRUCTIONS.md
+++ b/.claude/plugins/onebrain/INSTRUCTIONS.md
@@ -347,10 +347,10 @@ The plugin statically registers a PreToolUse hook (`hooks/hooks.json`, matcher `
 
 This hook is separate from the CLI-registered PostToolUse **search-reindex** / Stop **embed** hooks mentioned above — those are dynamically written into the vault's own `.claude/settings.json` by the CLI. The Ledger Gate hook ships statically in this plugin's `hooks/hooks.json` and is always *present* once the plugin loads; what's conditional is its *behavior*, not its registration.
 
-**Default: OFF.** The CLI answers `allow` immediately unless the vault's `onebrain.yml` sets `token_optimization.read_hook: ledger` (default `off`) — no plugin-side config parsing is needed; the CLI is the single source of truth for whether the gate is active.
+**Default: OFF.** The gate is active only when the vault's `onebrain.yml` sets `token_optimization.read_hook: ledger` (default `off`). Since v3.3.1 the hook script itself resolves the config with a cheap grep (walk up to the vault root) and, when `read_hook` is not `ledger`, allows the Read **without spawning `onebrain` at all** — so an off vault pays a grep, not a subprocess, per read. When `ledger` is set (or the config can't be resolved) it falls through to `onebrain token check`, which stays the source of truth for the verdict. (True dynamic registration — not registering the hook when off — is a planned v3.4.11 CLI+plugin follow-up.)
 
 **Three ways it stays harmless:**
-1. **Off by default** — `read_hook: off` in onebrain.yml means every check is an instant allow.
+1. **Off by default** — `read_hook: off` (or absent) means the script short-circuits to an instant allow with no `onebrain` subprocess.
 2. **`ONEBRAIN_HOOK_BYPASS=1`** — set this env var to skip the hook entirely for the session, regardless of onebrain.yml.
 3. **Fail-open** — a missing or too-old `onebrain` CLI, a missing `jq`, a non-`.md` path, malformed hook input, the 5s hook timeout, or any exit code other than 0/2 all resolve to "allow, do nothing." The hook only ever blocks on a genuine repeat-send verdict from the CLI — never on its own trouble.
 

--- a/.claude/plugins/onebrain/hooks/read-hook.sh
+++ b/.claude/plugins/onebrain/hooks/read-hook.sh
@@ -7,10 +7,12 @@
 # always pass through untouched.
 #
 # Default posture: OFF and fail-open everywhere.
-#   - `onebrain token check` itself answers "allow" immediately unless the
-#     vault's onebrain.yml sets `token_optimization.read_hook: ledger`
-#     (default: off) — no config parsing needed on the plugin side, the CLI
-#     is the single source of truth for whether the gate is active.
+#   - The gate is active ONLY when the vault's onebrain.yml sets
+#     `token_optimization.read_hook: ledger` (default: off). A cheap config
+#     short-circuit (below) skips the `onebrain` subprocess entirely on the
+#     off path, so the hook costs ~a grep, not a process spawn, when off. When
+#     ledger IS set — or the config can't be resolved — it falls through to
+#     `onebrain token check`, which stays the source of truth for the verdict.
 #   - ONEBRAIN_HOOK_BYPASS=1 skips this hook entirely for the session.
 #   - Any trouble at all (CLI missing/old, no `jq`, non-.md path, malformed
 #     hook input, unexpected exit code, the 5s hook timeout below) fails
@@ -71,6 +73,29 @@ case "${file_path}" in
   *.md | *.MD | *.Md | *.mD) ;;
   *) exit 0 ;;
 esac
+
+# Config short-circuit (v3.3.1): only `token_optimization.read_hook: ledger`
+# actually gates reads; every other value — including the default `off` and an
+# absent key — means "allow". So before paying for an `onebrain` subprocess on
+# EVERY .md read, cheaply resolve the vault's config and skip the CLI entirely
+# on the common off path. Walk up from the doc's directory to the vault root
+# (onebrain.yml, or legacy vault.yml). If the config is found and read_hook is
+# NOT ledger → allow immediately, no subprocess. If no config is found, fall
+# THROUGH to the authoritative `onebrain token check` (never guess when unsure
+# — the CLI is still the source of truth, and it fails open too). The
+# `read_hook:.*ledger` match tolerates quoting/spacing; comment lines (`#
+# read_hook: ...`) don't match the leading-key anchor, so the self-documenting
+# template's comments never false-trigger.
+_rh_dir=$(dirname "${file_path}")
+_rh_cfg=""
+while [ -n "${_rh_dir}" ] && [ "${_rh_dir}" != "/" ] && [ "${_rh_dir}" != "." ]; do
+  if [ -f "${_rh_dir}/onebrain.yml" ]; then _rh_cfg="${_rh_dir}/onebrain.yml"; break; fi
+  if [ -f "${_rh_dir}/vault.yml" ]; then _rh_cfg="${_rh_dir}/vault.yml"; break; fi
+  _rh_dir=$(dirname "${_rh_dir}")
+done
+if [ -n "${_rh_cfg}" ] && ! grep -Eq '^[[:space:]]*read_hook:.*ledger' "${_rh_cfg}"; then
+  exit 0
+fi
 
 if ! command -v onebrain >/dev/null 2>&1; then
   exit 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ---
-latest_version: 3.3.0
-released: 2026-07-11
+latest_version: 3.3.1
+released: 2026-07-12
 ---
 
 # Changelog
@@ -10,6 +10,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 > **Versioning:** Plugin version is tracked in `plugin.json`. Bump when ANY harness config changes — skills, agents, hooks, INSTRUCTIONS, Gemini settings, slash commands, etc.
 > For CLI binary changes, see the [`onebrain-ai/onebrain-cli`](https://github.com/onebrain-ai/onebrain-cli/blob/main/CHANGELOG.md) repository.
+
+## v3.3.1 — 2026-07-12 — Read-hook: zero-cost when off
+
+- **`read-hook.sh` config short-circuit** — the PreToolUse read-hook previously spawned `onebrain token check` on *every* vault `.md` Read even when the gate was off (the CLI answered `allow` immediately, but the subprocess still cost ~tens of ms per read). It now cheaply resolves the vault's `onebrain.yml` (walk up to the vault root; legacy `vault.yml` too) and, when `token_optimization.read_hook` is **not** `ledger` (the default), allows the Read with **no subprocess at all** — a grep instead of a process spawn. When `ledger` **is** set, or the config can't be resolved, it falls through to `onebrain token check` exactly as before (the CLI stays the source of truth). Fail-open and `ONEBRAIN_HOOK_BYPASS=1` unchanged; `.md`-gating and Windows/`jq` path handling unchanged. (True dynamic registration — not registering the hook at all when off — remains a v3.4.11 CLI+plugin follow-up.)
 
 ## v3.3.0 — 2026-07-11 — Vault-read Ledger Gate hook (v3.4.10 Track 8)
 


### PR DESCRIPTION
Follow-up from onebrain-ai/onebrain-cli **v3.4.10** (already tagged). พี่เก่ง's Q1 decision (2026-07-12): **option B** — make the read-hook near-zero-cost when off **now**, without waiting for the v3.4.11 CLI change that true dynamic registration would need.

## Problem
The PreToolUse read-hook (v3.3.0) spawned `onebrain token check` on **every** vault `.md` Read even when off — the CLI answered `allow` immediately, but the subprocess still cost ~tens of ms per read.

## Fix (plugin-only, no CLI change)
`read-hook.sh` now resolves the vault's `onebrain.yml` (walk up from the doc's dir to the vault root; legacy `vault.yml` too) and, when `token_optimization.read_hook` is **not** `ledger` (the default), allows the Read with **no subprocess** — a grep instead of a process spawn. When `ledger` **is** set (or the config can't be resolved), it falls through to `onebrain token check` exactly as before (the CLI stays the source of truth, and it fails open too).

Unchanged: fail-open on any trouble · `ONEBRAIN_HOOK_BYPASS=1` · `.md`-gating · `jq`/Windows path handling. `plugin.json` 3.3.0→3.3.1; CHANGELOG + INSTRUCTIONS.md updated.

## Manual test results (this repo has no CI; ran locally with a stub `onebrain` that records invocations)
| Case | Expect | Result |
|---|---|---|
| off config (`read_hook: off`) | exit 0, **onebrain NOT spawned** | ✅ exit 0, 0 calls |
| ledger config (`read_hook: ledger`) | falls through → onebrain called → deny | ✅ exit 2, 1 call |
| no config found | falls through → onebrain called (authoritative) | ✅ exit 2, 1 call |
| `ONEBRAIN_HOOK_BYPASS=1` | exit 0, nothing spawned | ✅ exit 0, 0 calls |
| non-`.md` path | exit 0, nothing spawned | ✅ exit 0, 0 calls |
- `bash -n` syntax OK · `shellcheck -S warning` clean · `check-config`/`check-links`/`check-skill-count` all pass.

## Still to verify on a real CLI ≥3.4.10 vault (post-merge field check)
- [ ] Real vault, `read_hook: off` → open a `.md` many times → no perceptible per-read latency; `onebrain` not in the process tree during reads.
- [ ] Real vault, `read_hook: ledger` → 2nd read of an unchanged doc is denied with the reference envelope; `--force` re-materializes.
- [ ] Windows: doc path with backslashes resolves the vault root + reads the config correctly.

## Not in scope
True **dynamic registration** (not registering the hook at all when off — CLI `register_hooks` writes settings.json conditionally) is a v3.4.11 CLI+plugin follow-up (chip task_56bba25c). B gets ~99% of the benefit now with no CLI dependency.

Part of the onebrain-cli v3.4.10 epic.