### PR TITLE
feat(search): silent search cascade + rerank_score thresholds + grep-gate hook (#221)

### DIFF
--- a/.claude/plugins/onebrain/INSTRUCTIONS.md
+++ b/.claude/plugins/onebrain/INSTRUCTIONS.md
@@ -188,9 +188,9 @@ When a user message clearly maps to a skill, invoke it directly — no `/command
 
 ## Search Strategy
 
-If the search MCP tools are available (`mcp__plugin_onebrain_search__query` in tool list), any vault content search runs the **cascade**: MCP query first, always → judge confidence via `rerank_score` bands (`<0.30` no strong match, `0.30–0.60` possible, `>0.60` confident) → Grep only as fallback (MCP unavailable/error, zero or all-low-confidence hits, or a freshness gap on a just-written file) → if Grep is also empty, an honest "not found." Never narrate which method was used — deliver results only, silently. Reserve Glob/Grep/Read outright for non-content lookups: known file paths, frontmatter field checks, structural/task-line scans, file-existence checks.
+If the search MCP tools are available (`mcp__plugin_onebrain_search__query` in tool list), any vault content search runs the **cascade**: MCP query first, always → judge confidence via `rerank_score` bands (`< 0.30` no strong match, `0.30 – 0.60` possible, `≥ 0.60` confident) → Grep only as fallback (MCP unavailable/error, zero or all-low-confidence hits, or a freshness gap on a just-written file; append an alternation branch `|mcp-miss` to the pattern when falling back legitimately) → if Grep is also empty, an honest "not found." Never narrate which method was used — deliver results only, silently. Reserve Glob/Grep/Read outright for non-content lookups: known file paths, frontmatter field checks, structural/task-line scans, file-existence checks.
 
-Full cascade contract, sub-query types (lex/vec/hyde), the `# mcp-miss` fallback marker, and index maintenance rules: `skills/startup/SEARCH.md`.
+Full cascade contract, sub-query types (lex/vec/hyde), the `|mcp-miss` fallback marker, and index maintenance rules: `skills/startup/SEARCH.md`.
 
 If the search tools are NOT available: use Glob/Grep/Read for all vault searches. No special handling needed.
 
@@ -302,8 +302,8 @@ Note inline: `[Loading memory: filename]`
 When the user asks you to recall something (a decision, preference, fact, or past discussion), search the memory layers in order of permanence:
 
 1. **`[agent_folder]/MEMORY.md`** : already in context; check here first
-2. **`[agent_folder]/memory/`** : MEMORY-INDEX.md is already in context — match query keywords against its Topics column to identify relevant files, then read those files. If no topic match, grep memory/ directly. Use the search tools if available for broader semantic search.
-3. **`[logs_folder]/session/`** : grep session logs at `[logs_folder]/session/**/*-session-*.md` (post-v2.4.0: session logs live under the dedicated `session/` subfolder; checkpoints live flat in `checkpoint/` and update/log entries in their own folders, so the old defensive `*-session-*` filter is no longer strictly necessary but keep it as a defense-in-depth) for past decisions and discussions
+2. **`[agent_folder]/memory/`** : MEMORY-INDEX.md is already in context — match query keywords against its Topics column to identify relevant files, then read those files. If no topic match, run the search cascade (search tools first, per `skills/startup/SEARCH.md`); grep memory/ only per the cascade's fallback triggers.
+3. **`[logs_folder]/session/`** : search session logs via the cascade (search tools first); grep `[logs_folder]/session/**/*-session-*.md` only as the cascade fallback (post-v2.4.0: session logs live under the dedicated `session/` subfolder; checkpoints live flat in `checkpoint/` and update/log entries in their own folders, so the old defensive `*-session-*` filter is no longer strictly necessary but keep it as a defense-in-depth) for past decisions and discussions
 
 Stop as soon as you find a confident answer. If the answer spans multiple layers, synthesize across them.
 
@@ -349,8 +349,21 @@ This hook is separate from the CLI-registered PostToolUse **search-reindex** / S
 
 **Three ways it stays harmless:**
 1. **Off by default** — `read_hook: off` (or absent) means the script short-circuits to an instant allow with no `onebrain` subprocess.
-2. **`ONEBRAIN_HOOK_BYPASS=1`** — set this env var to skip the hook entirely for the session, regardless of onebrain.yml.
+2. **`ONEBRAIN_HOOK_BYPASS=1`** — set this env var to skip the hook entirely for the session, regardless of onebrain.yml. (This variable disables BOTH PreToolUse hooks — this Ledger Gate and the Search Cascade Grep Gate below.)
 3. **Fail-open** — a missing or too-old `onebrain` CLI, a missing `jq`, a non-`.md` path, malformed hook input, the 5s hook timeout, or any exit code other than 0/2 all resolve to "allow, do nothing." The hook only ever blocks on a genuine repeat-send verdict from the CLI — never on its own trouble.
+
+### Search Cascade Grep Gate (PreToolUse Hook)
+
+The plugin statically registers a second PreToolUse hook (`hooks/hooks.json`, matcher `Grep`, script `hooks/grep-gate.sh`, 5s timeout) that enforces the search cascade (see Search Strategy above and `skills/startup/SEARCH.md`): a Grep that looks like a vault CONTENT search — targeting the vault's content folders (inbox/projects/areas/knowledge/resources, resolved from `onebrain.yml` `folders:` when readable, defaults otherwise), sweeping `.md` content, with a non-structural pattern — is blocked with an agent-facing reason (stderr, exit 2) telling the agent to route through `mcp__plugin_onebrain_search__query` first. The block reason is never shown to the user.
+
+**What it never blocks:** structural patterns (task-line scans, frontmatter anchors and `<key>: value` field lookups, YAML list anchors, wikilink scans — literal or escaped, date/checkpoint filename patterns, exact code identifiers), a `path` pointing at a single existing file (known-file greps are blessed by SEARCH.md's decision table), anything outside the content folders, and non-`.md` targets.
+
+**Escape hatch:** after a genuine MCP miss, append the alternation branch `|mcp-miss` to the Grep pattern (per SEARCH.md cascade step 3) — the hook allows it through on a plain substring match.
+
+**Ways it stays harmless:**
+1. **Search-disabled vaults are exempt** — when the resolved `onebrain.yml` has no `search.collection` (and no legacy top-level `qmd_collection`), the search MCP doesn't exist for that vault, so the hook allows everything. Same when no config file can be found at all.
+2. **`ONEBRAIN_HOOK_BYPASS=1`** — the same env var that disables the Ledger Gate also skips this hook entirely for the session.
+3. **Fail-open** — a missing `jq`, malformed hook input, an empty pattern, an unresolvable config, or the 5s hook timeout all resolve to "allow, do nothing." The hook only ever blocks when every gate condition is affirmatively met — never on its own trouble.
 
 ---
 

--- a/.claude/plugins/onebrain/INSTRUCTIONS.md
+++ b/.claude/plugins/onebrain/INSTRUCTIONS.md
@@ -188,11 +188,9 @@ When a user message clearly maps to a skill, invoke it directly — no `/command
 
 ## Search Strategy
 
-If the search MCP tools are available (`mcp__plugin_onebrain_search__query` in tool list):
+If the search MCP tools are available (`mcp__plugin_onebrain_search__query` in tool list), any vault content search runs the **cascade**: MCP query first, always → judge confidence via `rerank_score` bands (`<0.30` no strong match, `0.30–0.60` possible, `>0.60` confident) → Grep only as fallback (MCP unavailable/error, zero or all-low-confidence hits, or a freshness gap on a just-written file) → if Grep is also empty, an honest "not found." Never narrate which method was used — deliver results only, silently. Reserve Glob/Grep/Read outright for non-content lookups: known file paths, frontmatter field checks, structural/task-line scans, file-existence checks.
 
-- **Default to the search tools for any vault content search.** Topic lookup, concept search, "find notes about X", "what did I write about Y", related-notes discovery — these all go through `mcp__plugin_onebrain_search__query`. Do not reach for Grep first.
-- **Reserve Glob/Grep/Read for non-content lookups only:** known file paths, frontmatter field checks, exact regex/structural matches inside a known file, task-line scans, file-existence checks. If you find yourself grepping vault `.md` files for a topic or keyword, switch to the search tools.
-- See `skills/startup/SEARCH.md` for full search strategy, sub-query types (lex/vec/hyde), and index maintenance rules.
+Full cascade contract, sub-query types (lex/vec/hyde), the `# mcp-miss` fallback marker, and index maintenance rules: `skills/startup/SEARCH.md`.
 
 If the search tools are NOT available: use Glob/Grep/Read for all vault searches. No special handling needed.
 

--- a/.claude/plugins/onebrain/agents/inbox-classifier.md
+++ b/.claude/plugins/onebrain/agents/inbox-classifier.md
@@ -31,7 +31,7 @@ You receive:
 
 4. **Suggest filename**: Title Case, 2–5 words, no date prefix.
 
-5. **Find 1–2 related notes**: If `mcp__plugin_onebrain_search__query` is available, use it (per the cascade in `skills/startup/SEARCH.md`) with 2–3 keywords and keep only candidates with `rerank_score ≥ 0.30` (prefer `≥ 0.60`) — drop anything below 0.30. Otherwise Grep `[knowledge_folder]/**/*.md` and `[resources_folder]/**/*.md` for the same keywords. Skip folders that do not exist. Return top 1–2 file titles as wikilink candidates.
+5. **Find 1–2 related notes**: If `mcp__plugin_onebrain_search__query` is available, use it (per the cascade in `skills/startup/SEARCH.md`) with 2–3 keywords and keep only candidates with `rerank_score ≥ 0.30` (prefer `≥ 0.60`) — drop anything below 0.30. Otherwise Grep `[knowledge_folder]/**/*.md` and `[resources_folder]/**/*.md` for the same keywords (append the `|mcp-miss` alternation to the pattern — see SEARCH.md). Skip folders that do not exist. Return top 1–2 file titles as wikilink candidates.
 
 6. **Return** a structured recommendation (plain text, one field per line):
    ```

--- a/.claude/plugins/onebrain/agents/inbox-classifier.md
+++ b/.claude/plugins/onebrain/agents/inbox-classifier.md
@@ -31,7 +31,7 @@ You receive:
 
 4. **Suggest filename**: Title Case, 2–5 words, no date prefix.
 
-5. **Find 1–2 related notes**: Grep `[knowledge_folder]/**/*.md` and `[resources_folder]/**/*.md` for 2–3 keywords. Skip folders that do not exist. Return top 1–2 file titles as wikilink candidates.
+5. **Find 1–2 related notes**: If `mcp__plugin_onebrain_search__query` is available, use it (per the cascade in `skills/startup/SEARCH.md`) with 2–3 keywords and keep only candidates with `rerank_score ≥ 0.30` (prefer `≥ 0.60`) — drop anything below 0.30. Otherwise Grep `[knowledge_folder]/**/*.md` and `[resources_folder]/**/*.md` for the same keywords. Skip folders that do not exist. Return top 1–2 file titles as wikilink candidates.
 
 6. **Return** a structured recommendation (plain text, one field per line):
    ```

--- a/.claude/plugins/onebrain/agents/knowledge-linker.md
+++ b/.claude/plugins/onebrain/agents/knowledge-linker.md
@@ -26,6 +26,8 @@ You receive:
    - Notes where one provides context for another
    - Notes that form a natural sequence or hierarchy
 
+   If `mcp__plugin_onebrain_search__query` is available, use it to corroborate a candidate connection before proposing it: only propose a connection whose supporting hit scores `rerank_score ≥ 0.30` (prefer `≥ 0.60`). Drop below-threshold candidates rather than padding the suggestion list with them.
+
 4. **Suggest wikilinks**: For each connection found, propose:
    - Which note to add the link in
    - Where in the note to add it (quote the surrounding text)

--- a/.claude/plugins/onebrain/agents/link-suggester.md
+++ b/.claude/plugins/onebrain/agents/link-suggester.md
@@ -20,9 +20,9 @@ You receive:
 
 1. **Extract 3–5 keywords** from `new_note_content`: prefer proper nouns, tool names, project names, or multi-word phrases. Avoid generic words like "use", "note", "session". If fewer than 2 distinctive keywords can be extracted, stop (do nothing).
 
-2. **Search for related notes**: Use Grep to search `[knowledge_folder]/**/*.md`, `[resources_folder]/**/*.md`, `[areas_folder]/**/*.md`, and `[projects_folder]/**/*.md` for those keywords (case-insensitive). Skip any folder that does not exist. Collect files with ≥2 keyword hits. Exclude `new_note_path` itself.
+2. **Search for related notes**: If `mcp__plugin_onebrain_search__query` is available, use it (per the cascade in `skills/startup/SEARCH.md`) with the extracted keywords; otherwise Grep `[knowledge_folder]/**/*.md`, `[resources_folder]/**/*.md`, `[areas_folder]/**/*.md`, and `[projects_folder]/**/*.md` for those keywords (case-insensitive). Skip any folder that does not exist. Exclude `new_note_path` itself.
 
-3. **Filter to top 3**: Rank by number of keyword hits. If tied, prefer knowledge/ over resources/ over others.
+3. **Filter to top 3**: For MCP results, keep only candidates with `rerank_score ≥ 0.30`, preferring `≥ 0.60`; drop anything below 0.30 rather than including it for lack of a better option. For Grep results, collect files with ≥2 keyword hits and rank by hit count. If tied, prefer knowledge/ over resources/ over others.
 
 4. **Check for existing links**: Read `new_note_content`. Skip any candidate already wikilinked in the note.
 

--- a/.claude/plugins/onebrain/agents/link-suggester.md
+++ b/.claude/plugins/onebrain/agents/link-suggester.md
@@ -20,7 +20,7 @@ You receive:
 
 1. **Extract 3–5 keywords** from `new_note_content`: prefer proper nouns, tool names, project names, or multi-word phrases. Avoid generic words like "use", "note", "session". If fewer than 2 distinctive keywords can be extracted, stop (do nothing).
 
-2. **Search for related notes**: If `mcp__plugin_onebrain_search__query` is available, use it (per the cascade in `skills/startup/SEARCH.md`) with the extracted keywords; otherwise Grep `[knowledge_folder]/**/*.md`, `[resources_folder]/**/*.md`, `[areas_folder]/**/*.md`, and `[projects_folder]/**/*.md` for those keywords (case-insensitive). Skip any folder that does not exist. Exclude `new_note_path` itself.
+2. **Search for related notes**: If `mcp__plugin_onebrain_search__query` is available, use it (per the cascade in `skills/startup/SEARCH.md`) with the extracted keywords; otherwise Grep `[knowledge_folder]/**/*.md`, `[resources_folder]/**/*.md`, `[areas_folder]/**/*.md`, and `[projects_folder]/**/*.md` for those keywords (case-insensitive; append the `|mcp-miss` alternation to the pattern — see SEARCH.md). Skip any folder that does not exist. Exclude `new_note_path` itself.
 
 3. **Filter to top 3**: For MCP results, keep only candidates with `rerank_score ≥ 0.30`, preferring `≥ 0.60`; drop anything below 0.30 rather than including it for lack of a better option. For Grep results, collect files with ≥2 keyword hits and rank by hit count. If tied, prefer knowledge/ over resources/ over others.
 

--- a/.claude/plugins/onebrain/agents/tag-suggester.md
+++ b/.claude/plugins/onebrain/agents/tag-suggester.md
@@ -24,7 +24,7 @@ You receive:
 
 3. **Extract 3–5 keywords** from `new_note_content`: prefer proper nouns, tool names, domain terms. Avoid generic words ("note", "session", "use"). If fewer than 2 distinctive keywords, stop.
 
-4. **Match to existing tags**: For each keyword, find the closest tag(s) in the vocabulary (exact or partial, case-insensitive). Prefer existing tags over new ones. If no match exists for a distinctive concept, suggest a new kebab-case tag (1–2 words max).
+4. **Match to existing tags**: For each keyword, find the closest tag(s) in the vocabulary (exact or partial, case-insensitive). Prefer existing tags over new ones. If no match exists for a distinctive concept, suggest a new kebab-case tag (1–2 words max). When multiple tags are plausible for a keyword and `mcp__plugin_onebrain_search__query` is available, use it to confirm which tag's notes are actually relevant (`rerank_score ≥ 0.30`, prefer `≥ 0.60`) rather than guessing from string similarity alone — drop a candidate tag whose supporting notes all score below 0.30.
 
 5. **Skip tags already in the note**. Keep up to 3 candidates, prioritising existing vocabulary.
 

--- a/.claude/plugins/onebrain/hooks/grep-gate.sh
+++ b/.claude/plugins/onebrain/hooks/grep-gate.sh
@@ -9,32 +9,43 @@
 # looks like a content search sweeping the vault's markdown folders WITHOUT
 # that escape hatch — it does not gate structural greps (task-line scans,
 # frontmatter anchors, wikilink scans, date/checkpoint filename patterns,
-# exact code identifiers) or anything outside the vault's content folders.
+# exact code identifiers), single-known-file greps, or anything outside the
+# vault's content folders.
 #
 # Default posture: fail-open everywhere, mirroring hooks/read-hook.sh's
 # harmlessness contract (read that file first if editing this one).
-#   - ONEBRAIN_HOOK_BYPASS=1 skips this hook entirely for the session.
-#   - Any trouble at all (missing jq, unreadable/unresolvable config,
-#     malformed hook input, an empty pattern, non-Grep tool calls, the
-#     5s hook timeout) fails OPEN — the Grep call proceeds untouched.
+#   - ONEBRAIN_HOOK_BYPASS=1 skips this hook entirely for the session
+#     (the same variable also disables the Ledger Gate read hook).
+#   - Any trouble at all (missing jq, unresolvable config, malformed hook
+#     input, an empty pattern, non-Grep tool calls, the 5s hook timeout)
+#     fails OPEN — the Grep call proceeds untouched.
+#   - Search-disabled vaults are exempt: when the resolved onebrain.yml has
+#     no `search.collection` (and no legacy top-level `qmd_collection`),
+#     the search MCP does not exist for that vault, so there is no cascade
+#     to enforce — the hook allows everything. Same when no config file can
+#     be found at all (not a OneBrain vault).
 #   - This hook NEVER blocks a Grep outside 00-inbox/01-projects/02-areas/
 #     03-knowledge/04-resources (or the vault's configured equivalents),
-#     never blocks a non-.md target, and never blocks a structural pattern.
+#     never blocks a non-.md target, never blocks a grep whose `path` is a
+#     single existing file (SEARCH.md blesses exact-match greps in a known
+#     file), and never blocks a structural pattern.
 #
 # Escape hatch: a pattern containing the sentinel substring `mcp-miss`
-# (added by the agent, per SEARCH.md step 3, only after a genuine MCP miss)
-# always allows through — this is how the agent legitimately falls back to
-# Grep without tripping the gate on every retry.
+# always allows through. The canonical form is an appended ALTERNATION
+# branch — `real-pattern|mcp-miss` — which is regex-harmless (per
+# SEARCH.md step 3; a non-alternated literal append would change the
+# pattern's semantics and silently kill matches). The agent adds it only
+# after a genuine MCP miss.
 #
 # Verdict output: on a genuine block (exit 2), the one-line reason is
-# written to BOTH stdout and stderr — stdout per this hook's own contract,
-# stderr because that's what Claude Code's PreToolUse protocol actually
-# feeds back to the agent as block context (see read-hook.sh's header for
-# the same protocol note). The reason is agent-facing only; it is never
-# shown to the user.
+# written to stderr — that is what Claude Code's PreToolUse protocol feeds
+# back to the agent as block context (same field-proven protocol as
+# read-hook.sh). The reason is agent-facing only; it is never shown to the
+# user.
 #
-# See INSTRUCTIONS.md "Search Strategy" and skills/startup/SEARCH.md "The
-# Cascade" for the full contract this hook enforces.
+# See INSTRUCTIONS.md "Search Cascade Grep Gate (PreToolUse Hook)" and
+# skills/startup/SEARCH.md "The Cascade" for the full contract this hook
+# enforces.
 
 set -u
 
@@ -80,7 +91,8 @@ _gg_lc() {
 
 pattern_lc=$(_gg_lc "${pattern}")
 
-# mcp-miss sentinel: the agent's documented fallback marker.
+# mcp-miss sentinel: the agent's documented fallback marker (appended as an
+# alternation branch, `real-pattern|mcp-miss`). Plain substring match.
 case "${pattern_lc}" in
   *mcp-miss*) exit 0 ;;
 esac
@@ -92,7 +104,9 @@ case "${pattern}" in
     ;;
 esac
 
-# Frontmatter anchors: ^---, ^tags:, or a generic ^<word>: frontmatter key.
+# Frontmatter anchors: ^---, ^tags:, a generic ^<word>: frontmatter key, an
+# unanchored `<key>: value` field lookup (e.g. `url: https://…`), or a YAML
+# list-item anchor (`^  - `, `^\s*-\s`, and variants).
 case "${pattern}" in
   '^---'*) exit 0 ;;
   '^tags:'*) exit 0 ;;
