### PR TITLE
feat(digest): first run is a complete setup chain (v3.4.11)

### DIFF
--- a/.claude/plugins/onebrain/.claude-plugin/plugin.json
+++ b/.claude/plugins/onebrain/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "onebrain",
-  "version": "3.4.10",
+  "version": "3.4.11",
   "description": "OneBrain — Your AI Thinking Partner",
   "author": {
     "name": "OneBrain Contributors"

--- a/.claude/plugins/onebrain/.codex-plugin/plugin.json
+++ b/.claude/plugins/onebrain/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "onebrain",
-  "version": "3.4.10",
+  "version": "3.4.11",
   "description": "OneBrain — Your AI Thinking Partner",
   "namespace": "onebrain",
   "skills": "./skills/",

--- a/.claude/plugins/onebrain/skills/digest/SKILL.md
+++ b/.claude/plugins/onebrain/skills/digest/SKILL.md
@@ -76,6 +76,14 @@ user the note path, and remind them it is theirs to edit.
    confirm with the ✓/✗ state from `onebrain schedule list`. On skip: mention
    `/schedule-add` works any time later. Never re-offer when a `/digest` entry
    already exists in the schedule block.
+6. **Telegram offer (only when it can work):** if the telegram channel tools are
+   available in this session AND `notifications.telegram_chat_id` is not set, run
+   the **Notification Offer** flow from `schedule-add/SKILL.md` — user sends the
+   bot one message, the incoming channel tag carries `chat_id`, write it to
+   `onebrain.yml` and confirm with a test send. If the telegram tools are absent,
+   say nothing about Telegram (vault-log delivery is the normal path). This makes
+   the first `/digest` conversation a complete setup: sections → schedule →
+   delivery channel, no second command required.
 
 ## Step 1: Gather (per section present in config)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-latest_version: 3.4.10
+latest_version: 3.4.11
 released: 2026-07-30
 ---
 
@@ -10,6 +10,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 > **Versioning:** Plugin version is tracked in `plugin.json`. Bump when ANY harness config changes — skills, agents, hooks, INSTRUCTIONS, Gemini settings, slash commands, etc.
 > For CLI binary changes, see the [`onebrain-ai/onebrain-cli`](https://github.com/onebrain-ai/onebrain-cli/blob/main/CHANGELOG.md) repository.
+
+## v3.4.11 — 2026-07-30 — /digest first run is a complete setup chain
+
+- The interview now closes with the Telegram Notification Offer (shared with `/schedule-add`) when the telegram tools are present and no `notifications.telegram_chat_id` is set — sections → schedule → delivery channel in one conversation, no second command. Vaults without the telegram channel hear nothing about it.
 
 ## v3.4.10 — 2026-07-30 — /digest interview ends with a schedule offer
 


### PR DESCRIPTION
Per operator: after sections and the schedule offer, chain the **Telegram Notification Offer** (shared flow from `/schedule-add`) when the telegram tools are present and `notifications.telegram_chat_id` is unset — the first `/digest` conversation completes the whole setup (sections → schedule → delivery), no second command. Vaults without the telegram channel hear nothing about it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)