### PR TITLE
fix(resume): validate --task slug before overwriting _active.md (v3.4.14)

### DIFF
--- a/.claude/plugins/onebrain/.claude-plugin/plugin.json
+++ b/.claude/plugins/onebrain/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "onebrain",
-  "version": "3.4.13",
+  "version": "3.4.14",
   "description": "OneBrain — Your AI Thinking Partner",
   "author": {
     "name": "OneBrain Contributors"

--- a/.claude/plugins/onebrain/.codex-plugin/plugin.json
+++ b/.claude/plugins/onebrain/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "onebrain",
-  "version": "3.4.13",
+  "version": "3.4.14",
   "description": "OneBrain — Your AI Thinking Partner",
   "namespace": "onebrain",
   "skills": "./skills/",

--- a/.claude/plugins/onebrain/skills/pause/SKILL.md
+++ b/.claude/plugins/onebrain/skills/pause/SKILL.md
@@ -28,6 +28,7 @@ Writes a per-thread snapshot of the current work to `[logs_folder]/pause/` so th
    - Use `AskUserQuestion` to confirm. Question: "Active thread name? Suggested: `<proposed-slug>`" with options: (a) accept suggestion, (b) type a different slug
    - On confirmation, set `active_slug = <chosen>` and continue
 4. If `/pause --task=<slug>` was invoked with an explicit slug:
+   - If `<slug>` is not plain kebab-case (lowercase letters, digits, hyphens only — reject anything with glob or path characters like `*`, `?`, `[`, `/`) → abort with message "⚠️ Invalid thread name `<slug>`. Active thread unchanged." Slugs become filenames and glob patterns; never accept an unvalidated one.
    - If `_active.md` is empty or contains the same slug → set `active_slug = <slug>`, skip warning
    - If `_active.md` contains a different slug → use `AskUserQuestion`: "⚠️ Active thread: `<existing>` (N unmerged snapshots). Switch to `<new>`? (y/N)". On `y` → set `active_slug = <new>`. On `n` → abort silently with message "Pause aborted — active thread unchanged."
 

--- a/.claude/plugins/onebrain/skills/resume/SKILL.md
+++ b/.claude/plugins/onebrain/skills/resume/SKILL.md
@@ -12,9 +12,11 @@ Reads the latest snapshot of the active pause thread and announces its state in 
 
 ## Step 1: Resolve Active Thread
 
-1. Read `[logs_folder]/pause/_active.md`. If absent or empty → output "No active pause. คุยใหม่ได้เลย" and stop.
-2. Parse the single-line content as `active_slug`.
-3. If `/resume --task=<slug>` was invoked with explicit slug → use `<slug>` and overwrite `_active.md` to match (this enables switching from one paused thread to another).
+1. If `/resume --task=<slug>` was invoked with an explicit slug, validate BEFORE touching the pointer: glob `[logs_folder]/pause/*-{slug}-pause-*.md`.
+   - ≥1 match → set `active_slug = <slug>`, overwrite `_active.md` to match (this enables switching from one paused thread to another), and continue to Step 2.
+   - 0 matches → output "⚠️ No pause file found for `<slug>`. Active thread unchanged." and stop. Do NOT overwrite `_active.md` — a mistyped slug must not orphan the pointer or silently deactivate the current thread.
+2. Otherwise read `[logs_folder]/pause/_active.md`. If absent or empty → output "No active pause. คุยใหม่ได้เลย" and stop.
+3. Parse the single-line content as `active_slug`.
 
 ---
 

--- a/.claude/plugins/onebrain/skills/resume/SKILL.md
+++ b/.claude/plugins/onebrain/skills/resume/SKILL.md
@@ -12,11 +12,11 @@ Reads the latest snapshot of the active pause thread and announces its state in 
 
 ## Step 1: Resolve Active Thread
 
-1. If `/resume --task=<slug>` was invoked with an explicit slug, validate BEFORE touching the pointer: glob `[logs_folder]/pause/*-{slug}-pause-*.md`.
-   - ≥1 match → set `active_slug = <slug>`, overwrite `_active.md` to match (this enables switching from one paused thread to another), and continue to Step 2.
+1. If `/resume --task=<slug>` was invoked with an explicit slug, validate BEFORE touching the pointer:
+   - If `<slug>` is not plain kebab-case (lowercase letters, digits, hyphens only — reject anything with glob or path characters like `*`, `?`, `[`, `/`) → output "⚠️ Invalid thread name `<slug>`. Active thread unchanged." and stop. Never interpolate an unvalidated slug into the glob below.
+   - Glob `[logs_folder]/pause/*-{slug}-pause-*.md`. ≥1 match → set `active_slug = <slug>` and overwrite `_active.md` to match (this enables switching from one paused thread to another), then continue to Step 2. If the pointer write fails, output "⚠️ Could not update active pointer. Active thread unchanged." and stop — do not announce a thread the pointer does not record.
    - 0 matches → output "⚠️ No pause file found for `<slug>`. Active thread unchanged." and stop. Do NOT overwrite `_active.md` — a mistyped slug must not orphan the pointer or silently deactivate the current thread.
-2. Otherwise read `[logs_folder]/pause/_active.md`. If absent or empty → output "No active pause. คุยใหม่ได้เลย" and stop.
-3. Parse the single-line content as `active_slug`.
+2. Otherwise read `[logs_folder]/pause/_active.md`. If absent or empty → output "No active pause. คุยใหม่ได้เลย" and stop. If present, parse the single-line content as `active_slug`.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-latest_version: 3.4.13
+latest_version: 3.4.14
 released: 2026-08-29
 ---
 
@@ -10,6 +10,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 > **Versioning:** Plugin version is tracked in `plugin.json`. Bump when ANY harness config changes — skills, agents, hooks, INSTRUCTIONS, Gemini settings, slash commands, etc.
 > For CLI binary changes, see the [`onebrain-ai/onebrain-cli`](https://github.com/onebrain-ai/onebrain-cli/blob/main/CHANGELOG.md) repository.
+
+## v3.4.14 — 2026-08-29 — /resume --task validates before switching threads
+
+- `/resume --task=<slug>` now checks that at least one pause file exists for the requested slug BEFORE overwriting the `_active.md` pointer; on zero matches it reports "No pause file found — active thread unchanged" and stops. Previously a mistyped slug rewrote the pointer first, orphaning it and silently deactivating the current thread (found during the v3.4.13 adversarial review).
 
 ## v3.4.13 — 2026-08-29 — Auto-finalize skips threads the session never touched
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## v3.4.14 — 2026-08-29 — /resume --task validates before switching threads
 
-- `/resume --task=<slug>` now checks that at least one pause file exists for the requested slug BEFORE overwriting the `_active.md` pointer; on zero matches it reports "No pause file found — active thread unchanged" and stops. Previously a mistyped slug rewrote the pointer first, orphaning it and silently deactivating the current thread (found during the v3.4.13 adversarial review).
+- `/resume --task=<slug>` now validates the slug BEFORE overwriting the `_active.md` pointer: the name must be plain kebab-case (no glob/path characters) and at least one pause file must exist for it — otherwise it reports that the active thread is unchanged and stops. Previously a mistyped slug rewrote the pointer first, orphaning it and silently deactivating the current thread (found during review of the v3.4.13 change). A pointer write failure now also stops instead of announcing a thread the pointer does not record.
+- `/pause --task=<slug>` gets the same kebab-case shape check before its thread-switch flow.
 
 ## v3.4.13 — 2026-08-29 — Auto-finalize skips threads the session never touched
 


### PR DESCRIPTION
## Problem

Found during the adversarial review round of #241: `/resume --task=<slug>` (resume SKILL.md Step 1.3) overwrote the active-thread pointer `_active.md` BEFORE Step 2 checked whether any pause file exists for that slug. A mistyped slug therefore rewrote the pointer into an orphan (Step 2.3 only warns and stops), silently deactivating the previously active thread.

## Change

- **Validate-then-write**: the explicit `--task` slug is now checked before the pointer is touched — the pause-file glob must return ≥1 match; on zero matches `/resume` reports "No pause file found — active thread unchanged" and stops without writing.
- **Slug shape gate** (from this PR's own adversarial review): the `--task` value must be plain kebab-case before it is interpolated into the glob — a value like `*` would otherwise match any thread's files, "pass" validation, and write a corrupt pointer. The same shape check is added at `/pause --task`'s thread-switch entry point, closing the class at both places user-typed slugs enter the pointer/glob path (pointer-derived slugs elsewhere only ever come from these validated writers).
- **Pointer-write failure stop**: if the `_active.md` overwrite itself fails, `/resume` stops instead of announcing a thread the pointer does not record (mirrors `/pause`'s write-failure contract).
- Step 2's orphan-pointer warning is now reachable only for a genuine orphan pointer read from `_active.md`; the "same rule as `/resume` Step 2" cross-reference in pause's Auto-Finalize section is unaffected.
- Plugin version 3.4.13 → 3.4.14 (both `.claude-plugin` and `.codex-plugin` manifests) + CHANGELOG entry.

## Review

Risk-scaled pre-PR review: one cold adversarial pass (contract/failure-behavior — walked every `/resume` path and the `/pause --task` interaction) and one repo-consistency/deliverable pass (whole-repo stale-reference sweep, version-bump precedent, changelog accuracy). The adversarial pass's Important finding (glob-metacharacter slug) and two Minor findings (write-failure handling, step-numbering ambiguity) were fixed in the second commit; the consistency pass's changelog wording nits are folded in as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)