@@ -100,10 +114,16 @@ esac
 if printf '%s' "${pattern}" | grep -Eq '^\^[A-Za-z_][A-Za-z0-9_-]*:'; then
   exit 0
 fi
+if printf '%s' "${pattern}" | grep -Eq '^[A-Za-z_][A-Za-z0-9_-]*: '; then
+  exit 0
+fi
+if printf '%s' "${pattern}" | grep -Eq '^\^( +|\\s\*?|\[\[:space:\]\]\*?)*-'; then
+  exit 0
+fi
 
-# Wikilink scans: contains [[.
+# Wikilink scans: contains [[ — literal or regex-escaped (\[\[).
 case "${pattern}" in
-  *'[['*) exit 0 ;;
+  *'[['* | *'\[\['*) exit 0 ;;
 esac
 
 # Date / checkpoint filename patterns: YYYY-MM-DD-style digit-group regexes,
@@ -132,10 +152,32 @@ if printf '%s' "${pattern}" | grep -Eq '^[A-Za-z_][A-Za-z0-9_]*$'; then
 fi
 
 # ---------------------------------------------------------------------------
-# Resolve vault content folders from onebrain.yml (walk up from the target
-# path if given, else from $PWD), falling back to the documented defaults.
-# This is a best-effort default-value resolution, not a fail-open trigger —
-# an unreadable/missing config just means "use the defaults".
+# Single-known-file exemption: SEARCH.md's decision table blesses exact-match
+# greps inside a known file (e.g. Bookmarks.md lookups from /bookmark and
+# /summarize). If `path` resolves to an existing regular FILE, allow.
+# ---------------------------------------------------------------------------
+
+if [ -n "${target_path}" ]; then
+  _gg_abs="${target_path}"
+  case "${_gg_abs}" in
+    /*) ;;
+    *) _gg_abs="${PWD}/${_gg_abs}" ;;
+  esac
+  if [ -f "${_gg_abs}" ]; then
+    exit 0
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Resolve the vault config (walk up from the target path if given, else from
+# $PWD). Two outcomes short-circuit to allow:
+#   - no onebrain.yml / vault.yml found -> not a OneBrain vault, nothing to
+#     enforce;
+#   - config found but search is not configured (no `search.collection`, no
+#     legacy top-level `qmd_collection`) -> the search MCP doesn't exist for
+#     this vault, so the cascade can't apply; the hook must stay inert.
+# Otherwise read the content-folder names from it, falling back to the
+# documented defaults for any key that can't be parsed.
 # ---------------------------------------------------------------------------
 
 _gg_dir="${target_path:-$PWD}"
@@ -153,30 +195,42 @@ while [ -n "${_gg_walk}" ] && [ "${_gg_walk}" != "/" ] && [ "${_gg_walk}" != "."
   _gg_walk=$(dirname "${_gg_walk}")
 done
 
+if [ -z "${_gg_cfg}" ] || [ ! -r "${_gg_cfg}" ]; then
+  exit 0
+fi
+
+# Search-disabled vault -> inert. Nested `collection:` under `search:` is
+# matched cheaply by its indentation (same grep-not-YAML-parser tradeoff as
+# read-hook.sh); the legacy top-level `qmd_collection:` is still honored.
+if ! grep -Eq '^[[:space:]]+collection:[[:space:]]*[^[:space:]]' "${_gg_cfg}" \
+  && ! grep -Eq '^qmd_collection:[[:space:]]*[^[:space:]]' "${_gg_cfg}"; then
+  exit 0
+fi
+
 f_inbox="00-inbox"
 f_projects="01-projects"
 f_areas="02-areas"
 f_knowledge="03-knowledge"
 f_resources="04-resources"
 
-if [ -n "${_gg_cfg}" ] && [ -r "${_gg_cfg}" ]; then
-  _v=$(grep -E '^[[:space:]]+inbox:' "${_gg_cfg}" 2>/dev/null | head -1 | sed -E 's/^[[:space:]]+inbox:[[:space:]]*//' | tr -d '"'"'"'\r')
-  [ -n "${_v}" ] && f_inbox="${_v}"
-  _v=$(grep -E '^[[:space:]]+projects:' "${_gg_cfg}" 2>/dev/null | head -1 | sed -E 's/^[[:space:]]+projects:[[:space:]]*//' | tr -d '"'"'"'\r')
-  [ -n "${_v}" ] && f_projects="${_v}"
-  _v=$(grep -E '^[[:space:]]+areas:' "${_gg_cfg}" 2>/dev/null | head -1 | sed -E 's/^[[:space:]]+areas:[[:space:]]*//' | tr -d '"'"'"'\r')
-  [ -n "${_v}" ] && f_areas="${_v}"
-  _v=$(grep -E '^[[:space:]]+knowledge:' "${_gg_cfg}" 2>/dev/null | head -1 | sed -E 's/^[[:space:]]+knowledge:[[:space:]]*//' | tr -d '"'"'"'\r')
-  [ -n "${_v}" ] && f_knowledge="${_v}"
-  _v=$(grep -E '^[[:space:]]+resources:' "${_gg_cfg}" 2>/dev/null | head -1 | sed -E 's/^[[:space:]]+resources:[[:space:]]*//' | tr -d '"'"'"'\r')
-  [ -n "${_v}" ] && f_resources="${_v}"
-fi
+_v=$(grep -E '^[[:space:]]+inbox:' "${_gg_cfg}" 2>/dev/null | head -1 | sed -E 's/^[[:space:]]+inbox:[[:space:]]*//' | tr -d '"'"'"'\r')
+[ -n "${_v}" ] && f_inbox="${_v}"
+_v=$(grep -E '^[[:space:]]+projects:' "${_gg_cfg}" 2>/dev/null | head -1 | sed -E 's/^[[:space:]]+projects:[[:space:]]*//' | tr -d '"'"'"'\r')
+[ -n "${_v}" ] && f_projects="${_v}"
+_v=$(grep -E '^[[:space:]]+areas:' "${_gg_cfg}" 2>/dev/null | head -1 | sed -E 's/^[[:space:]]+areas:[[:space:]]*//' | tr -d '"'"'"'\r')
+[ -n "${_v}" ] && f_areas="${_v}"
+_v=$(grep -E '^[[:space:]]+knowledge:' "${_gg_cfg}" 2>/dev/null | head -1 | sed -E 's/^[[:space:]]+knowledge:[[:space:]]*//' | tr -d '"'"'"'\r')
+[ -n "${_v}" ] && f_knowledge="${_v}"
+_v=$(grep -E '^[[:space:]]+resources:' "${_gg_cfg}" 2>/dev/null | head -1 | sed -E 's/^[[:space:]]+resources:[[:space:]]*//' | tr -d '"'"'"'\r')
+[ -n "${_v}" ] && f_resources="${_v}"
 
