### PR TITLE
feat(digest): interview closes with a schedule offer (v3.4.10)

### DIFF
--- a/.claude/plugins/onebrain/.claude-plugin/plugin.json
+++ b/.claude/plugins/onebrain/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "onebrain",
-  "version": "3.4.9",
+  "version": "3.4.10",
   "description": "OneBrain — Your AI Thinking Partner",
   "author": {
     "name": "OneBrain Contributors"

--- a/.claude/plugins/onebrain/.codex-plugin/plugin.json
+++ b/.claude/plugins/onebrain/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "onebrain",
-  "version": "3.4.9",
+  "version": "3.4.10",
   "description": "OneBrain — Your AI Thinking Partner",
   "namespace": "onebrain",
   "skills": "./skills/",

--- a/.claude/plugins/onebrain/skills/digest/SKILL.md
+++ b/.claude/plugins/onebrain/skills/digest/SKILL.md
@@ -70,6 +70,13 @@ Ask with `AskUserQuestion` (multiSelect where sensible), one question per group:
 Write `[agent_folder]/digest.md` from the answers using the format above, show the
 user the note path, and remind them it is theirs to edit.
 
+5. **Schedule offer (last interview question):** "ให้รันอัตโนมัติทุกเช้ามั้ย? กี่โมง?"
+   (default 08:30). On yes: append the entry to `onebrain.yml`'s `schedule:` block —
+   match the file's existing list style exactly — and run `onebrain schedule register`;
+   confirm with the ✓/✗ state from `onebrain schedule list`. On skip: mention
+   `/schedule-add` works any time later. Never re-offer when a `/digest` entry
+   already exists in the schedule block.
+
 ## Step 1: Gather (per section present in config)
 
 Source quality rules learned from live testing — follow them, do not regress to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-latest_version: 3.4.9
+latest_version: 3.4.10
 released: 2026-07-30
 ---
 
@@ -10,6 +10,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 > **Versioning:** Plugin version is tracked in `plugin.json`. Bump when ANY harness config changes — skills, agents, hooks, INSTRUCTIONS, Gemini settings, slash commands, etc.
 > For CLI binary changes, see the [`onebrain-ai/onebrain-cli`](https://github.com/onebrain-ai/onebrain-cli/blob/main/CHANGELOG.md) repository.
+
+## v3.4.10 — 2026-07-30 — /digest interview ends with a schedule offer
+
+- The first-run interview now closes by offering to schedule the digest ("ทุกเช้า กี่โมง?", default 08:30) — writes the `onebrain.yml` entry and runs `onebrain schedule register` in the same flow, confirming with the truthful ✓/✗ state. Skipping points at `/schedule-add`; the offer never repeats once a `/digest` entry exists. Closes the gap where a user who just chose their sections had to know a second command to get the daily run.
 
 ## v3.4.9 — 2026-07-30 — /digest headless send is unconditional
 


### PR DESCRIPTION
Gap closed per operator: after the first-run interview picks sections, the natural next want is "run it every morning" — the flow now offers exactly that (default 08:30), writes the `onebrain.yml` entry matching the file's list style, runs `onebrain schedule register`, and confirms with the truthful ✓/✗ state. Skip → pointer to `/schedule-add`; never re-offers once a `/digest` entry exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)