-_gg_vault_root="${PWD}"
-[ -n "${_gg_cfg}" ] && _gg_vault_root=$(dirname "${_gg_cfg}")
+_gg_vault_root=$(dirname "${_gg_cfg}")
 
 # ---------------------------------------------------------------------------
-# Does the target path resolve inside a vault content folder?
+# Does the target resolve inside a vault content folder? Membership is judged
+# from `path` when given; else from `glob`'s leading path segment; a call
+# with NEITHER path NOR glob is a root sweep (gated only if a content folder
+# actually exists under the vault root).
 # ---------------------------------------------------------------------------
 
 _gg_in_content_folder() {
@@ -192,20 +246,17 @@ _gg_in_content_folder() {
   return 1
 }
 
-in_vault_content=1
-if [ -z "${target_path}" ]; then
-  # No path given: Grep defaults to sweeping cwd. Only "counts" if at least
-  # one content folder actually exists under the vault root — otherwise
-  # there's nothing vault-shaped to sweep, so don't gate.
-  found_any=0
+_gg_root_has_content() {
   for f in "${f_inbox}" "${f_projects}" "${f_areas}" "${f_knowledge}" "${f_resources}"; do
     if [ -d "${_gg_vault_root}/${f}" ]; then
-      found_any=1
-      break
+      return 0
     fi
   done
-  [ "${found_any}" -eq 1 ] || in_vault_content=0
-else
+  return 1
+}
+
+in_vault_content=1
+if [ -n "${target_path}" ]; then
   _gg_norm="${target_path}"
   case "${_gg_norm}" in
     ./*) _gg_norm="${_gg_norm#./}" ;;
@@ -213,6 +264,38 @@ else
   if ! _gg_in_content_folder "${_gg_norm}"; then
     in_vault_content=0
   fi
+elif [ -n "${target_glob}" ]; then
+  # Derive membership from the glob's leading path segment. A leading
+  # segment with no wildcard (e.g. `05-templates` in `05-templates/**/*.md`)
+  # scopes the sweep to that folder; a wildcard-bearing leading segment
+  # (`**/*.md`) or a bare filename glob (`*.md`) sweeps from the root and
+  # can reach content folders.
+  _gg_glob_norm="${target_glob}"
+  case "${_gg_glob_norm}" in
+    ./*) _gg_glob_norm="${_gg_glob_norm#./}" ;;
+  esac
+  _gg_glob_head=""
+  case "${_gg_glob_norm}" in
+    */*)
+      _gg_glob_head="${_gg_glob_norm%%/*}"
+      case "${_gg_glob_head}" in
+        *'*'* | *'?'* | *'['*)
+          # Wildcard leading segment — root sweep.
+          _gg_glob_head=""
+          ;;
+      esac
+      ;;
+  esac
+  if [ -n "${_gg_glob_head}" ]; then
+    if ! _gg_in_content_folder "${_gg_glob_head}"; then
+      in_vault_content=0
+    fi
+  else
+    _gg_root_has_content || in_vault_content=0
+  fi
+else
+  # No path, no glob: Grep defaults to sweeping cwd — a root sweep.
+  _gg_root_has_content || in_vault_content=0
 fi
 
 if [ "${in_vault_content}" -eq 0 ]; then
@@ -242,11 +325,11 @@ if [ "${targets_md}" -eq 0 ]; then
 fi
 
 # ---------------------------------------------------------------------------
-# All gate conditions met: block, with an agent-facing reason.
+# All gate conditions met: block, with an agent-facing reason on stderr
+# (Claude Code's PreToolUse protocol feeds stderr back as block context).
 # ---------------------------------------------------------------------------
 
-reason="vault content search must go through mcp__plugin_onebrain_search__query first; grep is the fallback after an MCP miss (add a '# mcp-miss' sentinel to the pattern when falling back legitimately)"
+reason="vault content search must go through mcp__plugin_onebrain_search__query first; grep is the fallback after an MCP miss (append an alternation branch '|mcp-miss' to the pattern when falling back legitimately — see skills/startup/SEARCH.md)"
 
-printf '%s\n' "${reason}"
 printf '%s\n' "${reason}" >&2
 exit 2

--- a/.claude/plugins/onebrain/hooks/grep-gate.sh
+++ b/.claude/plugins/onebrain/hooks/grep-gate.sh
@@ -1,0 +1,252 @@
+#!/usr/bin/env bash
+# OneBrain plugin v3 — Search Cascade Grep Gate (PreToolUse hook, Track C #221).
+#
+# Enforces the search cascade documented in
+# skills/startup/SEARCH.md: vault CONTENT search must go through
+# `mcp__plugin_onebrain_search__query` first. Grep is only the legitimate
+# fallback after a genuine MCP miss (unavailable/error, zero or all-low-
+# confidence hits, or a freshness gap). This hook gates a Grep call that
+# looks like a content search sweeping the vault's markdown folders WITHOUT
+# that escape hatch — it does not gate structural greps (task-line scans,
+# frontmatter anchors, wikilink scans, date/checkpoint filename patterns,
+# exact code identifiers) or anything outside the vault's content folders.
+#
+# Default posture: fail-open everywhere, mirroring hooks/read-hook.sh's
+# harmlessness contract (read that file first if editing this one).
+#   - ONEBRAIN_HOOK_BYPASS=1 skips this hook entirely for the session.
+#   - Any trouble at all (missing jq, unreadable/unresolvable config,
+#     malformed hook input, an empty pattern, non-Grep tool calls, the
+#     5s hook timeout) fails OPEN — the Grep call proceeds untouched.
+#   - This hook NEVER blocks a Grep outside 00-inbox/01-projects/02-areas/
+#     03-knowledge/04-resources (or the vault's configured equivalents),
+#     never blocks a non-.md target, and never blocks a structural pattern.
+#
+# Escape hatch: a pattern containing the sentinel substring `mcp-miss`
+# (added by the agent, per SEARCH.md step 3, only after a genuine MCP miss)
+# always allows through — this is how the agent legitimately falls back to
+# Grep without tripping the gate on every retry.
+#
+# Verdict output: on a genuine block (exit 2), the one-line reason is
+# written to BOTH stdout and stderr — stdout per this hook's own contract,
+# stderr because that's what Claude Code's PreToolUse protocol actually
+# feeds back to the agent as block context (see read-hook.sh's header for
+# the same protocol note). The reason is agent-facing only; it is never
+# shown to the user.
+#
+# See INSTRUCTIONS.md "Search Strategy" and skills/startup/SEARCH.md "The
+# Cascade" for the full contract this hook enforces.
+
+set -u
+
+# Bypass: explicit per-session opt-out, independent of onebrain.yml.
+if [ "${ONEBRAIN_HOOK_BYPASS:-}" = "1" ]; then
+  exit 0
+fi
+
+input=$(cat)
+
+# jq is the only reliable way to parse the hook JSON without a lossy
+# hand-rolled extraction. No jq -> fail open.
+if ! command -v jq >/dev/null 2>&1; then
+  exit 0
+fi
+
+tool_name=$(printf '%s' "${input}" | jq -r '.tool_name // empty' 2>/dev/null)
+if [ "${tool_name}" != "Grep" ]; then
+  exit 0
+fi
+
+pattern=$(printf '%s' "${input}" | jq -r '.tool_input.pattern // empty' 2>/dev/null)
+if [ -z "${pattern}" ]; then
+  # Malformed / no pattern to judge — fail open.
+  exit 0
+fi
+
+target_path=$(printf '%s' "${input}" | jq -r '.tool_input.path // empty' 2>/dev/null)
+target_glob=$(printf '%s' "${input}" | jq -r '.tool_input.glob // empty' 2>/dev/null)
+target_type=$(printf '%s' "${input}" | jq -r '.tool_input.type // empty' 2>/dev/null)
+
+# ---------------------------------------------------------------------------
+# Structural allowlist — always allowed, regardless of path/target. These are
+# the query shapes SEARCH.md's decision table already carves out as non-
+# content lookups (task-line scans, frontmatter anchors, wikilink scans,
+# date/checkpoint filenames, exact code identifiers), plus the mcp-miss
+# escape hatch itself.
+# ---------------------------------------------------------------------------
+
+_gg_lc() {
+  printf '%s' "$1" | tr '[:upper:]' '[:lower:]'
+}
+
+pattern_lc=$(_gg_lc "${pattern}")
+
+# mcp-miss sentinel: the agent's documented fallback marker.
+case "${pattern_lc}" in
+  *mcp-miss*) exit 0 ;;
+esac
+
+# Task-line patterns: - [ ], - [x], [ ], [x], and escaped-bracket variants.
+case "${pattern}" in
+  *'- \[ \]'* | *'- \[x\]'* | *'- \[X\]'* | *'\[ \]'* | *'\[x\]'* | *'\[X\]'* | *'- [ ]'* | *'- [x]'* | *'- [X]'*)
+    exit 0
+    ;;
+esac
+
+# Frontmatter anchors: ^---, ^tags:, or a generic ^<word>: frontmatter key.
+case "${pattern}" in
+  '^---'*) exit 0 ;;
+  '^tags:'*) exit 0 ;;
+esac
+if printf '%s' "${pattern}" | grep -Eq '^\^[A-Za-z_][A-Za-z0-9_-]*:'; then
+  exit 0
+fi
+
+# Wikilink scans: contains [[.
+case "${pattern}" in
+  *'[['*) exit 0 ;;
+esac
+
+# Date / checkpoint filename patterns: YYYY-MM-DD-style digit-group regexes,
+# or the literal word "checkpoint".
+if printf '%s' "${pattern}" | grep -Eq '[0-9]\{4\}.*[0-9]\{2\}.*[0-9]\{2\}|[0-9]{4}.*[0-9]{2}.*[0-9]{2}'; then
+  exit 0
+fi
+case "${pattern_lc}" in
+  *checkpoint*) exit 0 ;;
+esac
+
+# Exact code identifiers (heuristic): contains "::" or "_(" (namespaced /
+# function-call-shaped), or is a single space-free ALL_CAPS / snake_case
+# token with no other regex/prose structure.
+case "${pattern}" in
+  *'::'* | *'_('*) exit 0 ;;
+esac
+if printf '%s' "${pattern}" | grep -Eq '^[A-Za-z_][A-Za-z0-9_]*$'; then
+  # No spaces, identifier-shaped. Treat as a code-search token unless it's
+  # a single common English word with no underscore/caps signal — those are
+  # ambiguous, so only allowlist when it carries an underscore or is
+  # ALL_CAPS/camelCase-ish (has a case transition or underscore).
+  if printf '%s' "${pattern}" | grep -Eq '_|[A-Z]'; then
+    exit 0
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Resolve vault content folders from onebrain.yml (walk up from the target
+# path if given, else from $PWD), falling back to the documented defaults.
+# This is a best-effort default-value resolution, not a fail-open trigger —
+# an unreadable/missing config just means "use the defaults".
+# ---------------------------------------------------------------------------
+
+_gg_dir="${target_path:-$PWD}"
+case "${_gg_dir}" in
+  /*) ;;
+  *) _gg_dir="${PWD}/${_gg_dir}" ;;
+esac
+[ -d "${_gg_dir}" ] || _gg_dir=$(dirname "${_gg_dir}")
+
+_gg_cfg=""
+_gg_walk="${_gg_dir}"
+while [ -n "${_gg_walk}" ] && [ "${_gg_walk}" != "/" ] && [ "${_gg_walk}" != "." ]; do
+  if [ -f "${_gg_walk}/onebrain.yml" ]; then _gg_cfg="${_gg_walk}/onebrain.yml"; break; fi
+  if [ -f "${_gg_walk}/vault.yml" ]; then _gg_cfg="${_gg_walk}/vault.yml"; break; fi
+  _gg_walk=$(dirname "${_gg_walk}")
+done
+
+f_inbox="00-inbox"
+f_projects="01-projects"
+f_areas="02-areas"
+f_knowledge="03-knowledge"
+f_resources="04-resources"
+
+if [ -n "${_gg_cfg}" ] && [ -r "${_gg_cfg}" ]; then
+  _v=$(grep -E '^[[:space:]]+inbox:' "${_gg_cfg}" 2>/dev/null | head -1 | sed -E 's/^[[:space:]]+inbox:[[:space:]]*//' | tr -d '"'"'"'\r')
+  [ -n "${_v}" ] && f_inbox="${_v}"
+  _v=$(grep -E '^[[:space:]]+projects:' "${_gg_cfg}" 2>/dev/null | head -1 | sed -E 's/^[[:space:]]+projects:[[:space:]]*//' | tr -d '"'"'"'\r')
+  [ -n "${_v}" ] && f_projects="${_v}"
+  _v=$(grep -E '^[[:space:]]+areas:' "${_gg_cfg}" 2>/dev/null | head -1 | sed -E 's/^[[:space:]]+areas:[[:space:]]*//' | tr -d '"'"'"'\r')
+  [ -n "${_v}" ] && f_areas="${_v}"
+  _v=$(grep -E '^[[:space:]]+knowledge:' "${_gg_cfg}" 2>/dev/null | head -1 | sed -E 's/^[[:space:]]+knowledge:[[:space:]]*//' | tr -d '"'"'"'\r')
+  [ -n "${_v}" ] && f_knowledge="${_v}"
+  _v=$(grep -E '^[[:space:]]+resources:' "${_gg_cfg}" 2>/dev/null | head -1 | sed -E 's/^[[:space:]]+resources:[[:space:]]*//' | tr -d '"'"'"'\r')
+  [ -n "${_v}" ] && f_resources="${_v}"
+fi
+
+_gg_vault_root="${PWD}"
+[ -n "${_gg_cfg}" ] && _gg_vault_root=$(dirname "${_gg_cfg}")
+
+# ---------------------------------------------------------------------------
+# Does the target path resolve inside a vault content folder?
+# ---------------------------------------------------------------------------
+
+_gg_in_content_folder() {
+  candidate="$1"
+  for f in "${f_inbox}" "${f_projects}" "${f_areas}" "${f_knowledge}" "${f_resources}"; do
+    case "${candidate}" in
+      "${f}" | "${f}"/*) return 0 ;;
+    esac
+    case "${candidate}" in
+      "${_gg_vault_root}/${f}" | "${_gg_vault_root}/${f}"/*) return 0 ;;
+    esac
+  done
+  return 1
+}
+
+in_vault_content=1
+if [ -z "${target_path}" ]; then
+  # No path given: Grep defaults to sweeping cwd. Only "counts" if at least
+  # one content folder actually exists under the vault root — otherwise
+  # there's nothing vault-shaped to sweep, so don't gate.
+  found_any=0
+  for f in "${f_inbox}" "${f_projects}" "${f_areas}" "${f_knowledge}" "${f_resources}"; do
+    if [ -d "${_gg_vault_root}/${f}" ]; then
+      found_any=1
+      break
+    fi
+  done
+  [ "${found_any}" -eq 1 ] || in_vault_content=0
+else
+  _gg_norm="${target_path}"
+  case "${_gg_norm}" in
+    ./*) _gg_norm="${_gg_norm#./}" ;;
+  esac
+  if ! _gg_in_content_folder "${_gg_norm}"; then
+    in_vault_content=0
+  fi
+fi
+
+if [ "${in_vault_content}" -eq 0 ]; then
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Does the target look like it's searching .md content?
+# ---------------------------------------------------------------------------
+
+targets_md=1
+if [ -n "${target_glob}" ]; then
+  case "$(_gg_lc "${target_glob}")" in
+    *md* | '*' | '**' | '**/*') targets_md=1 ;;
+    *) targets_md=0 ;;
+  esac
+fi
+if [ -n "${target_type}" ]; then
+  case "$(_gg_lc "${target_type}")" in
+    md | markdown) targets_md=1 ;;
+    *) targets_md=0 ;;
+  esac
+fi
+
+if [ "${targets_md}" -eq 0 ]; then
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# All gate conditions met: block, with an agent-facing reason.
+# ---------------------------------------------------------------------------
+
+reason="vault content search must go through mcp__plugin_onebrain_search__query first; grep is the fallback after an MCP miss (add a '# mcp-miss' sentinel to the pattern when falling back legitimately)"
+
+printf '%s\n' "${reason}"
+printf '%s\n' "${reason}" >&2
+exit 2

--- a/.claude/plugins/onebrain/hooks/hooks.json
+++ b/.claude/plugins/onebrain/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "OneBrain plugin v3 — SessionStart hook that refuses to load against an incompatible OneBrain CLI (< v3.0.0), pairs with `requires.cli` in plugin.json. PreToolUse hook gates repeat Read calls on vault .md docs already sent this session (token-optimization Ledger Gate, CLI v3.4.10+, design §5b) — off by default (onebrain.yml `token_optimization.read_hook: off`), always fail-open. See INSTRUCTIONS.md \"Vault-read Ledger Gate (PreToolUse Hook)\".",
+  "description": "OneBrain plugin v3 — SessionStart hook that refuses to load against an incompatible OneBrain CLI (< v3.0.0), pairs with `requires.cli` in plugin.json. PreToolUse hooks: (1) gates repeat Read calls on vault .md docs already sent this session (token-optimization Ledger Gate, CLI v3.4.10+, design §5b) — off by default (onebrain.yml `token_optimization.read_hook: off`), always fail-open, see INSTRUCTIONS.md \"Vault-read Ledger Gate (PreToolUse Hook)\"; (2) gates vault-content Grep calls that skip the search cascade's MCP-first step (Track C #221) — always on, always fail-open, see skills/startup/SEARCH.md \"The Cascade\".",
   "hooks": {
     "SessionStart": [
       {
@@ -19,6 +19,16 @@
           {
             "type": "command",
             "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/read-hook.sh\"",
+            "timeout": 5
+          }
+        ]
+      },
+      {
+        "matcher": "Grep",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/grep-gate.sh\"",
             "timeout": 5
           }
         ]

--- a/.claude/plugins/onebrain/skills/braindump/SKILL.md
+++ b/.claude/plugins/onebrain/skills/braindump/SKILL.md
@@ -70,7 +70,7 @@ created: YYYY-MM-DD
 (Omit this section if no related notes are found)
 ```
 
-Find related notes via the search tools if available; fallback: Glob `[projects_folder]/**/*.md`, `[areas_folder]/**/*.md`, `[knowledge_folder]/**/*.md`, `[resources_folder]/**/*.md`. Omit `## Related Notes` if nothing relevant found.
+Find related notes via the search tools if available; fallback: Glob `[projects_folder]/**/*.md`, `[areas_folder]/**/*.md`, `[knowledge_folder]/**/*.md`, `[resources_folder]/**/*.md`. For search-tool results, only include candidates with `rerank_score ≥ 0.30` (prefer `≥ 0.60`) — drop anything below 0.30. Omit `## Related Notes` if nothing relevant found (or nothing clears the threshold).
 
 ---
 

--- a/.claude/plugins/onebrain/skills/capture/SKILL.md
+++ b/.claude/plugins/onebrain/skills/capture/SKILL.md
@@ -37,7 +37,7 @@ Classify the content : do not ask, infer from context:
 
 ## Step 3: Find and Link Related Notes
 
-Search for related notes (use the search tools if available, otherwise Glob `[knowledge_folder]/**/*.md`, `[resources_folder]/**/*.md`, `[areas_folder]/**/*.md`, `[projects_folder]/**/*.md`). Exclude the destination file. Include top 1–3 as wikilinks automatically. Omit `## Related` if nothing relevant found.
+Search for related notes (use the search tools if available, otherwise Glob `[knowledge_folder]/**/*.md`, `[resources_folder]/**/*.md`, `[areas_folder]/**/*.md`, `[projects_folder]/**/*.md`). Exclude the destination file. For search-tool results, only include candidates with `rerank_score ≥ 0.30` (prefer `≥ 0.60`) — drop anything below 0.30. Include top 1–3 as wikilinks automatically. Omit `## Related` if nothing relevant found (or nothing clears the threshold).
 
 ---
 

--- a/.claude/plugins/onebrain/skills/connect/SKILL.md
+++ b/.claude/plugins/onebrain/skills/connect/SKILL.md
@@ -27,7 +27,7 @@ AskUserQuestion:
 
 ## Step 2: Scan Notes
 
-Use the search tools if available for semantic search across notes; fallback: Glob `[projects_folder]/**/*.md`, `[areas_folder]/**/*.md`, `[knowledge_folder]/**/*.md`, `[resources_folder]/**/*.md`. For each note, extract:
+Use the search tools if available for semantic search across notes; fallback: Glob `[projects_folder]/**/*.md`, `[areas_folder]/**/*.md`, `[knowledge_folder]/**/*.md`, `[resources_folder]/**/*.md`. For search-tool results, only carry forward candidates with `rerank_score ≥ 0.30` (prefer `≥ 0.60`) into Step 3 — drop anything below 0.30 rather than proposing a weak connection. For each note, extract:
 - Title
 - Tags (from frontmatter)
 - Key concepts mentioned (first 200 words)

--- a/.claude/plugins/onebrain/skills/consolidate/SKILL.md
+++ b/.claude/plugins/onebrain/skills/consolidate/SKILL.md
@@ -54,7 +54,7 @@ For each item:
 ### 3a. Analyze
 Read the file fully. Use the pre-classification from Step 2.5 as the starting point. Confirm or adjust based on your own reading:
 - What type of knowledge this is (insight, reference, idea, project note, area)
-- What existing notes it relates to (search via the search tools if available, otherwise Glob `[knowledge_folder]/**/*.md`, `[resources_folder]/**/*.md`, `[projects_folder]/**/*.md`, `[areas_folder]/**/*.md`)
+- What existing notes it relates to (search via the search tools if available, otherwise Glob `[knowledge_folder]/**/*.md`, `[resources_folder]/**/*.md`, `[projects_folder]/**/*.md`, `[areas_folder]/**/*.md`). For search-tool results, only keep candidates with `rerank_score ≥ 0.30` (prefer `≥ 0.60`) — drop anything below 0.30.
 - Whether it deserves its own note or should be merged into an existing one
 
 ### 3b. Decide Destination
@@ -106,7 +106,7 @@ Based on the routing decision above:
 - **New note**: Create `[destination-folder]/[subfolder]/[Topic Name].md` with proper frontmatter
 - **Archive**: If the item is outdated or irrelevant, move to `[archive_folder]/YYYY/MM/`
 
-Always add wikilinks connecting to at least one related note.
+Add wikilinks connecting to at least one related note found in 3a that cleared the `rerank_score ≥ 0.30` threshold (Grep-fallback candidates are unaffected). If none cleared it, omit `## Related` rather than linking a weak match.
 
 ---
 

--- a/.claude/plugins/onebrain/skills/distill/SKILL.md
+++ b/.claude/plugins/onebrain/skills/distill/SKILL.md
@@ -25,7 +25,7 @@ If not, ask:
 
 Search across the vault for notes related to the topic. Use 2–3 specific keywords or phrases from the topic (prefer proper nouns and multi-word phrases over generic single words):
 
-Use the search tools if available for content searches; Grep/Glob as fallback.
+Use the search tools if available for content searches; Grep/Glob as fallback. For the `## Related` links in the final digest (Step 5), only carry forward search-tool candidates with `rerank_score ≥ 0.30` (prefer `≥ 0.60`) — drop anything below 0.30 rather than linking a weak match.
 
 1. **Session logs**: Search `[logs_folder]/session/**/*-session-*.md` for topic keywords — extract matching `## Key Decisions`, `## Action Items`, `## Open Questions` sections. (Post-v2.4.0: session logs live under `session/` only; the `-session-` infix is now defense-in-depth.)
 2. **Inbox**: Search `[inbox_folder]/*.md` for related content

--- a/.claude/plugins/onebrain/skills/distill/SKILL.md
+++ b/.claude/plugins/onebrain/skills/distill/SKILL.md
@@ -25,7 +25,7 @@ If not, ask:
 
 Search across the vault for notes related to the topic. Use 2–3 specific keywords or phrases from the topic (prefer proper nouns and multi-word phrases over generic single words):
 
-Use the search tools if available for content searches; Grep/Glob as fallback. For the `## Related` links in the final digest (Step 5), only carry forward search-tool candidates with `rerank_score ≥ 0.30` (prefer `≥ 0.60`) — drop anything below 0.30 rather than linking a weak match.
+Use the search tools if available for content searches; Grep/Glob as fallback (when falling back to Grep, append the `|mcp-miss` alternation to the pattern — see SEARCH.md). For the `## Related` links in the final digest (Step 5), only carry forward search-tool candidates with `rerank_score ≥ 0.30` (prefer `≥ 0.60`) — drop anything below 0.30 rather than linking a weak match.
 
 1. **Session logs**: Search `[logs_folder]/session/**/*-session-*.md` for topic keywords — extract matching `## Key Decisions`, `## Action Items`, `## Open Questions` sections. (Post-v2.4.0: session logs live under `session/` only; the `-session-` infix is now defense-in-depth.)
 2. **Inbox**: Search `[inbox_folder]/*.md` for related content

--- a/.claude/plugins/onebrain/skills/import/SKILL.md
+++ b/.claude/plugins/onebrain/skills/import/SKILL.md
@@ -142,7 +142,7 @@ Ask using AskUserQuestion:
 
 **If "yes":** For each successfully created note (process one at a time):
 
-1. **Find related vault notes:** Search using the search tools if available, otherwise Grep `[knowledge_folder]/**/*.md`, `[resources_folder]/**/*.md`, `[projects_folder]/**/*.md` for keywords from the imported note's title, tags, and Summary section. Exclude the imported note itself.
+1. **Find related vault notes:** Search using the search tools if available, otherwise Grep `[knowledge_folder]/**/*.md`, `[resources_folder]/**/*.md`, `[projects_folder]/**/*.md` for keywords from the imported note's title, tags, and Summary section (when falling back to Grep, append the `|mcp-miss` alternation to the pattern — see SEARCH.md). For search-tool results, only include candidates with `rerank_score ≥ 0.30` (prefer `≥ 0.60`) — drop anything below 0.30. Exclude the imported note itself.
 
 2. **Present suggestions:**
    ```

--- a/.claude/plugins/onebrain/skills/import/references/note-template.md
+++ b/.claude/plugins/onebrain/skills/import/references/note-template.md
@@ -68,6 +68,6 @@ file_type: <pdf|docx|xlsx|pptx|image|svg|video|script>
 - **Excel (full extraction)**: replaces `## Key Points / Contents` : use `## Summary` (AI-generated) + `## [Sheet Name]` (markdown table per sheet)
 - **Excel (stub)**: `## Summary` : left blank for manual entry
 
-**Scan for related notes:** After creating the note, grep `[resources_folder]/**/*.md` and `[knowledge_folder]/**/*.md` for titles or tags related to the file's topic. Suggest up to 2 wikilinks if found. If no related notes are found, leave the `## Related` section with: `_No related notes found : add links manually._`
+**Scan for related notes:** After creating the note, search for titles or tags related to the file's topic — use the search tools if available (only include candidates with `rerank_score ≥ 0.30`, prefer `≥ 0.60`; drop anything below 0.30), otherwise Glob/Grep `[resources_folder]/**/*.md` and `[knowledge_folder]/**/*.md` (append the `|mcp-miss` alternation to a Grep pattern — see SEARCH.md). Suggest up to 2 wikilinks if found. If no related notes are found (or nothing clears the threshold), leave the `## Related` section with: `_No related notes found : add links manually._`
 
 > **Note on `file_path`:** `file_path` is only included for files imported from an explicit path (kept in place after import). For inbox-staged files, `file_path` is omitted : the staging copy is deleted and the note is the permanent artifact.

--- a/.claude/plugins/onebrain/skills/reading-notes/SKILL.md
+++ b/.claude/plugins/onebrain/skills/reading-notes/SKILL.md
@@ -126,7 +126,7 @@ rating: [1-5 if they want to rate it]
 [[Related Note 2]]
 ```
 
-Populate `## Related` by searching for vault notes related to the book's topic (use the search tools if available, otherwise Glob `[resources_folder]/**/*.md`, `[knowledge_folder]/**/*.md`).
+Populate `## Related` by searching for vault notes related to the book's topic (use the search tools if available, otherwise Glob `[resources_folder]/**/*.md`, `[knowledge_folder]/**/*.md`). For search-tool results, only include candidates with `rerank_score ≥ 0.30` (prefer `≥ 0.60`) — drop anything below 0.30 rather than linking a weak match.
 
 ---
 

--- a/.claude/plugins/onebrain/skills/search/SKILL.md
+++ b/.claude/plugins/onebrain/skills/search/SKILL.md
@@ -32,9 +32,16 @@ Distinct from existing skills:
 
 ## Tools used
 
-- **Search tools lex+vec+hyde** if `search.collection` is configured in onebrain.yml (legacy top-level `qmd_collection` still honored) (preferred)
-- **Glob + Grep fallback** if the search tools are unavailable
+- **Search tools lex+vec+hyde** if `search.collection` is configured in onebrain.yml (legacy top-level `qmd_collection` still honored) (preferred) — follows the cascade in `skills/startup/SEARCH.md`
+- **Glob + Grep fallback** per the cascade's fallback triggers, or unconditionally if the search tools are unavailable
 - **Heuristic question-type detection**: matches `^why\b` (or the agent's bilingual intent inference on non-English equivalents) → "why mode"; else → "what mode"
+
+## Confidence
+
+Every MCP hit carries a `rerank_score` (0–1). Apply the cascade's bands when composing the answer:
+- **`> 0.60`** — confident; cite directly in the direct answer / decision chain.
+- **`0.30 – 0.60`** — possible; include only in the Sources list, not folded into the direct-answer synthesis as settled fact.
+- **`< 0.30`** — no strong match; drop it. If, after the cascade's Grep fallback, nothing clears `0.30`, output an honest **no strong match** result instead of stitching noise into an answer (see Output format below).
 
 ## Output format — what mode
 
@@ -46,6 +53,12 @@ For "what is X" / "what's the current state of X" questions, synthesize a direct
 📚 Sources (top 5 by relevance):
   1. <file path>:<heading> — <1-line excerpt>
   2. ...
+```
+
+**No strong match** (all candidates scored below 0.30 and the cascade's Grep fallback found nothing either):
+
+```
+🔴 No strong match for "<query>" — nothing in the vault clears the confidence bar.
 ```
 
 ## Output format — why mode
@@ -64,8 +77,8 @@ For "why did X" / "why is X" questions, reconstruct chronological decision chain
 ## Skill flow
 
 1. Detect question type from input (`why` keyword or default to `what`)
-2. Run search query (lex+vec+hyde) OR grep fallback
-3. Score results by question type (why → emphasize sessions + decisions logs; what → emphasize knowledge + project notes)
+2. Run the cascade: search query (lex+vec+hyde) first, Grep only on a cascade fallback trigger
+3. Score results by question type (why → emphasize sessions + decisions logs; what → emphasize knowledge + project notes), applying the confidence bands above
 4. Top-K cap: 5 results by default; `--all` flag returns full ranked list
 5. Format per mode above
 

--- a/.claude/plugins/onebrain/skills/search/SKILL.md
+++ b/.claude/plugins/onebrain/skills/search/SKILL.md
@@ -39,7 +39,7 @@ Distinct from existing skills:
 ## Confidence
 
 Every MCP hit carries a `rerank_score` (0–1). Apply the cascade's bands when composing the answer:
-- **`> 0.60`** — confident; cite directly in the direct answer / decision chain.
+- **`≥ 0.60`** — confident; cite directly in the direct answer / decision chain.
 - **`0.30 – 0.60`** — possible; include only in the Sources list, not folded into the direct-answer synthesis as settled fact.
 - **`< 0.30`** — no strong match; drop it. If, after the cascade's Grep fallback, nothing clears `0.30`, output an honest **no strong match** result instead of stitching noise into an answer (see Output format below).
 

--- a/.claude/plugins/onebrain/skills/startup/SEARCH.md
+++ b/.claude/plugins/onebrain/skills/startup/SEARCH.md
@@ -9,14 +9,14 @@ Any vault **content** search — topic lookup, "find notes about X", "what did I
 2. **Judge confidence via `rerank_score`** (0–1, per hit):
    - **`< 0.30`** — no strong match. Treat as equivalent to zero hits.
    - **`0.30 – 0.60`** — possible match. Usable, but don't present as settled fact.
-   - **`> 0.60`** — confident match. Safe to cite directly.
+   - **`≥ 0.60`** — confident match. Safe to cite directly.
 
 3. **Fall back to Grep only when one of these holds:**
    - MCP tool is unavailable (not in tool list) or returns an error.
    - Zero hits, or every hit scores `< 0.30`.
    - **Freshness gap** — the file was written or edited this same turn/session and the index hasn't caught up yet. This is the most common legitimate fallback trigger; don't second-guess it.
 
-   When falling back after a genuine MCP miss, include the sentinel substring `mcp-miss` in the Grep `pattern` itself (e.g. append it as a harmless alternation branch: `real-pattern|mcp-miss`) — this is the documented escape hatch the PreToolUse grep-gate hook scans the pattern for, to let the fallback through without treating it as an anti-pattern. Do not add this token speculatively; only after step 1–2 actually produced a miss, and only when the Grep target is otherwise inside the vault's content folders (the hook doesn't gate anything outside them regardless).
+   When falling back after a genuine MCP miss, append the alternation branch `|mcp-miss` to the Grep `pattern` (canonical form: `real-pattern|mcp-miss` — the alternation is regex-harmless, whereas a non-alternated literal append would change the pattern's semantics and silently kill matches). This is the documented escape hatch the PreToolUse grep-gate hook scans the pattern for, to let the fallback through without treating it as an anti-pattern. Do not add this token speculatively; only after step 1–2 actually produced a miss, and only when the Grep target is otherwise inside the vault's content folders (the hook doesn't gate anything outside them regardless).
 
 4. **Grep also comes back empty (or isn't applicable) → honest "not found."** Never pad a low-confidence MCP result into an answer just because Grep didn't help either. Say plainly that nothing matched.
 

--- a/.claude/plugins/onebrain/skills/startup/SEARCH.md
+++ b/.claude/plugins/onebrain/skills/startup/SEARCH.md
@@ -1,8 +1,32 @@
 # Search Guide
 
-## Search Strategy
+## The Cascade
 
-When the search MCP tools are available (look for `mcp__plugin_onebrain_search__query` in your tool list), **the search tools are the default for vault content search** — not Grep. Reach for Grep only when the query is genuinely about exact text matches inside a known file.
+Any vault **content** search — topic lookup, "find notes about X", "what did I write about Y", related-notes discovery, fuzzy-concept recall — follows this cascade, in order. This does NOT apply to known-path reads, structural pattern scans (task lines, frontmatter keys, wikilink scans), or code/config greps — see the decision table below for those.
+
+1. **MCP query first, always.** Call `mcp__plugin_onebrain_search__query` with `lex` + `vec` sub-queries (add `hyde` for fuzzy/conceptual asks) and an `intent` string. This is the default entry point for every content search — never start with Grep.
+
+2. **Judge confidence via `rerank_score`** (0–1, per hit):
+   - **`< 0.30`** — no strong match. Treat as equivalent to zero hits.
+   - **`0.30 – 0.60`** — possible match. Usable, but don't present as settled fact.
+   - **`> 0.60`** — confident match. Safe to cite directly.
+
+3. **Fall back to Grep only when one of these holds:**
+   - MCP tool is unavailable (not in tool list) or returns an error.
+   - Zero hits, or every hit scores `< 0.30`.
+   - **Freshness gap** — the file was written or edited this same turn/session and the index hasn't caught up yet. This is the most common legitimate fallback trigger; don't second-guess it.
+
+   When falling back after a genuine MCP miss, include the sentinel substring `mcp-miss` in the Grep `pattern` itself (e.g. append it as a harmless alternation branch: `real-pattern|mcp-miss`) — this is the documented escape hatch the PreToolUse grep-gate hook scans the pattern for, to let the fallback through without treating it as an anti-pattern. Do not add this token speculatively; only after step 1–2 actually produced a miss, and only when the Grep target is otherwise inside the vault's content folders (the hook doesn't gate anything outside them regardless).
+
+4. **Grep also comes back empty (or isn't applicable) → honest "not found."** Never pad a low-confidence MCP result into an answer just because Grep didn't help either. Say plainly that nothing matched.
+
+5. **Silence rule.** Never narrate which method produced the answer. No "I searched with MCP first," no "falling back to grep," no "the index was stale so I used Grep instead." Deliver only the results (or the honest not-found). The cascade is implementation detail, not user-facing content.
+
+6. **Self-healing on freshness-gap fallback.** If step 3's trigger was specifically the freshness gap (file written this turn, not yet indexed), silently fire `onebrain search reindex --pending-only` in the background (fire-and-forget, don't wait on it) so the next query in this session doesn't need the same fallback. Engine contention across concurrent callers is already handled by the CLI's own warm per-vault daemon (v3.4.13+) — no plugin-side handling needed for that case.
+
+## Search Strategy — Tool Selection
+
+When the search MCP tools are available (look for `mcp__plugin_onebrain_search__query` in your tool list), **the search tools are the default for vault content search** — not Grep. Reach for Grep only per the cascade fallback triggers above, or for the genuinely non-content lookups in the table below.
 
 **search-first decision rule:**
 
@@ -17,7 +41,7 @@ When the search MCP tools are available (look for `mcp__plugin_onebrain_search__
 | "Find all `- [ ] ` task lines in projects/" | `Grep` (structural pattern, not content search) |
 | "Find exact string `MIN_ACTIVITY` in src/" | `Grep` (code search, not vault content) |
 
-**Common anti-pattern to avoid:** running `Grep` over `03-knowledge/` or `04-resources/` to find notes about a topic. That is a content search — use the search tools. Grep returns line matches, the search tools return ranked documents with snippets and are what was designed for that question.
+**Common anti-pattern to avoid:** running `Grep` over `03-knowledge/` or `04-resources/` to find notes about a topic without having tried MCP first. That is a content search — the cascade requires MCP query as step 1. Grep returns line matches, the search tools return ranked documents with snippets and calibrated `rerank_score` confidence, and are what was designed for that question.
 
 **Sub-query types** (pass to `searches` parameter):
 - `lex` — BM25 keyword search (exact terms, fast)
@@ -26,7 +50,7 @@ When the search MCP tools are available (look for `mcp__plugin_onebrain_search__
 - Combine `lex` + `vec` for best results: `[{type:'lex', query:'error'}, {type:'vec', query:'error handling best practices'}]`
 - Always pass `intent` to disambiguate and improve snippets.
 
-**When the search tools are not available** (not installed or not set up), use Glob/Grep/Read as normal — this is the default and requires no special handling.
+**When the search tools are not available** (not installed or not set up), use Glob/Grep/Read as normal — this is the default and requires no special handling. The cascade and rerank_score bands only apply when the MCP tool is present.
 
 Without embeddings, `mcp__plugin_onebrain_search__query` uses BM25 keyword search only. To enable semantic/similarity search (finding conceptually related notes, not just keyword matches), the index must be embedded at least once — run `onebrain search reindex`. Suggest this if the user asks for similarity-based or "related notes" queries and the search tools are available but embeddings haven't been run.
 
@@ -39,3 +63,5 @@ onebrain search reindex
 ```
 
 This triggers a background reindex. The command reads `search.collection` from onebrain.yml (falling back to the legacy top-level `qmd_collection` when unset) and exits silently if the search index is not installed or the collection is not set. It is fire-and-forget — no need to wait for it to complete.
+
+For the narrower freshness-gap case handled inline during the cascade (step 6 above), prefer `onebrain search reindex --pending-only` — it's the same fire-and-forget contract but scoped to unembedded/pending docs rather than a full reindex.


### PR DESCRIPTION
## Summary

Catches the plugin skill layer up with the CLI's calibrated reranked search (`rerank_score` 0–1 since v3.4.7, warm per-vault daemons since v3.4.13, `--pending-only`/`--lex-only` reindex).

> Version bump note: plugin.json/CHANGELOG.md are intentionally untouched — the plugin version bump ships in a separate PR per the release process.

**1. Cascade rewrite (`skills/startup/SEARCH.md` + `INSTRUCTIONS.md`)**
- Strict cascade for any vault content search: MCP `query` first, always → judge confidence via `rerank_score` bands (`< 0.30` no strong match, `0.30 – 0.60` possible, `≥ 0.60` confident) → Grep fallback only on MCP unavailable/error, zero-or-all-low-confidence hits, or a freshness gap → Grep also empty → honest "not found."
- Silence rule: never narrate which method was used.
- Self-healing: freshness-gap fallback silently fires `onebrain search reindex --pending-only` (fire-and-forget); engine contention is already handled by the CLI's warm daemon (v3.4.13), no plugin action needed.
- Existing decision table and Index Maintenance section kept, wrapped by the cascade.
- `INSTRUCTIONS.md`: Search Strategy section compacted to state the cascade + silence rule; "Recalling Information" inverted to cascade order; new `### Search Cascade Grep Gate (PreToolUse Hook)` section sibling to the Ledger Gate section (both note `ONEBRAIN_HOOK_BYPASS=1` disables both hooks).

**2. rerank_score consumption**
- `skills/search/SKILL.md`: confidence bands drive a "no strong match" outcome vs. confident citation (`≥ 0.60`).
- 4 agents (`link-suggester`, `knowledge-linker`, `tag-suggester`, `inbox-classifier`): only suggest from candidates with `rerank_score ≥ 0.30` (prefer `≥ 0.60`); below-threshold candidates dropped, not padded in.
- `capture`, `connect`, `consolidate`, `distill`, `reading-notes`, `braindump`, `import` SKILL.md + `import/references/note-template.md`: `## Related` suggestions gated on the same thresholds (note-template modernized to search-tools-first).
- Grep-fallback instructions in `inbox-classifier`, `link-suggester`, `distill`, `import`, `note-template` mention the `|mcp-miss` alternation so their own documented fallback isn't blocked by the hook.

**3. PreToolUse grep-gate hook**
- New `.claude/plugins/onebrain/hooks/grep-gate.sh`, registered in `hooks/hooks.json` (PreToolUse, matcher `Grep`, 5s timeout).
- Modeled on `hooks/read-hook.sh`'s config-resolution walk-up and fail-open discipline (not modified).
- Blocks a Grep that: targets a vault content folder (`00-inbox`/`01-projects`/`02-areas`/`03-knowledge`/`04-resources`, resolved from `onebrain.yml` `folders:` when readable, else defaults; membership judged from `path`, else from the `glob`'s leading segment, else root sweep) AND targets `.md` content AND uses a non-structural pattern.
- Always allows: structural patterns (task lines, frontmatter anchors + unanchored `<key>: value` lookups + YAML list anchors, wikilink scans literal AND escaped, date/checkpoint filenames, code identifiers), a `path` resolving to a single existing FILE, the `|mcp-miss` alternation sentinel, non-content-folder targets, non-`.md` targets.
- Inert for search-disabled vaults: no `search.collection` (and no legacy `qmd_collection`) in the resolved config → allow all; same when no config found.
- Fails open on: `ONEBRAIN_HOOK_BYPASS=1`, missing `jq`, unresolvable config, malformed input, empty pattern, non-Grep tool calls.
- Block reason goes to stderr only (read-hook.sh's field-proven protocol), agent-facing, never shown to the user.

### Regression fixture matrix (24/24 pass; all JSON python-generated and piped)

| Case | Exit |
|---|---|
| blocked: topic grep in `03-knowledge` | 2 |
| blocked: vault-root sweep (no path, no glob) | 2 |
| blocked: content-folder glob + content pattern (`03-knowledge/**/*.md`) | 2 |
| blocked: plain lowercase word in content folder | 2 |
| blocked: absolute path inside content folder | 2 |
| blocked: filename-only glob `*.md` (root sweep) | 2 |
| allowed: task-line pattern | 0 |
| allowed: non-vault path (`src`) | 0 |
| allowed: `ONEBRAIN_HOOK_BYPASS=1` | 0 |
| allowed: literal wikilink scan (`\[\[`) | 0 |
| allowed: escaped wikilink regex (`\[\[.*?\]\]`, doctor scan) | 0 |
| allowed: `\|mcp-miss` alternation sentinel | 0 |
| allowed: code identifier (`MIN_ACTIVITY`) | 0 |
| allowed: frontmatter anchors (`^tags:`, `^created:`) | 0 |
| allowed: unanchored field lookup (`url: https://…`) | 0 |
| allowed: YAML list anchors (`^  - `, `^\s*-\s`) | 0 |
| allowed: date/checkpoint filename pattern | 0 |
| allowed: non-md glob (`*.py`) | 0 |
| allowed: single known FILE (`04-resources/Bookmarks.md`) | 0 |
| allowed: non-content glob (`05-templates/**/*.md`, no path) | 0 |
| allowed: vault WITHOUT `search.collection` (topic grep) | 0 |
| allowed: non-Grep `tool_name` | 0 |
| allowed: missing `jq` on PATH (fail-open) | 0 |
| verified: block reason on stderr ONLY (stdout empty) | 2 |

### CI

- `scripts/check-links.py` — pass
- `scripts/check-skill-count.py` — pass (30 skills, docs consistent)
- `scripts/check-config.py` — fails locally only due to `tomllib` requiring Python 3.11+ (local env is 3.9.6); pre-existing on `origin/main` too, unrelated to this change — will run clean on CI's Python version.
- `bash -n hooks/grep-gate.sh` — clean

## Test plan
- [ ] CI green (config validity, markdown links, skill count)
- [ ] Hub review: verify cascade wording matches other tracks' assumptions about MCP tool availability
- [ ] Smoke-test grep-gate hook in a real vault session (structural greps unaffected, content greps route through MCP)

Closes #221